### PR TITLE
Removed references to TSLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "read-text-file": "^1.1.0",
     "replace-in-file": "^4.1.0",
     "sinon": "^7.3.2",
-    "tslint": "^5.18.0",
-    "tslint-microsoft-contrib": "^6.2.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-external-module-name": "^2.1.0",
     "typedoc-plugin-markdown": "^2.0.6",


### PR DESCRIPTION
### Description
Using ESLint now lets TSLint deprecated, and can be easily removed.

### Changes
**package.json**: removed references:
-  `tslint` 
- `tslint-microsoft-contrib`

### Testing
All the tests run successfully.

![image](https://user-images.githubusercontent.com/24591490/61662347-a555fa00-aca4-11e9-9556-8fead387ec5e.png)

![image](https://user-images.githubusercontent.com/24591490/61662510-f36afd80-aca4-11e9-8226-eaf82105afe8.png)



![image](https://user-images.githubusercontent.com/24591490/61662384-b4d54300-aca4-11e9-9f43-a04f7aad675c.png)

