### PR TITLE
Increase code coverage in botbuilder library - StatusCodeError class

### DIFF
--- a/libraries/botbuilder/tests/statusCodeError.test.js
+++ b/libraries/botbuilder/tests/statusCodeError.test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const assert = require('assert');
+const { StatusCodeError } = require('../');
+const { StatusCodes } = require('botbuilder-core');
+
+describe(`StatusCodeError`, function() {
+    it(`should work with a message.`, done => {
+        try {
+            const message = 'This is an error message';
+            const error = new StatusCodeError(StatusCodes.NOT_FOUND, message);
+
+            assert.strictEqual(error.message, message, `message should be equal to "${message}".`)
+            assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
+
+    it(`should work without a message.`, done => {
+        try {
+            const error = new StatusCodeError(StatusCodes.NOT_FOUND);
+
+            assert.strictEqual(error.message, '', 'message should be empty.')
+            assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
+
+    it(`should statusCode be undefined if not passed as a parameter.`, done => {
+        try {
+            const error = new StatusCodeError();
+
+            assert.strictEqual(error.statusCode, undefined, 'statusCode should be undefined.')
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
+});

--- a/libraries/botbuilder/tests/statusCodeError.test.js
+++ b/libraries/botbuilder/tests/statusCodeError.test.js
@@ -8,39 +8,41 @@ const { StatusCodeError } = require('../');
 const { StatusCodes } = require('botbuilder-core');
 
 describe(`StatusCodeError`, function() {
-    it(`should work with a message.`, done => {
-        try {
-            const message = 'This is an error message';
-            const error = new StatusCodeError(StatusCodes.NOT_FOUND, message);
+    describe('constructor()', () => {
+        it(`should work with a message.`, done => {
+            try {
+                const message = 'This is an error message';
+                const error = new StatusCodeError(StatusCodes.NOT_FOUND, message);
 
-            assert.strictEqual(error.message, message, `message should be equal to "${message}".`)
-            assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
-            done();
-        } catch (error) {
-            done(error);
-        }
-    });
+                assert.strictEqual(error.message, message, `message should be equal to "${message}".`)
+                assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
 
-    it(`should work without a message.`, done => {
-        try {
-            const error = new StatusCodeError(StatusCodes.NOT_FOUND);
+        it(`should work without a message.`, done => {
+            try {
+                const error = new StatusCodeError(StatusCodes.NOT_FOUND);
 
-            assert.strictEqual(error.message, '', 'message should be empty.')
-            assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
-            done();
-        } catch (error) {
-            done(error);
-        }
-    });
+                assert.strictEqual(error.message, '', 'message should be empty.')
+                assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
 
-    it(`should statusCode be undefined if not passed as a parameter.`, done => {
-        try {
-            const error = new StatusCodeError();
+        it(`should statusCode be undefined if not passed as a parameter.`, done => {
+            try {
+                const error = new StatusCodeError();
 
-            assert.strictEqual(error.statusCode, undefined, 'statusCode should be undefined.')
-            done();
-        } catch (error) {
-            done(error);
-        }
+                assert.strictEqual(error.statusCode, undefined, 'statusCode should be undefined.')
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
     });
 });


### PR DESCRIPTION
Addresses # 2432

## Description
This PR adds unit tests for the [StatusCodeError](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/statusCodeError.ts) class increasing the code [coverage](https://coveralls.io/builds/31822744/source?filename=libraries/botbuilder/src/statusCodeError.ts) from **33%** to **100%**.

## Specific Changes
- Added **statusCodeError.test.js** file with unit tests for the constructor.

## Testing
The following images show the new tests passing.
![imagen](https://user-images.githubusercontent.com/62260472/86800164-1d016e00-c049-11ea-89a6-81e766fc5eb9.png)