### PR TITLE
[Teams] Fix broken TeamsActivityHandler tests

### DIFF
--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -153,7 +153,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
     // (undocumented)
     resumeDialog(outerDC: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
-    telemetryClient: BotTelemetryClient;
 }
 
 // @public
@@ -254,6 +253,7 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
     readonly dialogs: DialogSet;
     findDialog(dialogId: string): Dialog | undefined;
     protected getInternalVersion(): string;
+    telemetryClient: BotTelemetryClient;
 }
 
 // @public

--- a/libraries/botbuilder-dialogs/src/choices/channel.ts
+++ b/libraries/botbuilder-dialogs/src/choices/channel.ts
@@ -26,6 +26,7 @@ export function supportsSuggestedActions(channelId: string, buttonCnt: number = 
         case Channels.Emulator:
         case Channels.Directline:
         case Channels.Webchat:
+        case Channels.DirectlineSpeech:
             return (buttonCnt <= 100);
         default:
             return false;
@@ -48,6 +49,7 @@ export function supportsCardActions(channelId: string, buttonCnt: number = 100):
         case Channels.Slack:
         case Channels.Emulator:
         case Channels.Directline:
+        case Channels.DirectlineSpeech:
         case Channels.Webchat:
         case Channels.Cortana:
             return (buttonCnt <= 100);

--- a/libraries/botbuilder-dialogs/tests/choices_channel.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_channel.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { Channels } = require('botbuilder-core');
 const { supportsSuggestedActions, supportsCardActions, hasMessageFeed, getChannelId } = require('../lib');
 
 describe('channel methods', function() {
@@ -97,5 +98,16 @@ describe('channel methods', function() {
     it(`should return an empty string if context.activity.channelId is falsey.`, function () {
         const channel = getChannelId({ activity: { } });
         assert(channel === '', `expected "", instead received ${ channel }`);
+    });
+
+    // "directlinespeech" tests
+    it(`should return true for supportsSuggestedActions() with directlinespeech and 100`, function () {
+        const validNumOfSuggestedActions = supportsSuggestedActions(Channels.DirectlineSpeech, 100);
+        assert(validNumOfSuggestedActions, `returned false.`);
+    });
+
+    it(`should return true for supportsCardActions() with directlinespeech and 100`, () => {
+        const validNumOfCardActions = supportsCardActions(Channels.DirectlineSpeech, 100);
+        assert(validNumOfCardActions, `returned false.`);
     });
 });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -22,12 +22,12 @@ describe('TeamsActivityHandler', () => {
                     return { status: 418 };
                 }
             }
-    
+
             const bot = new InvokeHandler();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             adapter.send({ type: ActivityTypes.Invoke })
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
@@ -37,7 +37,7 @@ describe('TeamsActivityHandler', () => {
                     done();
                 })
                 .catch(err => done(err));
-    
+
         });
 
         it('should call onTurnActivity if non-Invoke is received', done => {
@@ -46,11 +46,11 @@ describe('TeamsActivityHandler', () => {
                 await context.sendActivity('Hello');
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             adapter.send({ type: ActivityTypes.Message, text: 'Hello' })
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, ActivityTypes.Message);
@@ -62,13 +62,13 @@ describe('TeamsActivityHandler', () => {
     });
 
     describe('should send a BadRequest status code if', () => {
-        it('a bad BotMessagePreview.action is received by the bot', async () => {
+        it('a bad BotMessagePreview.action is received by the bot', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'this.is.a.bad.action' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -76,16 +76,18 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 400, `incorrect status code "${ activity.value.status }", expected "400"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('a bad FileConsentCardResponse.action is received by the bot', async () => {
+        it('a bad FileConsentCardResponse.action is received by the bot', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'this.is.a.bad.action' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -93,18 +95,20 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 400, `incorrect status code "${ activity.value.status }", expected "400"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
     });
 
     describe('should send a NotImplemented status code if', () => {
-        it('handleTeamsMessagingExtensionSubmitAction is not overridden', async () => {
+        it('handleTeamsMessagingExtensionSubmitAction is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('composeExtension/submitAction');
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -112,16 +116,18 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsBotMessagePreviewEdit is not overridden', async () => {
+        it('onTeamsBotMessagePreviewEdit is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'edit' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -129,16 +135,18 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsBotMessagePreviewSend is not overridden', async () => {
+        it('onTeamsBotMessagePreviewSend is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'send' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -146,16 +154,18 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsFileConsentAccept is not overridden', async () => {
+        it('handleTeamsFileConsentAccept is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -163,103 +173,117 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsFileConsentDecline is not overridden', async () => {
+        it('handleTeamsFileConsentDecline is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsO365ConnectorCardAction is not overridden', async () => {
+        it('handleTeamsO365ConnectorCardAction is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const teamsO365ConnectorCardActionActivity = createInvokeActivity('actionableMessage/executeAction');
             adapter.send(teamsO365ConnectorCardActionActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsSigninVerifyState is not overridden', async () => {
+        it('handleTeamsSigninVerifyState is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const signinVerifyStateActivity = createInvokeActivity('signin/verifyState');
             adapter.send(signinVerifyStateActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', async () => {
+        it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const cardButtonClickedActivity = createInvokeActivity('composeExtension/onCardButtonClicked');
             adapter.send(cardButtonClickedActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsTaskModuleFetch is not overridden', async () => {
+        it('handleTeamsTaskModuleFetch is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const taskFetchActivity = createInvokeActivity('task/fetch');
             adapter.send(taskFetchActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsTaskModuleSubmit is not overridden', async () => {
+        it('handleTeamsTaskModuleSubmit is not overridden', done => {
             const bot = new TeamsActivityHandler();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const taskSubmitActivity = createInvokeActivity('task/submit');
             adapter.send(taskSubmitActivity)
                 .assertReply(activity => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
     });
 
@@ -276,13 +300,13 @@ describe('TeamsActivityHandler', () => {
             }
         }
 
-        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentAccept', async () => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentAccept', done => {
             const bot = new OKFileConsent();
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -290,10 +314,12 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 200, `incorrect status code "${activity.value.status}", expected "200"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(activity.value.body)}`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', async () => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', done => {
             const bot = new OKFileConsent();
 
             const adapter = new TestAdapter(async context => {
@@ -307,10 +333,12 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 200, `incorrect status code "${activity.value.status}", expected "200"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(activity.value.body)}`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', async () => {
+        it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', done => {
             class FileConsent extends TeamsActivityHandler {
                 async handleTeamsFileConsent(context, fileConsentCardResponse) {
                     assert(context, 'context not found');
@@ -330,7 +358,9 @@ describe('TeamsActivityHandler', () => {
                     assert(activity.value.status === 200, `incorrect status code "${activity.value.status}", expected "200"`);
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(activity.value.body)}`);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
 
@@ -397,8 +427,8 @@ describe('TeamsActivityHandler', () => {
     });
 
     describe('should send a BadRequest status code when', () => {
-        it('handleTeamsFileConsent() receives an unexpected action value', () => {
-            const bot = new TeamsActivityHandler();            
+        it('handleTeamsFileConsent() receives an unexpected action value', done => {
+            const bot = new TeamsActivityHandler();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
@@ -409,11 +439,13 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 400);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', () => {
-            const bot = new TeamsActivityHandler();            
+        it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', done => {
+            const bot = new TeamsActivityHandler();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
@@ -424,7 +456,9 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 400);
                     assert.strictEqual(activity.value.body, undefined);
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
     });
 
@@ -453,7 +487,7 @@ describe('TeamsActivityHandler', () => {
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
                 assert(fileConsentCalled, 'handleTeamsFileConsent handler was not called before handleTeamsFileConsentDecline handler');
                 fileConsentDeclineCalled = true;
-            }            
+            }
         }
 
         beforeEach(() => {
@@ -468,12 +502,12 @@ describe('TeamsActivityHandler', () => {
             fileConsentCalled = false;
         });
 
-        it('handleTeamsFileConsent handler before an handleTeamsFileConsentAccept handler', async () => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentAccept handler', done => {
             const bot = new FileConsentBot();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -484,15 +518,17 @@ describe('TeamsActivityHandler', () => {
                 }).then(() => {
                     assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
                     assert(fileConsentAcceptCalled, 'handleTeamsFileConsentAccept handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', async () => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', done => {
             const bot = new FileConsentBot();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
@@ -503,8 +539,9 @@ describe('TeamsActivityHandler', () => {
                 }).then(() => {
                     assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
                     assert(fileConsentDeclineCalled, 'handleTeamsFileConsentDecline handler not called');
-    
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
     });
 
@@ -541,7 +578,7 @@ describe('TeamsActivityHandler', () => {
             onDialogCalled = true;
         });
 
-        it('onTeamsMembersAdded routed activity', () => {
+        it('onTeamsMembersAdded routed activity', done => {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalledCount = 0;
@@ -575,11 +612,11 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const wasGetMember = TeamsInfo.getMember;
             TeamsInfo.getMember = function(context, userId) {
                 getMemberCalledCount ++;
@@ -593,10 +630,12 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalledCount === 2, 'TeamsInfo.getMember not called twice');
                     TeamsInfo.getMember = wasGetMember;
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsMembersAdded for bot routed activity does NOT call TeamsInfo.getMember', () => {
+        it('onTeamsMembersAdded for bot routed activity does NOT call TeamsInfo.getMember', done => {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalled = false;
@@ -606,7 +645,7 @@ describe('TeamsActivityHandler', () => {
             const activity = createConvUpdateActivity({ team, eventType: 'teamMemberAdded' });
             activity.membersAdded = membersAddedMock;
             activity.recipient = { id: membersAddedMock[0].id };
-            
+
             bot.onConversationUpdate(async (context, next) => {
                 assert(context, 'context not found');
                 assert(next, 'next not found');
@@ -631,11 +670,11 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             const wasGetMember = TeamsInfo.getMember;
             TeamsInfo.getMember = function(context, userId) {
                 getMemberCalled = true;
@@ -649,14 +688,16 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalled === false, 'TeamsInfo.getMember was called, but should not have been');
                     TeamsInfo.getMember = wasGetMember;
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsMembersRemoved routed activity', () => {
+        it('onTeamsMembersRemoved routed activity', done => {
             const bot = new TeamsActivityHandler();
-    
+
             let onTeamsMemberAddedEvent = false;
-    
+
             const membersRemovedMock = [{ id: 'test'} , { id: 'id' }];
             const team = { id: 'team' };
             const activity = createConvUpdateActivity({ team, eventType: 'teamMemberRemoved' });
@@ -686,24 +727,26 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
                     assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsChannelCreated routed activity', () => {
+        it('onTeamsChannelCreated routed activity', done => {
             const bot = new TeamsActivityHandler();
-    
+
             let onTeamsChannelCreatedEventCalled = false;
-    
+
             const team = { id: 'team' };
             const channel = { id: 'channel', name: 'channelName' };
             const activity = createConvUpdateActivity({ channel, team, eventType: 'channelCreated' });
@@ -732,24 +775,26 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsChannelCreatedEventCalled, 'onTeamsChannelCreated handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('onTeamsChannelDeleted routed activity', () => {
+        it('onTeamsChannelDeleted routed activity', done => {
             const bot = new TeamsActivityHandler();
-    
+
             let onTeamsChannelDeletedEventCalled = false;
-    
+
             const team = { id: 'team' };
             const channel = { id: 'channel', name: 'channelName' };
             const activity = createConvUpdateActivity({ channel, team, eventType: 'channelDeleted' });
@@ -778,24 +823,26 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
+
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsChannelDeletedEventCalled, 'onTeamsChannelDeletedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
-        
-        it('onTeamsChannelRenamed routed activity', () => {
+
+        it('onTeamsChannelRenamed routed activity', done => {
             const bot = new TeamsActivityHandler();
-    
+
             let onTeamsChannelRenamedEventCalled = false;
-    
+
             const team = { id: 'team' };
             const channel = { id: 'channel', name: 'channelName' };
             const activity = createConvUpdateActivity({ channel, team, eventType: 'channelRenamed' });
@@ -824,20 +871,22 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
+
             const adapter = new TestAdapter(async context => {
-                await bot.run(context);
+                await bot.run(context)
             });
-    
+
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsChannelRenamedEventCalled, 'onTeamsChannelRenamedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
-        
-        it('onTeamsTeamRenamed routed activity', () => {
+
+        it('onTeamsTeamRenamed routed activity', done => {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamRenamedEventCalled = false;
@@ -877,17 +926,19 @@ describe('TeamsActivityHandler', () => {
                     assert(onTeamsTeamRenamedEventCalled, 'onTeamsTeamRenamedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                });
+                    done();
+                })
+                .catch(err => done(err));
         });
 
-        it('signin/verifyState routed activity', async () => {
+        it('signin/verifyState routed activity', done => {
             onDialogCalled = false;
             handleTeamsSigninVerifyStateCalled = false;
 
             class InvokeHandler extends TeamsActivityHandler {
                 constructor() {
                     super();
-                    
+
                     this.onDialog(async (context, next) => {
                         assert(context, 'context not found');
                         onDialogCalled = true;
@@ -895,23 +946,28 @@ describe('TeamsActivityHandler', () => {
                     });
                 }
 
-                async handleTeamsSigninVerifyState(context) {
+                handleTeamsSigninVerifyState(context) {
                     assert(context, 'context not found');
                     handleTeamsSigninVerifyStateCalled = true;
                 }
             }
-    
+
             const bot = new InvokeHandler();
+
             const team = { id: 'team' };
             const activity = createSignInVerifyState({ team, channelId: 'msteams' });
-            
+
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
             });
-    
-            await adapter.send(activity);
-            assert(onDialogCalled, 'onDialog handler not called'); 
-            assert(handleTeamsSigninVerifyStateCalled, 'handleTeamsSigninVerifyState handler not called'); 
+
+            adapter.send(activity)
+                .then(() => {
+                    assert(onDialogCalled, 'onDialog handler not called');
+                    assert(handleTeamsSigninVerifyStateCalled, 'handleTeamsSigninVerifyState handler not called');
+                    done();
+                })
+                .catch(err => done(err));
         });
     });
 });


### PR DESCRIPTION
Fixes # 1393

## Description
This PR adds catching errors to the [TeamsActivityHandler tests](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/tests/teamsActivityHandler.test.js), so they can fail properly when an error occurs.

## Specific Changes
- Adds missing catching errors for every test in the [teamsActivityHandler.test.js](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/tests/teamsActivityHandler.test.js) file.
- Repaced the `async` keyword with a `done` callback for each `it` function test.

## Testing
In the image below shows the test list that were passing before and after this changes.
![imagen](https://user-images.githubusercontent.com/62260472/86628420-3e5a4f80-bfa0-11ea-8a91-26870d1a5a0d.png)