### PR TITLE
[MANX-453] Add getTokenStatus method

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -444,14 +444,14 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
     
     public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ): Promise<TokenStatus[]>
     {
-       if(!userId && (!context.activity.from || !context.activity.from.id)){
-        throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);
-       }
+        if (!userId && (!context.activity.from || !context.activity.from.id)) {
+            throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);
+        }
         this.checkEmulatingOAuthCards(context);
-        !userId? userId = context.activity.from.id: userId;
+        ! userId? userId = context.activity.from.id : userId;
         const url: string = this.oauthApiUrl(context);
         const client: TokenApiClient = this.createTokenApiClient(url);
-
+        
         return (await client.userToken.getTokenStatus(userId, {channelId: context.activity.channelId, include: includeFilter}))._response.parsedBody;
     }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TurnContext } from 'botbuilder-core';
+import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TokenStatus, TurnContext } from 'botbuilder-core';
 import { ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, JwtTokenValidation, MicrosoftAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenApiModels } from 'botframework-connector';
 import * as os from 'os';
 
@@ -432,6 +432,27 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
 
         const finalState: string = Buffer.from(JSON.stringify(state)).toString('base64');
         return (await client.botSignIn.getSignInUrl(finalState, { channelId: context.activity.channelId }))._response.bodyAsText;
+    }
+
+    /** 
+     * Retrieves the token status for each configured connection for the given user.
+     * <param name="context">Context for the current turn of conversation with the user.</param>
+     * <param name="userId">The user Id for which token status is retrieved.</param>
+     * <param name="includeFilter">Optional comma seperated list of connection's to include. Blank will return token status for all configured connections.</param>
+     * <returns>Array of TokenStatus.</returns>
+     * */ 
+    
+    public async  getTokenStatus(context: TurnContext, userId: string, includeFilter?: string ):Promise<TokenStatus[]>
+    {
+
+       if(!context || !userId){
+        throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing userId or cotext`);
+       }
+        this.checkEmulatingOAuthCards(context);
+        const url: string = this.oauthApiUrl(context);
+        const client: TokenApiClient = this.createTokenApiClient(url);
+
+        return (await client.userToken.getTokenStatus(userId, {channelId: context.activity.channelId, include: includeFilter}))._response.parsedBody;
     }
 
     /**

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -444,9 +444,8 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
     
     public async  getTokenStatus(context: TurnContext, userId: string, includeFilter?: string ):Promise<TokenStatus[]>
     {
-
-       if(!context || !userId){
-        throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing userId or cotext`);
+       if(!context.activity.from || !context.activity.from.id){
+        throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);
        }
         this.checkEmulatingOAuthCards(context);
         const url: string = this.oauthApiUrl(context);

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -442,12 +442,13 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * @returns Array of TokenStatus
      * */ 
     
-    public async  getTokenStatus(context: TurnContext, userId: string, includeFilter?: string ):Promise<TokenStatus[]>
+    public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ):Promise<TokenStatus[]>
     {
-       if(!context.activity.from || !context.activity.from.id){
+       if(!userId && (!context.activity.from || !context.activity.from.id)){
         throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);
        }
         this.checkEmulatingOAuthCards(context);
+        !userId? userId = context.activity.from.id: userId;
         const url: string = this.oauthApiUrl(context);
         const client: TokenApiClient = this.createTokenApiClient(url);
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -442,7 +442,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * @returns Array of TokenStatus
      * */ 
     
-    public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ):Promise<TokenStatus[]>
+    public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ): Promise<TokenStatus[]>
     {
        if(!userId && (!context.activity.from || !context.activity.from.id)){
         throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -6,8 +6,8 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TokenStatus, TurnContext } from 'botbuilder-core';
-import { ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, JwtTokenValidation, MicrosoftAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenApiModels } from 'botframework-connector';
+import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TurnContext } from 'botbuilder-core';
+import { ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, JwtTokenValidation, MicrosoftAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenStatus, TokenApiModels } from 'botframework-connector';
 import * as os from 'os';
 
 /**

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -436,10 +436,10 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
 
     /** 
      * Retrieves the token status for each configured connection for the given user.
-     * <param name="context">Context for the current turn of conversation with the user.</param>
-     * <param name="userId">The user Id for which token status is retrieved.</param>
-     * <param name="includeFilter">Optional comma seperated list of connection's to include. Blank will return token status for all configured connections.</param>
-     * <returns>Array of TokenStatus.</returns>
+     * @param context Context for the current turn of conversation with the user.
+     * @param userId The user Id for which token status is retrieved.
+     * @param includeFilter Optional comma seperated list of connection's to include. Blank will return token status for all configured connections.
+     * @returns Array of TokenStatus
      * */ 
     
     public async  getTokenStatus(context: TurnContext, userId: string, includeFilter?: string ):Promise<TokenStatus[]>

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -174,30 +174,6 @@ describe(`BotFrameworkAdapter`, function () {
             done();
         });
     });
-    
-    const reference = {
-        activityId: '1234',
-        channelId: 'test',
-        serviceUrl: 'https://example.org/channel',
-        user: { id: 'user', name: 'User Name' },
-        bot: { id: 'bot', name: 'Bot Name' },
-        conversation: { id: 'convo1' }
-    };
-
-    it(`should return the status of every connection the user has`, async function () {
-            const adapter = new AdapterUnderTest();
-            const activity =  
-                {
-                    channelId: "directline", 
-                    from: 
-                    { 
-                        id: "testUser" 
-                    } 
-                }
-             
-            const context = new TurnContext(adapter, activity);
-            await adapter.getTokenStatus(context);
-    });
 
     it(`should processActivity() sent as body.`, function (done) {
         let called = false;
@@ -354,6 +330,19 @@ describe(`BotFrameworkAdapter`, function () {
         }, (err) => {
             assert(err, `error not returned.`);
             done();
+        });
+    });
+
+    it(`should return the status of every connection the user has`, async function () {
+            
+        const adapter = new AdapterUnderTest();
+        const context = new TurnContext(adapter, incomingMessage);
+        adapter.getTokenStatus(context)
+        .then((responses)=>{
+            assert(responses.length>0);
+        })
+        .catch((error) => {
+            assert(error);
         });
     });
 

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -811,4 +811,28 @@ describe(`BotFrameworkAdapter`, function () {
         }
         assert(false, `should have thrown an error message`);
     });
+
+    it(`should throw error if missing from in getTokenStatus()`, async function () {
+        try {
+            const adapter = new AdapterUnderTest();
+            await adapter.getTokenStatus({ activity: {} });
+        } catch (err) {
+            assert(err.message === 'BotFrameworkAdapter.getTokenStatus(): missing from or from.id',
+                `expected "BotFrameworkAdapter.getTokenStatus(): missing from or from.id" Error message, not "${ err.message }"`);
+            return;
+        }
+        assert(false, `should have thrown an error message`);
+    });
+
+    it(`should throw error if missing from.id in getTokenStatus()`, async function () {
+        try {
+            const adapter = new AdapterUnderTest();
+            await adapter.getTokenStatus({ activity: { from: {} } });
+        } catch (err) {
+            assert(err.message === 'BotFrameworkAdapter.getTokenStatus(): missing from or from.id',
+                `expected "BotFrameworkAdapter.getTokenStatus(): missing from or from.id" Error message, not "${ err.message }"`);
+            return;
+        }
+        assert(false, `should have thrown an error message`);
+    });
 });

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -133,6 +133,19 @@ function assertResponse(res, statusCode, hasBody) {
 
 describe(`BotFrameworkAdapter`, function () {
     this.timeout(5000);
+    
+    it(`should return the status of every connection the user has`, async function () {
+            
+        const adapter = new AdapterUnderTest();
+        const context = new TurnContext(adapter, incomingMessage);
+        adapter.getTokenStatus(context)
+        .then((responses) => {
+            assert(responses.length>0);
+        })
+        .catch((error) => {
+            assert(error);
+        });
+    });
 
     it(`should authenticateRequest() if no appId or appPassword.`, function (done) {
         const req = new MockRequest(incomingMessage);
@@ -330,19 +343,6 @@ describe(`BotFrameworkAdapter`, function () {
         }, (err) => {
             assert(err, `error not returned.`);
             done();
-        });
-    });
-
-    it(`should return the status of every connection the user has`, async function () {
-            
-        const adapter = new AdapterUnderTest();
-        const context = new TurnContext(adapter, incomingMessage);
-        adapter.getTokenStatus(context)
-        .then((responses)=>{
-            assert(responses.length>0);
-        })
-        .catch((error) => {
-            assert(error);
         });
     });
 

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -174,6 +174,30 @@ describe(`BotFrameworkAdapter`, function () {
             done();
         });
     });
+    
+    const reference = {
+        activityId: '1234',
+        channelId: 'test',
+        serviceUrl: 'https://example.org/channel',
+        user: { id: 'user', name: 'User Name' },
+        bot: { id: 'bot', name: 'Bot Name' },
+        conversation: { id: 'convo1' }
+    };
+
+    it(`should return the status of every connection the user has`, async function () {
+            const adapter = new AdapterUnderTest();
+            const activity =  
+                {
+                    channelId: "directline", 
+                    from: 
+                    { 
+                        id: "testUser" 
+                    } 
+                }
+             
+            const context = new TurnContext(adapter, activity);
+            await adapter.getTokenStatus(context);
+    });
 
     it(`should processActivity() sent as body.`, function (done) {
         let called = false;
@@ -815,6 +839,7 @@ describe(`BotFrameworkAdapter`, function () {
     it(`should throw error if missing from in getTokenStatus()`, async function () {
         try {
             const adapter = new AdapterUnderTest();
+
             await adapter.getTokenStatus({ activity: {} });
         } catch (err) {
             assert(err.message === 'BotFrameworkAdapter.getTokenStatus(): missing from or from.id',

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -135,15 +135,11 @@ describe(`BotFrameworkAdapter`, function () {
     this.timeout(5000);
     
     it(`should return the status of every connection the user has`, async function () {
-            
         const adapter = new AdapterUnderTest();
         const context = new TurnContext(adapter, incomingMessage);
         adapter.getTokenStatus(context)
         .then((responses) => {
-            assert(responses.length>0);
-        })
-        .catch((error) => {
-            assert(error);
+            assert(responses.length > 0);
         });
     });
 

--- a/libraries/botframework-connector/src/index.ts
+++ b/libraries/botframework-connector/src/index.ts
@@ -9,3 +9,4 @@ export * from './auth';
 export { ConnectorClient } from './connectorApi/connectorClient';
 export { TokenApiClient, TokenApiModels } from './tokenApi/tokenApiClient';
 export { EmulatorApiClient } from './emulatorApiClient';
+export * from './tokenApi/models'

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1227,29 +1227,6 @@ export interface TokenResponse {
 }
 
 /**
- * The status of a particular token
- */
-export interface TokenStatus {
-  /**
-   * @member {string} [channelId] The channelId of the token status pertains to
-   */
-  channelId?: string;
-  /**
-   * @member {string} [connectionName] The name of the connection the token
-   * status pertains to
-   */
-  connectionName?: string;
-  /**
-   * True if a token is stored for this ConnectionName
-   */
-  hasToken?: boolean;
-  /**
-   * The display name of the service provider for which this Token belongs to
-   */
-  serviceProviderDisplayName?: string;
-}
-
-/**
  * W3C Payment Method Data for Microsoft Pay
  */
 export interface MicrosoftPayMethodData {

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1227,6 +1227,29 @@ export interface TokenResponse {
 }
 
 /**
+ * The status of a particular token
+ */
+export interface TokenStatus {
+  /**
+   * @member {string} [channelId] The channelId of the token status pertains to
+   */
+  channelId?: string;
+  /**
+   * @member {string} [connectionName] The name of the connection the token
+   * status pertains to
+   */
+  connectionName?: string;
+  /**
+   * True if a token is stored for this ConnectionName
+   */
+  hasToken?: boolean;
+  /**
+   * The display name of the service provider for which this Token belongs to
+   */
+  serviceProviderDisplayName?: string;
+}
+
+/**
  * W3C Payment Method Data for Microsoft Pay
  */
 export interface MicrosoftPayMethodData {


### PR DESCRIPTION
Fixes 787

## Description
As requested in the mentioned issue, the method `getTokenStatus` was added to the `BotFrameworkAdapter` class, using the logic that already existed in the [`userToken` class](https://github.com/southworkscom/botbuilder-js/blob/2c4961fedb9212d5a0a3ec6dc3a2bc2de459141a/libraries/botframework-connector/src/tokenApi/operations/userToken.ts#L123).

## Specific Changes

  - Add TokenStatus to the index.ts file
  - Port GetTokenStatusAsync from [C#](https://github.com/Microsoft/botbuilder-dotnet/blob/924eaa286fe3cebfaebae27570f504977c8591e9/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L663) to TypeScript (as getTokenStatus).

## Testing
![imagen](https://user-images.githubusercontent.com/22912283/53261883-e5905c80-36b3-11e9-9739-8eb2f9ea4c01.png)


