### PR TITLE
Fix TSLint stylistic warnings in botConfigurationBase

### DIFF
--- a/libraries/botframework-config/src/botConfigurationBase.ts
+++ b/libraries/botframework-config/src/botConfigurationBase.ts
@@ -2,8 +2,10 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import { AppInsightsService, BlobStorageService, BotService, ConnectedService, CosmosDbService, DispatchService, EndpointService, FileService, GenericService, LuisService, QnaMakerService } from './models';
-import { IAppInsightsService, IBlobStorageService, IBotConfiguration, IBotService, IConnectedService, ICosmosDBService, IDispatchService, IEndpointService, IFileService, IGenericService, ILuisService, IQnAService, ServiceTypes } from './schema';
+import { AppInsightsService, BlobStorageService, BotService, ConnectedService, CosmosDbService, DispatchService, EndpointService,
+         FileService, GenericService, LuisService, QnaMakerService } from './models';
+import { IAppInsightsService, IBlobStorageService, IBotConfiguration, IBotService, IConnectedService, ICosmosDBService, IDispatchService,
+         IEndpointService, IFileService, IGenericService, ILuisService, IQnAService, ServiceTypes } from './schema';
 
 // This is class which allows you to manipulate in memory representations of bot configuration with no nodejs depedencies
 export class BotConfigurationBase implements Partial<IBotConfiguration> {
@@ -62,6 +64,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
         Object.assign(botConfig, source);
         botConfig.services = services;
         botConfig.migrateData();
+
         return botConfig;
     }
 
@@ -70,6 +73,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
         Object.assign(newConfig, this);
         delete (<any>newConfig).internal;
         newConfig.services = this.services.slice().map((service) => (<ConnectedService>service).toJSON());
+
         return newConfig;
     }
 
@@ -151,7 +155,6 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
         }
     }
 
-
     // migrate old formated data into new format
     protected migrateData(): void {
         for (const service of this.services) {
@@ -162,7 +165,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
                         // old bot service records may not have the appId on the bot, but we probably have it already on an endpoint
                         if (!botService.appId) {
-                            for(const s of this.services){
+                            for (const s of this.services) {
                                 if (s.type == ServiceTypes.Endpoint) {
                                     const endpoint = <IEndpointService>s;
                                     if (endpoint.appId) {
@@ -182,6 +185,6 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
         }
 
         // this is now a 2.0 version of the schema
-        this.version = "2.0";
+        this.version = '2.0';
     }
 }


### PR DESCRIPTION
## Proposed Changes
Fix various TSLint style warnings in `botConfigurationBase.ts`:
- max-line-length
- newline-before-return
- no-consecutive-blank-lines
- one-line
- quotemark
- whitespace
## Testing
Travis will no longer report these warnings