### PR TITLE
Add YAML files for CI build

### DIFF
--- a/build-CI-yaml/basic-test-CI.yml
+++ b/build-CI-yaml/basic-test-CI.yml
@@ -11,7 +11,6 @@ pool:
   vmImage: 'vs2017-win2016'
     
 steps:
-
 - task: NodeTool@0
   displayName: 'Use Node 10x'
   inputs:

--- a/build-CI-yaml/basic-test-CI.yml
+++ b/build-CI-yaml/basic-test-CI.yml
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+trigger:
+    - master
+
+pr:
+    - master
+    
+pool:
+  vmImage: 'vs2017-win2016'
+    
+steps:
+
+- task: NodeTool@0
+  displayName: 'Use Node 10x'
+  inputs:
+    versionSpec: 10.15.3
+
+- task: Npm@1
+  displayName: 'npm install'
+  inputs:
+    verbose: false
+
+- task: Npm@1
+  displayName: 'npm test'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run test'

--- a/build-CI-yaml/linux-bot-test-CI.yml
+++ b/build-CI-yaml/linux-bot-test-CI.yml
@@ -52,27 +52,18 @@ steps:
    set D=$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot
    
    robocopy %S%\botbuilder %D%\botbuilder /S /XF .gitignore /XD src tests /NFL /NDL
-   
    robocopy %S%\botbuilder-core %D%\botbuilder-core /S /XF .gitignore /XD src tests /NFL /NDL
-   
    robocopy %S%\botframework-connector %D%\botframework-connector /S /XF .gitignore /XD src tests /NFL /NDL
-   
    robocopy %S%\botframework-schema %D%\botframework-schema /S /XF .gitignore /XD src tests /NFL /NDL
    
    Move $(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\deployment-scripts\linux\* $(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot
    
    git config --global user.name "BotBuilderDotNetPipeline"
-   
    git config --global user.email BotBuilderDotNet@Pipeline.com
-   
    git init
-   
    git add .
-   
    git commit -m "Add bot source code"
-   
    git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(TestBotName).scm.azurewebsites.net:443/$(TestBotName).git
-   
    git push azure master
   workingDirectory: 'libraries/functional-tests/functionaltestbot'
   displayName: 'Git Bot Deployment'
@@ -86,9 +77,7 @@ steps:
 
 - powershell: |
    $json = Get-Content '$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\DirectLineCreate.json' | Out-String | ConvertFrom-Json
-   
    $key = $json.properties.properties.sites.key
-   
    echo "##vso[task.setvariable variable=DIRECT_LINE_KEY;]$key"
   displayName: 'Get Direct Line Keys'
 

--- a/build-CI-yaml/linux-bot-test-CI.yml
+++ b/build-CI-yaml/linux-bot-test-CI.yml
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+trigger:
+    - master
+    
+pr:
+    - master
+
+pool:
+  vmImage: 'vs2017-win2016'
+
+variables:
+  TestBotName: 'TestBotGAZLinux'
+
+steps:
+- task: AzureResourceGroupDeployment@2
+  displayName: 'Create Bot Resource Group'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    resourceGroupName: '$(TestBotName)'
+    location: 'Central US'
+    csmFile: 'libraries/functional-tests/functionaltestbot/template/linux/template.json'
+    overrideParameters: '-botName "$(TestBotName)" -sku {"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1} -linuxFxVersion "NODE|10.14" -location "West US" -appId "$(TestBotAppId)" -appSecret "$(TestBotAppSecret)"'
+
+- task: AzureCLI@1
+  displayName: 'Prepare Bot to Deploy'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: 'call az bot prepare-deploy --code-dir "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot" --lang Javascript'
+
+- task: NodeTool@0
+  displayName: 'Use Node 10x'
+  inputs:
+    versionSpec: 10.15.3
+
+- task: Npm@1
+  displayName: 'npm install'
+  inputs:
+    verbose: false
+
+- task: Npm@1
+  displayName: 'npm run build'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run build'
+
+- script: |
+   set S=$(System.DefaultWorkingDirectory)\libraries
+   set D=$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot
+   
+   robocopy %S%\botbuilder %D%\botbuilder /S /XF .gitignore /XD src tests /NFL /NDL
+   
+   robocopy %S%\botbuilder-core %D%\botbuilder-core /S /XF .gitignore /XD src tests /NFL /NDL
+   
+   robocopy %S%\botframework-connector %D%\botframework-connector /S /XF .gitignore /XD src tests /NFL /NDL
+   
+   robocopy %S%\botframework-schema %D%\botframework-schema /S /XF .gitignore /XD src tests /NFL /NDL
+   
+   Move $(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\deployment-scripts\linux\* $(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot
+   
+   git config --global user.name "BotBuilderDotNetPipeline"
+   
+   git config --global user.email BotBuilderDotNet@Pipeline.com
+   
+   git init
+   
+   git add .
+   
+   git commit -m "Add bot source code"
+   
+   git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(TestBotName).scm.azurewebsites.net:443/$(TestBotName).git
+   
+   git push azure master
+  workingDirectory: 'libraries/functional-tests/functionaltestbot'
+  displayName: 'Git Bot Deployment'
+
+- task: AzureCLI@1
+  displayName: 'Create Direct Line'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: 'call az bot directline create -n "$(TestBotName)" -g "$(TestBotName)" > "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/DirectLineCreate.json"'
+
+- powershell: |
+   $json = Get-Content '$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\DirectLineCreate.json' | Out-String | ConvertFrom-Json
+   
+   $key = $json.properties.properties.sites.key
+   
+   echo "##vso[task.setvariable variable=DIRECT_LINE_KEY;]$key"
+  displayName: 'Get Direct Line Keys'
+
+- task: Npm@1
+  displayName: 'npm functional-test'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run functional-test'
+
+- task: AzureCLI@1
+  displayName: 'Delete Resource Group'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: 'call az group delete -n "$(TestBotName)" --yes'
+  condition: always()

--- a/build-CI-yaml/windows-bot-test-CI.yml
+++ b/build-CI-yaml/windows-bot-test-CI.yml
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+trigger:
+    - master
+    
+pr:
+    - master
+
+pool:
+  vmImage: 'vs2017-win2016'
+
+variables:
+  TestBotName: 'FuncTestBotWin'
+
+steps:
+
+- task: AzureResourceGroupDeployment@2
+  displayName: 'Create Bot Resource Group'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    resourceGroupName: '$(TestBotName)'
+    location: 'Central US'
+    csmFile: 'libraries/functional-tests/functionaltestbot/template/windows/template.json'
+    overrideParameters: '-serverFarmName "$(TestBotName)" -createServerFarm true -serverFarmLocation "Central US" -serverFarmSku {"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1} -siteName "$(TestBotName)" -kind "sdk" -siteLocation "Central US" -appId "$(TestBotAppId)" -appSecret "$(TestBotAppSecret)" -zipUrl "https://bot-framework.azureedge.net/static/59409-2a1ed9f3ee/bot-packages/v1.3.18/node.js-abs-webapp-v4_echobot.zip" -botId "$(TestBotName)" -sku "S1" -endpoint ""'
+
+- task: AzureCLI@1
+  displayName: 'Prepare Bot to Deploy'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: |
+     call az bot prepare-deploy --code-dir "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot" --lang Javascript
+     
+- powershell: |
+   move-item -path $(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/deployment-scripts/windows/* -destination $(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot
+   
+   $DirToCompress = "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot"
+   $DirtoExclude =@("node_modules", "template", "deployment-scripts")
+   $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude
+   $ZipFileResult ="$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/testbot.zip"
+   Compress-Archive -Path $files -DestinationPath $ZipFileResult
+  displayName: 'Compress Bot Source Code'
+
+- task: AzureCLI@1
+  displayName: 'Create Direct Line'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: |
+     call az webapp deployment source config-zip --resource-group "$(TestBotName)" --name "$(TestBotName)" --src "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/testbot.zip"
+     
+     call az bot directline create -n "$(TestBotName)" -g "$(TestBotName)" > "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/DirectLineCreate.json"
+
+- powershell: |
+   $json = Get-Content '$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\DirectLineCreate.json' | Out-String | ConvertFrom-Json
+   
+   $key = $json.properties.properties.sites.key
+   
+   echo "##vso[task.setvariable variable=DIRECT_LINE_KEY;]$key"
+
+  displayName: 'Get Direct Line Keys'
+
+- task: NodeTool@0
+  displayName: 'Use Node 10x'
+  inputs:
+    versionSpec: 10.15.3
+
+
+- task: Npm@1
+  displayName: 'npm install'
+  inputs:
+    verbose: false
+
+- task: Npm@1
+  displayName: 'npm functional-test'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run functional-test'
+
+- task: AzureCLI@1
+  displayName: 'Delete Resource Group'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: 'call az group delete -n "$(TestBotName)" --yes'
+  condition: always()

--- a/build-CI-yaml/windows-bot-test-CI.yml
+++ b/build-CI-yaml/windows-bot-test-CI.yml
@@ -14,7 +14,6 @@ variables:
   TestBotName: 'FuncTestBotWin'
 
 steps:
-
 - task: AzureResourceGroupDeployment@2
   displayName: 'Create Bot Resource Group'
   inputs:
@@ -34,7 +33,7 @@ steps:
      
 - powershell: |
    move-item -path $(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/deployment-scripts/windows/* -destination $(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot
-   
+
    $DirToCompress = "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot"
    $DirtoExclude =@("node_modules", "template", "deployment-scripts")
    $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude
@@ -49,14 +48,11 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      call az webapp deployment source config-zip --resource-group "$(TestBotName)" --name "$(TestBotName)" --src "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/testbot.zip"
-     
      call az bot directline create -n "$(TestBotName)" -g "$(TestBotName)" > "$(System.DefaultWorkingDirectory)/libraries/functional-tests/functionaltestbot/DirectLineCreate.json"
 
 - powershell: |
    $json = Get-Content '$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot\DirectLineCreate.json' | Out-String | ConvertFrom-Json
-   
    $key = $json.properties.properties.sites.key
-   
    echo "##vso[task.setvariable variable=DIRECT_LINE_KEY;]$key"
 
   displayName: 'Get Direct Line Keys'
@@ -65,7 +61,6 @@ steps:
   displayName: 'Use Node 10x'
   inputs:
     versionSpec: 10.15.3
-
 
 - task: Npm@1
   displayName: 'npm install'


### PR DESCRIPTION
## Description
This pull request adds YAML files to set up build pipelines running tests.

## Specific Changes
We added three YAML files inside the folder `build-CI-yaml` in the root folder.
The added files are:
- `basic-test-CI`: install dependencies and run the tests.
- `linux-bot-test-CI`: deploys a bot in Azure in a Linux environment and runs the tests for that bot.
- `windows-bot-test-CI`: deploys a bot in Azure in a Windows environment and runs the tests for that bot.

## How to use
The next steps will guide you thought the configuration of a Build pipeline based on the YAML file.

### Prerequisites
- Azure DevOps organization. You can find documentation here.
- Azure subscription. Required to create and delete Azure resources.
- Configure an Azure Connection Service. [Steps here](#add-a-connection-service)

### Set up build pipeline
1- Create a pipeline using the classic editor, this options allows us to select the YAML file to configure the pipeline.
![image](https://user-images.githubusercontent.com/38112957/70465480-cecec100-1a9f-11ea-8321-49eb42c126f2.png)

2- Configure the repository and branch.
![image](https://user-images.githubusercontent.com/38112957/70465714-4f8dbd00-1aa0-11ea-9a27-f5966bf150bb.png)

3- In the Configuration as code, select the YAML option.
![image](https://user-images.githubusercontent.com/38112957/70465840-9b406680-1aa0-11ea-9598-b6f47dd9c6cd.png)

4- In section YAML, write the build name and select the build YAML file inside the folder `build-CI-yaml` in the root of the directory.
![image](https://user-images.githubusercontent.com/38112957/70465856-a7c4bf00-1aa0-11ea-89cd-27e49ac28eb5.png)

5- In the Variables section add the following variables.
- For the Windows CI build:
  - TestBotAppdId
  - TestBotAppSecret
  - AzureSubscription (Connection name from Connected Service)

- For the Linux CI build:
  - TestBotAppdId
  - TestBotAppSecret
  - AzureSubscription (Connection name from Connected Service)
  - AzureDeploymentUser
  - AzureDeploymentPassword

- For the basic CI build you don't need to add any variable.

### Add a Connection Service
This step is required to use your Azure Subscription for the Windows and Linux CI builds. If you already have a Connection Service configured, save its Connection name to use it later as _AzureSubscription_.

For more info go to [this link](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml).

1-  In your Azure DevOps project, go to project settings -> Service Connections -> New service connection.
![image](https://user-images.githubusercontent.com/38112957/70467844-b319e980-1aa4-11ea-8f92-987bbba28120.png)

2- Select Azure Resource Manager and click Next. In the dialog select `use the full version of the service connection dialog`.
![image](https://user-images.githubusercontent.com/38112957/70468143-4fdc8700-1aa5-11ea-9f0a-f679125e0d25.png)

3- Fill all the fields and check the `Allow all pipelines to use this connection` option. Save the name you are using in `Connection name`, this will be the variable **AzureSubscription** in following steps
![image](https://user-images.githubusercontent.com/38112957/70469973-d6df2e80-1aa8-11ea-9240-563552f41a6a.png)

## Testing
In the following image, you can see an example of one the builds running in a pipeline from the YAML file.
![image](https://user-images.githubusercontent.com/37461749/70533837-a47d1200-1b38-11ea-9db8-279da5ad5b3e.png)

