### PR TITLE
[BotFramework-Connector] Refactor instantiation of env

### DIFF
--- a/libraries/botframework-connector/src/index.ts
+++ b/libraries/botframework-connector/src/index.ts
@@ -1,4 +1,12 @@
-(new Function('require', 'const env = (global || window); if (!env.hasOwnProperty("FormData")) { env.FormData = require("form-data"); }; if (!env.hasOwnProperty("fetch")) { env.fetch = require("node-fetch"); }'))(require);
+const env = (new Function('return (global || window);'))();
+
+if (!env.hasOwnProperty("FormData")) {
+    env.FormData = require('form-data');
+};
+
+if (!env.hasOwnProperty("fetch")) {
+    env.fetch = require('node-fetch');
+}
 
 import { TokenResponse } from './connectorApi/models/mappers';
 


### PR DESCRIPTION
## Description
Fix webpack bundling with polyfill with BotFramework Connector.

## Specific Changes
Extract _requires_ from string function body to functional code and kept _get global access pattern_ for `env`.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->