### PR TITLE
[BotBuilder-JS] Add scripts to package JSON to run the functional tests for each environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "lerna run build",
     "clean": "lerna run clean",
     "functional-test": "lerna run build && nyc mocha \"libraries/functional-tests/tests/*.test.js\"",
-    "browser-functional-test": "cd libraries/browser-functional-tests && node nightwatch.js -e chrome",
+    "browser-functional-test": "cd libraries/browser-functional-tests && node nightwatch.js -e",
     "test": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\"",
     "test:coveralls": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
     "test-coverage": "nyc mocha \"libraries/bot*/tests/*.test.js\" ",


### PR DESCRIPTION
Modified the script in the Package JSON in order to stop using Chrome as the default Browser.

## Description

We will work with three or more different Browsers, so in order to not have conflicts in the future, we had to remove the Browser Chrome as the default test Browser and instead, we will test each environment in the Pipeline.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Remove "chrome" from the Script

## Testing

In the image we tested Edge and Chrome (only Chrome succeeded, because we didn't have installed yet the Web Driver for Edge)
![image](https://user-images.githubusercontent.com/44620563/69363812-e6204880-0c6f-11ea-90fd-2388ff030e0f.png)
