### PR TITLE
 Disable various rules in botConfiguration.ts

### DIFF
--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -56,6 +56,7 @@ export class CosmosDbStorage implements Storage {
      * @param settings Setting to configure the provider.
      * @param connectionPolicyConfigurator (Optional) An optional delegate that accepts a ConnectionPolicy for customizing policies. More information at http://azure.github.io/azure-documentdb-node/global.html#ConnectionPolicy
      */
+    // tslint:disable-next-line:max-line-length
     public constructor(settings: CosmosDbStorageSettings, connectionPolicyConfigurator: (policy: DocumentBase.ConnectionPolicy) => void = null) {
         if (!settings) {
             throw new Error('The settings parameter is required.');

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -14,6 +14,7 @@ import * as encrypt from './encrypt';
 import { ExportOptions } from './exportOptions';
 import { ConnectedService } from './models';
 import { IBlobStorageService, IBotConfiguration, IConnectedService, ICosmosDBService, IDispatchService, IEndpointService, IFileService, IGenericService, ILuisService, IQnAService, ServiceTypes } from './schema';
+// tslint:disable-next-line:no-var-requires no-require-imports
 let exec = util.promisify(require('child_process').exec);
 
 interface InternalBotConfig {
@@ -276,6 +277,7 @@ export class BotConfiguration extends BotConfigurationBase {
     }
 
     // export the services from the bot file as resource files and recipe file
+    // tslint:disable-next-line:cyclomatic-complexity
     public async export(folder: string, exportOptions?: Partial<ExportOptions>): Promise<BotRecipe> {
         let options = Object.assign({ download: true }, exportOptions);
 


### PR DESCRIPTION
## Proposed Changes
Disable `no-require-imports` and `no-var-requires` as the workaround for this warning would not be more beneficial than using var requires.

Disable `cyclomatic-complexity` temporarily until the function `export()` can be refactored enough to lower the Cyclomatic Complexity below 20.

## Testing
Travis will no longer report these warnings