### PR TITLE
Fix TSLint warnings in botbuilder botbuilder-dialogs

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -110,7 +110,6 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
         return this.dialogs.find(dialogId);
     }
 
-
     protected onBeginDialog(innerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
         return innerDC.beginDialog(this.initialDialogId, options);
     }

--- a/libraries/botbuilder-dialogs/src/dialogSet.ts
+++ b/libraries/botbuilder-dialogs/src/dialogSet.ts
@@ -29,7 +29,7 @@ import { DialogContext, DialogState } from './dialogContext';
  * const userState = new UserState(memoryStorage);
  * const dialogs = new DialogSet();
  * const userProfile = userState.createProperty('profile');
- * 
+ *
  * dialogs.add(new WaterfallDialog('fillProfile', [
  *     async (step) => {
  *         step.values.profile = {};
@@ -139,7 +139,7 @@ import { DialogContext, DialogState } from './dialogContext';
  *
  *         // Continue execution if there's an "active" dialog
  *         await dc.continueDialog();
- * 
+ *
  *         if (!context.responded && isMessage) {
  *             // Greet user and fill in profile if missing
  *             const user = await userState.get(context);
@@ -193,8 +193,9 @@ export class DialogSet {
             throw new Error(`DialogSet.add(): A dialog with an id of '${dialog.id}' already added.`);
         }
 
-         this.dialogs[dialog.id] = dialog;
-         return this;
+        this.dialogs[dialog.id] = dialog;
+
+        return this;
     }
 
     /**

--- a/libraries/botbuilder-dialogs/src/mainDialog.ts
+++ b/libraries/botbuilder-dialogs/src/mainDialog.ts
@@ -8,34 +8,33 @@
 import { StatePropertyAccessor, TurnContext } from 'botbuilder-core';
 import { ComponentDialog } from './componentDialog';
 import { DialogTurnResult, DialogTurnStatus } from './dialog';
-import { DialogState } from './dialogContext';
+import { DialogContext, DialogState } from './dialogContext';
 import { DialogSet } from './dialogSet';
-
 
 const MAIN_DIALOG_ID: string = 'main';
 
 /**
  * Base class for a bots main dialog.
- * 
+ *
  * @remarks
- * This class extends `ComponentDialog` and adds a `run()` method to simplify dispatching an 
+ * This class extends `ComponentDialog` and adds a `run()` method to simplify dispatching an
  * incoming activity to the bots dialog system. Developers should extend this class and then add
  * all of their bots child dialogs using the `addDialog()` method.
  */
 export class MainDialog extends ComponentDialog {
-    private readonly mainDialogSet: DialogSet;
-
     /**
      * State property used to persist the bots dialog stack.
      */
     protected readonly dialogState: StatePropertyAccessor<DialogState>;
+
+    private readonly mainDialogSet: DialogSet;
 
     /**
      * Creates a new MainDialog instance.
      * @param dialogState State property used to persist the bots dialog stack.
      * @param dialogId (Optional) id to assign to the main dialog on the stack. Defaults to a value of 'main'.
      */
-    constructor(dialogState: StatePropertyAccessor<DialogState>, dialogId = MAIN_DIALOG_ID) {
+    constructor(dialogState: StatePropertyAccessor<DialogState>, dialogId: string = MAIN_DIALOG_ID) {
         super(dialogId);
         if (!dialogState) {
             throw new Error('dialogState is null');
@@ -46,10 +45,10 @@ export class MainDialog extends ComponentDialog {
 
     /**
      * Processes an incoming activity.
-     * 
+     *
      * @remarks
-     * The activity will simply be dispatched to the main dialog for processing. If current dialog 
-     * stack doesn't contain a main dialog, a new instance of the main dialog will be started. 
+     * The activity will simply be dispatched to the main dialog for processing. If current dialog
+     * stack doesn't contain a main dialog, a new instance of the main dialog will be started.
      * @param context Turn context containing the activity that was received.
      */
     public async run(context: TurnContext): Promise<DialogTurnResult> {
@@ -59,14 +58,14 @@ export class MainDialog extends ComponentDialog {
 
         // Create a dialog context and try to continue running the current dialog
 
-        const dc = await this.mainDialogSet.createContext(context);
-        let result = await dc.continueDialog();
-
+        const dc: DialogContext = await this.mainDialogSet.createContext(context);
+        let result: DialogTurnResult = await dc.continueDialog();
 
         // Start the main dialog if there wasn't a running one
         if (result.status === DialogTurnStatus.empty) {
             result = await dc.beginDialog(this.id);
         }
+
         return result;
     }
 }

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -62,6 +62,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
      */
     public addStep(step: WaterfallStep<O>): WaterfallDialog<O> {
         this.steps.push(step);
+
         return this;
     }
 
@@ -104,7 +105,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
             // Create step context
             const nextCalled: boolean = false;
-            const step = new WaterfallStepContext<O>(dc, {
+            const step: WaterfallStepContext<O> = new WaterfallStepContext<O>(dc, {
                 index: index,
                 options: <O>state.options,
                 reason: reason,

--- a/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { DialogContext } from './dialogContext';
 import { DialogReason, DialogTurnResult } from './dialog';
+import { DialogContext } from './dialogContext';
 
 export interface WaterfallStepInfo<O extends object> {
     // The index of the current waterfall step being executed.
@@ -28,7 +28,7 @@ export interface WaterfallStepInfo<O extends object> {
      * Used to skip to the next waterfall step.
      * @param result (Optional) result to pass to the next step.
      */
-    onNext: (result?: any) => Promise<DialogTurnResult>;
+    onNext(result?: any): Promise<DialogTurnResult>;
 
 }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -7,13 +7,13 @@
  */
 
 import {
+    ChannelValidation,
     ClaimsIdentity,
     ConnectorClient,
     JwtTokenValidation,
     MicrosoftAppCredentials,
     OAuthApiClient,
-    SimpleCredentialProvider,
-    ChannelValidation
+    SimpleCredentialProvider
 } from 'botframework-connector';
 
 import {


### PR DESCRIPTION
## Proposed Changes
Fix various TSLint warnings in `/botbuilder-dialogs/` and `botFrameworkAdapter.ts`:
- eofline
- newline-before-return
- no-trailing-whitespace
- ordered-imports
- prefer-method-signature
- typedef
## Testing
Travis will no longer report these warnings