### PR TITLE
Add Teams' Channel Restored event

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -33,8 +33,10 @@ import { TeamsInfo } from './teamsInfo';
 export class TeamsActivityHandler extends ActivityHandler {
 
     /**
-     * 
-     * @param context 
+     * Invoked when an invoke activity is received from the connector.
+     * Invoke activities can be used to communicate many different things.
+     * @param context A context object for this turn.
+     * @returns An Invoke Response for the activity.
      */
     protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
         let runEvents = true;
@@ -102,8 +104,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
-     * @param context 
+     * Handles a Teams Card Action Invoke activity.
+     * @param context A context object for this turn.
+     * @returns An Invoke Response for the activity.
      */
     protected async handleTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
         throw new Error('NotImplemented');
@@ -114,8 +117,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * `handleTeamsFileConsentAccept` and `handleTeamsFileConsentDecline`.
      * Developers are not passed a pointer to the next `handleTeamsFileConsent` handler because the _wrapper_ around
      * the handler will call `onDialogs` handlers after delegating to `handleTeamsFileConsentAccept` or `handleTeamsFileConsentDecline`.
-     * @param context
-     * @param fileConsentCardResponse
+     * @param context A context object for this turn.
+     * @param fileConsentCardResponse Represents the value of the invoke activity sent when the user acts on a file consent card.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsFileConsent(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         switch (fileConsentCardResponse.action) {
@@ -132,8 +136,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Receives invoke activities with Activity name of 'fileConsent/invoke' with confirmation from user
      * @remarks
      * This type of invoke activity occur during the File Consent flow.
-     * @param context
-     * @param fileConsentCardResponse
+     * @param context A context object for this turn.
+     * @param fileConsentCardResponse Represents the value of the invoke activity sent when the user acts on a file consent card.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         throw new Error('NotImplemented');
@@ -143,22 +148,28 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Receives invoke activities with Activity name of 'fileConsent/invoke' with decline from user
      * @remarks
      * This type of invoke activity occur during the File Consent flow.
-     * @param context
-     * @param fileConsentCardResponse
+     * @param context A context object for this turn.
+     * @param fileConsentCardResponse Represents the value of the invoke activity sent when the user acts on a file consent card.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         throw new Error('NotImplemented');
     }
 
     /**
-     * Receives invoke activities with Activity name of 'actionableMessage/executeAction'
+     * Receives invoke activities with Activity name of 'actionableMessage/executeAction'.
+     * @param context A context object for this turn.
+     * @param query The O365 connector card HttpPOST invoke query.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
         throw new Error('NotImplemented');
     }
 
-    /*
-     * override default because to call teams specific events
+    /**
+     * Invoked when a signIn invoke activity is received from the connector.
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onSignInInvoke(context: TurnContext): Promise<void> {
         switch (context.activity.name) {
@@ -170,9 +181,10 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Receives invoke activities with Activity name of 'signin/verifyState'
-     * @param context
-     * @param action
+     * Receives invoke activities with Activity name of 'signin/verifyState'.
+     * @param context A context object for this turn.
+     * @param query Signin state (part of signin action auth flow) verification invoke query.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsSigninVerifyState(context: TurnContext, query: SigninStateVerificationQuery): Promise<void> {
         throw new Error('NotImplemented');
@@ -180,8 +192,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with Activity name of 'signin/tokenExchange'
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param query Signin state (part of signin action auth flow) verification invoke query
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsSigninTokenExchange(context: TurnContext, query: SigninStateVerificationQuery): Promise<void> {
         throw new Error('NotImplemented');
@@ -189,8 +202,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with Activity name of 'composeExtension/onCardButtonClicked'
-     * @param context 
-     * @param cardData 
+     * @param context A context object for this turn.
+     * @param cardData Object representing the card data.
+     * @returns A task that represents the work queued to execute.
      */
     protected async handleTeamsMessagingExtensionCardButtonClicked(context: TurnContext, cardData: any): Promise<void> {
         throw new Error('NotImplemented');
@@ -198,8 +212,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with Activity name of 'task/fetch'
-     * @param context
-     * @param taskModuleRequest
+     * @param context A context object for this turn.
+     * @param taskModuleRequest The task module invoke request value payload.
+     * @returns A Task Module Response for the request.
      */
     protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         throw new Error('NotImplemented');
@@ -207,8 +222,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with Activity name of 'task/submit'
-     * @param context
-     * @param taskModuleRequest
+     * @param context A context object for this turn.
+     * @param taskModuleRequest The task module invoke request value payload.
+     * @returns A Task Module Response for the request.
      */
     protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         throw new Error('NotImplemented');
@@ -218,8 +234,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Receives invoke activities with Activity name of 'composeExtension/queryLink'
      * @remarks
      * Used in creating a Search-based Message Extension.
-     * @param context
-     * @param query
+     * @param context A context object for this turn.
+     * @param query he invoke request body type for app-based link query.
+     * @returns The Messaging Extension Response for the query.
      */
     protected async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
@@ -229,8 +246,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Receives invoke activities with the name 'composeExtension/query'.
      * @remarks
      * Used in creating a Search-based Message Extension.
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param query The query for the search command.
+     * @returns The Messaging Extension Response for the query.
      */
     protected async handleTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
@@ -240,8 +258,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Receives invoke activities with the name 'composeExtension/selectItem'.
      * @remarks
      * Used in creating a Search-based Message Extension.
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param query he object representing the query.
+     * @returns The Messaging Extension Response for the query.
      */
     protected async handleTeamsMessagingExtensionSelectItem(context: TurnContext, query: any): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
@@ -253,8 +272,9 @@ export class TeamsActivityHandler extends ActivityHandler {
      * A handler registered through this method does not dispatch to the next handler (either `handleTeamsMessagingExtensionSubmitAction`, `handleTeamsMessagingExtensionBotMessagePreviewEdit`, or `handleTeamsMessagingExtensionBotMessagePreviewSend`).
      * This method exists for developers to optionally add more logic before the TeamsActivityHandler routes the activity to one of the
      * previously mentioned handlers.
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param action The messaging extension action.
+     * @returns The Messaging Extension Action Response for the action.
      */
     protected async handleTeamsMessagingExtensionSubmitActionDispatch(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         if (action.botMessagePreviewAction) {
@@ -273,10 +293,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with the name 'composeExtension/submitAction'.
-     * @remarks
-     * This invoke activity is received when a user 
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param action The messaging extension action.
+     * @returns The Messaging Extension Action Response for the action.
      */
     protected async handleTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
@@ -285,10 +304,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     /**
      * Receives invoke activities with the name 'composeExtension/submitAction' with the 'botMessagePreview' property present on activity.value.
      * The value for 'botMessagePreview' is 'edit'.
-     * @remarks
-     * This invoke activity is received when a user
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param action The messaging extension action.
+     * @returns The Messaging Extension Action Response for the action.
      */
     protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
@@ -297,10 +315,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     /**
      * Receives invoke activities with the name 'composeExtension/submitAction' with the 'botMessagePreview' property present on activity.value.
      * The value for 'botMessagePreview' is 'send'.
-     * @remarks
-     * This invoke activity is received when a user 
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param action The messaging extension action.
+     * @returns The Messaging Extension Action Response for the action.
      */
     protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
@@ -308,8 +325,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with the name 'composeExtension/fetchTask'
-     * @param context
-     * @param action
+     * @param context A context object for this turn.
+     * @param action The messaging extension action.
+     * @returns The Messaging Extension Action Response for the action.
      */
     protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
@@ -317,8 +335,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with the name 'composeExtension/querySettingUrl' 
-     * @param context
-     * @param query
+     * @param context A context object for this turn.
+     * @param query The Messaging extension query.
+     * @returns The Messaging Extension Action Response for the query.
      */
     protected async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
@@ -326,8 +345,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Receives invoke activities with the name 'composeExtension/setting' 
-     * @param context
-     * @param query
+     * @param context A context object for this turn.
+     * @param settings Object representing the configuration settings.
+     * @returns A task that represents the work queued to execute.
      */
     protected handleTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings: any): Promise<void> {
         throw new Error('NotImplemented');
@@ -335,9 +355,8 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this method to change the dispatching of ConversationUpdate activities.
-     * @remarks
-     * 
-     * @param context 
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async dispatchConversationUpdateActivity(context: TurnContext): Promise<void> {
         await this.handle(context, 'ConversationUpdate', async () => {
@@ -388,7 +407,8 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Called in `dispatchConversationUpdateActivity()` to trigger the `'TeamsMembersAdded'` handlers.
      * @remarks
      * If no handlers are registered for the `'TeamsMembersAdded'` event, the `'MembersAdded'` handlers will run instead.
-     * @param context 
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsMembersAdded(context: TurnContext): Promise<void> {
         if ('TeamsMembersAdded' in this.handlers && this.handlers['TeamsMembersAdded'].length > 0) {
@@ -437,7 +457,8 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Called in `dispatchConversationUpdateActivity()` to trigger the `'TeamsMembersRemoved'` handlers.
      * @remarks
      * If no handlers are registered for the `'TeamsMembersRemoved'` event, the `'MembersRemoved'` handlers will run instead.
-     * @param context 
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsMembersRemoved(context: TurnContext): Promise<void> {
         if ('TeamsMembersRemoved' in this.handlers && this.handlers['TeamsMembersRemoved'].length > 0) {
@@ -448,24 +469,30 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
-     * @param context 
+     * Invoked when a Channel Created event activity is received from the connector.
+     * Channel Created correspond to the user creating a new channel.
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsChannelCreated(context): Promise<void> {
         await this.handle(context, 'TeamsChannelCreated', this.defaultNextEvent(context));
     }
 
     /**
-     * 
-     * @param context 
+     * Invoked when a Channel Deleted event activity is received from the connector.
+     * Channel Deleted correspond to the user deleting a channel.
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute. 
      */
     protected async onTeamsChannelDeleted(context): Promise<void> {
         await this.handle(context, 'TeamsChannelDeleted', this.defaultNextEvent(context));
     }
 
     /**
-     * 
-     * @param context 
+     * Invoked when a Channel Renamed event activity is received from the connector.
+     * Channel Renamed correspond to the user renaming a new channel.
+     * @param context A context object for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsChannelRenamed(context): Promise<void> {
         await this.handle(context, 'TeamsChannelRenamed', this.defaultNextEvent(context));
@@ -474,23 +501,28 @@ export class TeamsActivityHandler extends ActivityHandler {
     /**
      * Invoked when a Channel Restored event activity is received from the connector.
      * Channel Restored correspond to the user restoring a previously deleted channel.
-     * @param context The context for this turn
+     * @param context The context for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsChannelRestored(context): Promise<void> {
         await this.handle(context, 'TeamsChannelRestored', this.defaultNextEvent(context));
     }
 
     /**
-     * 
-     * @param context 
+     * Invoked when a Team Renamed event activity is received from the connector.
+     * Team Renamed correspond to the user renaming a team.
+     * @param context The context for this turn.
+     * @returns A task that represents the work queued to execute.
      */
     protected async onTeamsTeamRenamed(context): Promise<void> {
         await this.handle(context, 'TeamsTeamRenamed', this.defaultNextEvent(context));
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when members other than the bot
+     * join the channel, such as your bot's welcome logic.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsMembersAddedEvent(handler: (membersAdded: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsMembersAdded', async (context, next) => {
@@ -500,8 +532,10 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when members other than the bot
+     * leave the channel, such as your bot's good-bye logic.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsMembersRemovedEvent(handler: (membersRemoved: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsMembersRemoved', async (context, next) => {
@@ -511,8 +545,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when a channel is created.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsChannelCreatedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsChannelCreated', async (context, next) => {
@@ -522,8 +557,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when a channel is deleted.
      * @param handler 
+     * @returns A task that represents the work queued to execute. 
      */
     public onTeamsChannelDeletedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsChannelDeleted', async (context, next) => {
@@ -533,8 +569,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when a channel is renamed.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsChannelRenamedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsChannelRenamed', async (context, next) => {
@@ -546,6 +583,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     /**
      * Override this in a derived class to provide logic for when a channel is restored.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsChannelRestoredEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsChannelRestored', async (context, next) => {
@@ -555,8 +593,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Override this in a derived class to provide logic for when a team is renamed.
      * @param handler 
+     * @returns A task that represents the work queued to execute.
      */
     public onTeamsTeamRenamedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsTeamRenamed', async (context, next) => {

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -368,6 +368,9 @@ export class TeamsActivityHandler extends ActivityHandler {
         
                     case 'channelRenamed':
                         return await this.onTeamsChannelRenamed(context);
+
+                    case 'channelRestored':
+                        return await this.onTeamsChannelRestored(context);
         
                     case 'teamRenamed':
                         return await this.onTeamsTeamRenamed(context);
@@ -469,6 +472,15 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
+     * Invoked when a Channel Restored event activity is received from the connector.
+     * Channel Restored correspond to the user restoring a previously deleted channel.
+     * @param context The context for this turn
+     */
+    protected async onTeamsChannelRestored(context): Promise<void> {
+        await this.handle(context, 'TeamsChannelRestored', this.defaultNextEvent(context));
+    }
+
+    /**
      * 
      * @param context 
      */
@@ -528,6 +540,17 @@ export class TeamsActivityHandler extends ActivityHandler {
         return this.on('TeamsChannelRenamed', async (context, next) => {
             const teamsChannelData = context.activity.channelData as TeamsChannelData;
             await handler(teamsChannelData.channel, teamsChannelData.team, context, next);
+        });
+    }
+    
+    /**
+     * Override this in a derived class to provide logic for when a channel is restored.
+     * @param handler 
+     */
+    public onTeamsChannelRestoredEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
+        return this.on('TeamsChannelRestored', async (context, next) => {
+            const teamsChannelData = context.activity.channelData as TeamsChannelData;
+            await handler(teamsChannelData.team, context, next);
         });
     }
 

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -836,6 +836,52 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                 });
         });
+
+        it('onTeamsChannelRestored routed activity', () => {
+            const bot = new TeamsActivityHandler();
+    
+            let onTeamsChannelRestoredEventCalled = false;
+    
+            const team = { id: 'team' };
+            const channel = { id: 'channel', name: 'channelName' };
+            const activity = createConvUpdateActivity({ channel, team, eventType: 'channelRestored' });
+
+            bot.onConversationUpdate(async (context, next) => {
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                onConversationUpdateCalled = true;
+                await next();
+            });
+
+            bot.onTeamsChannelRestoredEvent(async (channelInfo, teamInfo, context, next) => {
+                assert(channelInfo, 'channelInfo not found');
+                assert(teamInfo, 'teamsInfo not found');
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                assert.strictEqual(teamInfo, team);
+                assert.strictEqual(channelInfo, channel);
+                onTeamsChannelRestoredEventCalled = true;
+                await next();
+            });
+
+            bot.onDialog(async (context, next) => {
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                onDialogCalled = true;
+                await next();
+            });
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            adapter.send(activity)
+                .then(() => {
+                    assert(onTeamsChannelRestoredEventCalled, 'onTeamsChannelRestoredEvent handler not called');
+                    assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
+                    assert(onDialogCalled, 'onDialog handler not called');
+                });
+        });
         
         it('onTeamsTeamRenamed routed activity', () => {
             const bot = new TeamsActivityHandler();


### PR DESCRIPTION
Addresses # 2367

## Description
This PR adds the Teams' **Channel Restored** event in [teamsActivityHandler](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/teamsActivityHandler.ts) class.

## Specific Changes
  - Updated [teamsActivityHandler](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/teamsActivityHandler.ts) class to add the new _OnTeamsChannelRestoredEvent_ method.
  - Add unit test for the new method in [teamsActivityHandler.tests](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/tests/teamsActivityHandler.test.js) class.

## Testing
The following image shows the new event being handled by a test bot.
![image](https://user-images.githubusercontent.com/44245136/86260713-044e0f80-bb94-11ea-9067-cee8e2df5be3.png)


The next image shows the new test passing.
![image](https://user-images.githubusercontent.com/44245136/86260740-0adc8700-bb94-11ea-9544-110c3332edc1.png)
