### PR TITLE
[PORT] Fix WaterfallStepContext to use parent dc properly

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -246,17 +246,19 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
         let dialogState = {} as DialogState;
 
-        if(!!instance){
-            dialogState = instance.state[PERSISTED_DIALOG_STATE] || { dialogStack: [] };
-            instance.state[PERSISTED_DIALOG_STATE] = dialogState
+        if (!instance) {
+            instance = { state: {} } as DialogInstance;
         }
-        
+
+        dialogState = instance.state[PERSISTED_DIALOG_STATE] || { dialogStack: [] };
+        instance.state[PERSISTED_DIALOG_STATE] = dialogState
+
         let innerDC: DialogContext;
-        
-        if (context instanceof DialogContext) {
+
+        if(context instanceof DialogContext){
             innerDC = new DialogContext(this.dialogs, context, dialogState);
 
-        }else {
+        }else{
             innerDC = new DialogContext(this.dialogs, context, dialogState);
         }
 

--- a/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
@@ -59,9 +59,8 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
      * @param info Values to initialize the step context with.
      */
     constructor(dc: DialogContext, info: WaterfallStepInfo<O>) {
-        super(dc.dialogs, dc.context, { dialogStack: dc.stack });
+        super(dc.dialogs, dc, { dialogStack: dc.stack });
         this._info = info;
-        this.parent = dc.parent;
     }
 
     /**

--- a/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
@@ -1,5 +1,5 @@
 const { ActivityTypes, ConversationState, MemoryStorage, TestAdapter } = require('botbuilder-core');
-const { Dialog, DialogReason, DialogSet, DialogTurnStatus, WaterfallDialog } = require('../');
+const { Dialog, DialogReason, DialogSet, DialogTurnStatus, WaterfallDialog, ComponentDialog } = require('../');
 
 const assert = require('assert');
 
@@ -634,4 +634,61 @@ describe('WaterfallDialog', function () {
         }, DialogReason.cancelCalled);
         assert(trackEventCalled, 'trackEvent was never called.');
     });
+
+    it('should waterfall parent be equal to Component Dialog.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const waterfall = new WaterfallDialog('waterfall', [
+            step => ({ status: DialogTurnStatus.complete, result: step })
+        ]);
+
+        const component = new ComponentDialog('composite')
+        component.addDialog(waterfall)
+
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(component);
+
+        const adapter = new TestAdapter(async turnContext => {
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.beginDialog('composite');
+
+            if (results.status === DialogTurnStatus.complete) {
+                const waterfallParent = results.result.parent.parent;
+
+                assert.strictEqual(waterfallParent.dialogs.dialogs['composite'], component, 'WaterfallDialog "waterfall" parent should be equal to ComponentDialog "composite".');
+            }
+
+            done();
+        });
+
+        adapter.send('Hi');
+    });
+
+    it('should waterfall parent be equal to Dialog Context.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const waterfall = new WaterfallDialog('waterfall', [
+            step => ({ status: DialogTurnStatus.complete, result: step })
+        ]);
+
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(waterfall);
+
+        const adapter = new TestAdapter(async turnContext => {
+            const dc = await dialogs.createContext(turnContext);
+            const results = await dc.beginDialog('waterfall');
+
+            if (results.status === DialogTurnStatus.complete) {
+                assert.deepStrictEqual(results.result.parent, dc, 'waterfall parent should be equal to Dialog Context.');
+            }
+
+            done();
+        });
+
+        adapter.send('Hi');
+    });
+
 });


### PR DESCRIPTION
Fixes # 2162

> Port this change from botbuilder-dotnet/master branch:
> microsoft/botbuilder-dotnet# 3855

## Description
This PR fixes an issue that was causing the [WaterfallStepContext](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/waterfallStepContext.ts#L61) class to not assign the **DataContext** parent correctly.

## Specific Changes
- Update [createInnerDC](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/componentDialog.ts#L246) method to support [DialogContext](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/dialogContext.ts#L56) class as a parameter.
- Update [createChildContext](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/componentDialog.ts#L173) method to support the changes made in the [createInnerDC](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/componentDialog.ts#L246) method.
- Update [WaterfallStepContext](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/waterfallStepContext.ts#L61) class constructor to pass the parent correctly to the inherited class.
- Add unit test to support this changes, located in [waterfallDialog.test.js](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js#L32).

## Testing
In the following images are listed the new **unit tests** and the proper parent inheritance.
![image](https://user-images.githubusercontent.com/62260472/86495141-79fddb00-bd4e-11ea-84c5-db1161a5ebcd.png)
![image](https://user-images.githubusercontent.com/62260472/86495122-66527480-bd4e-11ea-977c-9cfa20f54e15.png)