### PR TITLE
Fixes browsers functional test build pipeline

### DIFF
--- a/libraries/browser-functional-tests/package.json
+++ b/libraries/browser-functional-tests/package.json
@@ -4,7 +4,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^77.0.0",
+    "chromedriver": "79.0.0",
     "dotenv": "^8.0.0",
     "nightwatch": "^1.2.4",
     "geckodriver": "^1.19.1",

--- a/libraries/browser-functional-tests/package.json
+++ b/libraries/browser-functional-tests/package.json
@@ -4,7 +4,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "79.0.0",
+    "chromedriver": "^79.0.0",
     "dotenv": "^8.0.0",
     "nightwatch": "^1.2.4",
     "geckodriver": "^1.19.1",


### PR DESCRIPTION
## Description
The Browser Functional Test build pipeline is falling due to the chrome driver version. 

Google Chrome updates to version 79.0.0 a few days ago. 

![image](https://user-images.githubusercontent.com/37461749/72901281-3e270a00-3d08-11ea-95ba-253ccb1fdf2e.png)

This pull request updates the version of the `chromedriver` dependency to the current stable version `79.0.0`

## Specific Changes
- Update chrome driver version

## Testing 
![image](https://user-images.githubusercontent.com/37461749/72903575-349fa100-3d0c-11ea-89d6-4a1c44dd8bb4.png)


