### PR TITLE
Fix TSLint warnings in botbuilder-core

### DIFF
--- a/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
+++ b/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
@@ -43,16 +43,15 @@ export class AutoSaveStateMiddleware implements Middleware {
      * Creates a new AutoSaveStateiMiddleware instance.
      * @param botStates Zero or more BotState plugins to register.
      */
+    public botStateSet: BotStateSet;
     constructor(...botStates: BotState[]) {
         this.botStateSet = new BotStateSet();
         if (botStates) {
-            for (let botState of botStates) {
+            for (const botState of botStates) {
                 this.botStateSet.add(botState);
             }
         }
     }
-
-    public botStateSet: BotStateSet;
 
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         await next();
@@ -67,6 +66,7 @@ export class AutoSaveStateMiddleware implements Middleware {
         botStates.forEach((botstate: BotState) => {
             this.botStateSet.add(botstate);
         });
+
         return this;
     }
 

--- a/libraries/botbuilder-core/src/botStateSet.ts
+++ b/libraries/botbuilder-core/src/botStateSet.ts
@@ -42,11 +42,10 @@ export class BotStateSet {
      * Creates a new AutoSaveStateiMiddleware instance.
      * @param botStates Zero or more BotState plugins to register.
      */
-    public constructor(...botStates: BotState[]) {
+    public botStates: BotState[] = [];
+     public constructor(...botStates: BotState[]) {
         BotStateSet.prototype.add.apply(this, botStates);
     }
-
-    public botStates: BotState[] = [];
 
     /**
      * Registers `BotState` plugins with the set.
@@ -80,6 +79,7 @@ export class BotStateSet {
         const promises: Promise<any>[] = this.botStates.map((botstate: BotState) => botstate.load(context, force));
 
         await Promise.all(promises);
+
         return;
     }
 
@@ -99,6 +99,7 @@ export class BotStateSet {
         const promises: Promise<void>[] = this.botStates.map((botstate: BotState) => botstate.saveChanges(context, force));
 
         await Promise.all(promises);
+
         return;
     }
 }

--- a/libraries/botbuilder-core/src/index.ts
+++ b/libraries/botbuilder-core/src/index.ts
@@ -27,4 +27,3 @@ export * from './testAdapter';
 export * from './transcriptLogger';
 export * from './turnContext';
 export * from './userState';
-

--- a/libraries/botbuilder-core/src/privateConversationState.ts
+++ b/libraries/botbuilder-core/src/privateConversationState.ts
@@ -52,6 +52,7 @@ export class PrivateConversationState extends BotState {
         super(storage, (context: TurnContext) => {
             // Calculate storage key
             const key: string = this.getStorageKey(context);
+
             return key ? Promise.resolve(key) : Promise.reject(new Error(NO_KEY));
         });
     }
@@ -77,6 +78,7 @@ export class PrivateConversationState extends BotState {
         if (!userId) {
             throw new Error('missing activity.from.id');
         }
+
         return `${channelId}/conversations/${conversationId}/users/${userId}/${this.namespace}`;
     }
 }

--- a/libraries/botbuilder-core/src/propertyManager.ts
+++ b/libraries/botbuilder-core/src/propertyManager.ts
@@ -1,4 +1,4 @@
-import { StatePropertyAccessor } from "./botStatePropertyAccessor";
+import { StatePropertyAccessor } from './botStatePropertyAccessor';
 
 export interface PropertyManager {
     /**

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -44,6 +44,7 @@ export type DeleteActivityHandler = (
     next: () => Promise<void>
 ) => Promise<void>;
 
+// tslint:disable-next-line:no-empty-interface
 export interface TurnContext {}
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 		"@types/fs-extra": {
 			"version": "4.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2ffs-extra/-/fs-extra-4.0.0.tgz",
-			"integrity": "sha1-HddCrVybzjCPelLQLrwBQhvJEC8=",
+			"integrity": "sha512-PlKJw6ujJXLJjbvB3T0UCbY3jibKM6/Ya5cc9j1q+mYDeK3aR4Dp+20ZwxSuvJr9mIoPxp7+IL4aMOEvsscRTA==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -307,7 +307,7 @@
 		"cliui": {
 			"version": "4.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/cliui/-/cliui-4.0.0.tgz",
-			"integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
+			"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 			"requires": {
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
@@ -378,7 +378,7 @@
 		"coveralls": {
 			"version": "3.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/coveralls/-/coveralls-3.0.0.tgz",
-			"integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
+			"integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
 			"dev": true,
 			"requires": {
 				"js-yaml": "^3.6.1",
@@ -932,7 +932,7 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "http://bbnpm.azurewebsites.net/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
 			"dev": true
 		},
 		"lolex": {
@@ -1610,7 +1610,7 @@
 		"typedoc": {
 			"version": "0.9.0",
 			"resolved": "http://bbnpm.azurewebsites.net/typedoc/-/typedoc-0.9.0.tgz",
-			"integrity": "sha1-FZv/fHeEzluR2G8+TMiSjmIECVc=",
+			"integrity": "sha512-numP0CtcUK4I1Vssw6E1N/FjyJWpWqhLT4Zb7Gw3i7ca3ElnYh6z41Y/tcUhMsMYn6L8b67E/Fu4XYYKkNaLbA==",
 			"requires": {
 				"@types/fs-extra": "4.0.0",
 				"@types/handlebars": "4.0.31",
@@ -1634,7 +1634,7 @@
 				"@types/lodash": {
 					"version": "4.14.74",
 					"resolved": "http://bbnpm.azurewebsites.net/@types%2flodash/-/lodash-4.14.74.tgz",
-					"integrity": "sha1-rDvY25iOf3A45dIr12p7oT+HYWg="
+					"integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ=="
 				},
 				"fs-extra": {
 					"version": "4.0.3",
@@ -1874,7 +1874,7 @@
 		"yargs": {
 			"version": "11.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/yargs/-/yargs-11.0.0.tgz",
-			"integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
+			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 			"requires": {
 				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -3410,7 +3410,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
## Proposed Changes
Fix the following TSLint warnings in `botbuilder-core`:
- eofline
- member-ordering
- newline-before-return
- no-consecutive-blank-lines
- no-empty-interface
- prefer-const
- quotemark

## Testing
Travis will no longer report these warnings