### PR TITLE
Fix various TSLint warnings in botframework-config

### DIFF
--- a/libraries/botframework-config/src/exportOptions.ts
+++ b/libraries/botframework-config/src/exportOptions.ts
@@ -1,9 +1,9 @@
-import { IConnectedService } from "./schema";
+import { IConnectedService } from './schema';
 
 export interface ExportOptions {
     // should resources be downloaded info folder
     download: boolean;
 
     // progress callback during export
-    progress?: (service: IConnectedService, command: string, index: number, total: number) => void
+    progress?(service: IConnectedService, command: string, index: number, total: number): void;
 }

--- a/libraries/botframework-config/src/index.ts
+++ b/libraries/botframework-config/src/index.ts
@@ -4,8 +4,8 @@
  */
 export { BotConfiguration } from './botConfiguration';
 export { BotConfigurationBase } from './botConfigurationBase';
-export { BotRecipe, IBlobResource, ICosmosDBResource, IDispatchResource, IFileResource, IGenericResource, IResource, IUrlResource } from './botRecipe';
+export { BotRecipe, IBlobResource, ICosmosDBResource, IDispatchResource,
+         IFileResource, IGenericResource, IResource, IUrlResource } from './botRecipe';
 export { ExportOptions } from './exportOptions';
 export * from './models';
 export * from './schema';
-

--- a/libraries/botframework-config/src/schema.ts
+++ b/libraries/botframework-config/src/schema.ts
@@ -90,7 +90,7 @@ export interface ICosmosDBService extends IAzureService {
 
     // endpoint/uri for CosmosDB
     endpoint: string;
-    
+
     // key for accessing CosmosDB
     key: string;
 


### PR DESCRIPTION
## Proposed Changes
Fix various TSLint warnings related to style in `botframework-config`
- eofline
- max-line-length
- no-consecutive-blank-lines
- no-trailing-whitespace
- prefer-method-signature
- quotemark
- semicolon
## Testing
Travis will no longer report these warnings