### PR TITLE
[Streaming, Engineering] Add integration tests for ChannelServiceRoutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ libraries/functional-tests/**/*.vscode/launch.json
 
 # @microsoft/api-extractor
 libraries/*/temp
-libraries/*/dist 
+libraries/*/dist
 
 # User-specific files
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -320,3 +320,6 @@ package-lock.json
 
 consumer-test/**.js
 consumer-test/**.json
+
+# Transpiled botbuilder integration tests
+libraries/**/transpiled-tests/

--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -53,8 +53,9 @@ steps:
   enabled: false
 
 - bash: |
-   sed -i '' 's/${Version}/$(version)/g' package.json 
+   sed -i '' 's/${Version}/$(version)/g' package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/adaptive-expressions/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/bot-integration-tests/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-ai/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-applicationinsights/package.json

--- a/build/yaml/js-build-steps.yml
+++ b/build/yaml/js-build-steps.yml
@@ -35,8 +35,9 @@ steps:
 
 - bash: |
     set -o xtrace
-    sed -i '' 's/${Version}/$(version)/g' package.json 
+    sed -i '' 's/${Version}/$(version)/g' package.json
     sed -i '' 's/${Version}/$(version)/g' libraries/adaptive-expressions/package.json
+    sed -i '' 's/${Version}/$(version)/g' libraries/bot-integration-tests/package.json
     sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder/package.json
     sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-ai/package.json
     sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-applicationinsights/package.json

--- a/lerna.json
+++ b/lerna.json
@@ -21,6 +21,7 @@
     "libraries/functional-tests/dialogToDialog/dialogSkillBot",
     "libraries/testbot",
     "libraries/botframework-streaming",
+    "libraries/bot-integration-tests",
     "libraries/testskills/skillparent",
     "libraries/testskills/skillchild",
     "transcripts"

--- a/libraries/bot-integration-tests/package.json
+++ b/libraries/bot-integration-tests/package.json
@@ -10,12 +10,14 @@
   },
   "author": "Microsoft Corp.",
   "license": "MIT",
+  "dependencies": {
+    "botbuilder": "4.1.6",
+    "botframework-connector": "4.1.6"
+  },
   "devDependencies": {
     "@types/express": "^4.17.7",
     "@types/mocha": "^5.2.7",
     "@types/restify": "^8.4.2",
-    "botbuilder": "4.1.6",
-    "botframework-connector": "4.1.6",
     "express": "^4.17.1",
     "mocha": "^6.2.3",
     "nyc": "^15.1.0",

--- a/libraries/bot-integration-tests/package.json
+++ b/libraries/bot-integration-tests/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bot-integration-tests",
+  "version": "4.1.6",
+  "description": "Integration tests for botbuilder",
+  "scripts": {
+    "build": "tsc",
+    "just-test": "tsc && mocha \"./transpiled-tests/**/*.test.js\"",
+    "test": "tsc && nyc mocha \"./transpiled-tests/**/*.test.js\"",
+    "set-version": "npm version --allow-same-version ${Version}"
+  },
+  "author": "Microsoft Corp.",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/express": "^4.17.7",
+    "@types/mocha": "^5.2.7",
+    "@types/restify": "^8.4.2",
+    "botbuilder": "4.1.6",
+    "botframework-connector": "4.1.6",
+    "express": "^4.17.1",
+    "mocha": "^6.2.3",
+    "nyc": "^15.1.0",
+    "restify": "^8.5.1"
+  }
+}

--- a/libraries/bot-integration-tests/src/channelServiceRoutes.test.ts
+++ b/libraries/bot-integration-tests/src/channelServiceRoutes.test.ts
@@ -1,0 +1,80 @@
+import { strictEqual } from 'assert';
+
+import { createServer } from 'restify';
+import { ChannelServiceHandler, ChannelServiceRoutes } from 'botbuilder';
+import { AuthenticationConfiguration, SimpleCredentialProvider } from 'botframework-connector';
+import express from 'express';
+
+describe('ChannelServiceRoutes - Integration Tests', function () {
+    it('should successfully configure all routes on an Express Application', () => {
+        const app = express();
+        const handler = new ChannelServiceHandler(new SimpleCredentialProvider('', ''), new AuthenticationConfiguration());
+        const routes = new ChannelServiceRoutes(handler);
+
+        routes.register(app);
+
+        const bfRoutes = (app._router.stack as Array<any>).filter(layer => {
+            const route: express.IRoute = layer.route;
+            if (route) {
+                return route.path.startsWith('/v3/conversations');
+            }
+        });
+
+        strictEqual(bfRoutes.length, 12);
+    });
+
+    it('should successfully configure all routes on an Express Application with a provided basePath', () => {
+        const app = express();
+        const handler = new ChannelServiceHandler(new SimpleCredentialProvider('', ''), new AuthenticationConfiguration());
+        const routes = new ChannelServiceRoutes(handler);
+
+        routes.register(app, '/test');
+
+        const bfRoutes = (app._router.stack as Array<any>).filter(layer => {
+            const route: express.IRoute = layer.route;
+            if (route) {
+                return route.path.startsWith('/test/v3/conversations');
+            }
+        });
+
+        strictEqual(bfRoutes.length, 12);
+    });
+
+    it('should successfully configure all routes on a Restify Server', () => {
+        const server = createServer();
+        const handler = new ChannelServiceHandler(new SimpleCredentialProvider('', ''), new AuthenticationConfiguration());
+        const routes = new ChannelServiceRoutes(handler);
+
+        routes.register(server);
+
+        const info = server.getDebugInfo();
+        const registeredRoutes = info.routes;
+
+        const bfRoutes = registeredRoutes && registeredRoutes.filter(route => {
+            if (route.path) {
+                return route.path.startsWith('/v3/conversations');
+            }
+        });
+
+        strictEqual(bfRoutes.length, 12);
+    });
+
+    it('should successfully configure all routes on a Restify Server with a provided basePath', () => {
+        const server = createServer();
+        const handler = new ChannelServiceHandler(new SimpleCredentialProvider('', ''), new AuthenticationConfiguration());
+        const routes = new ChannelServiceRoutes(handler);
+
+        routes.register(server, '/test');
+
+        const info = server.getDebugInfo();
+        const registeredRoutes = info.routes;
+
+        const bfRoutes = registeredRoutes && registeredRoutes.filter(route => {
+            if (route.path) {
+                return route.path.startsWith('/test/v3/conversations');
+            }
+        });
+
+        strictEqual(bfRoutes.length, 12);
+    });
+});

--- a/libraries/bot-integration-tests/tsconfig.json
+++ b/libraries/bot-integration-tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "declaration": false,
+      "esModuleInterop": true,
+      "sourceMap": true,
+      "module": "commonjs",
+      "outDir": "./transpiled-tests",
+      "rootDir": "./src",
+      "target": "es6",
+      "lib": [ "es2015", "dom" ],
+      "types" : ["node", "mocha"]
+    },
+    "include": [
+      "src/**/*"
+    ]
+}

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -39,7 +39,7 @@ export class ChannelServiceRoutes {
     }
 
     /**
-     * Registers all WebServer 
+     * Registers all Channel Service paths on the provided WebServer.
      * @param server WebServer
      * @param basePath Optional basePath which is appended before the service's REST API is configured on the WebServer.
      */
@@ -55,8 +55,15 @@ export class ChannelServiceRoutes {
         server.post(basePath + '/v3/conversations/:conversationId/activities/history', this.processSendConversationHistory.bind(this));
         server.post(basePath + '/v3/conversations/:conversationId/attachments', this.processUploadAttachment.bind(this));
 
-        server.del(basePath + '/v3/conversations/:conversationId/members/:memberId', this.processDeleteConversationMember.bind(this));
-        server.del(basePath + '/v3/conversations/:conversationId/activities/:activityId', this.processDeleteActivity.bind(this));
+        // Express 4.x uses the delete() method to register handlers for the DELETE method.
+        // Restify 8.x uses the del() method.
+        if (typeof(server.delete) === 'function') {
+            server.delete(basePath + '/v3/conversations/:conversationId/members/:memberId', this.processDeleteConversationMember.bind(this));
+            server.delete(basePath + '/v3/conversations/:conversationId/activities/:activityId', this.processDeleteActivity.bind(this));
+        } else if (typeof(server.del) === 'function') {
+            server.del(basePath + '/v3/conversations/:conversationId/members/:memberId', this.processDeleteConversationMember.bind(this));
+            server.del(basePath + '/v3/conversations/:conversationId/activities/:activityId', this.processDeleteActivity.bind(this));
+        }
     }
 
     private processSendToConversation(req: WebRequest, res: WebResponse): void {

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "clean": "lerna run clean",
     "functional-test": "lerna run build && nyc mocha \"libraries/functional-tests/tests/*.test.js\"",
     "browser-functional-test": "cd libraries/browser-functional-tests && node nightwatch.js -e",
-    "test": "lerna run build && nyc mocha \"libraries/@(adaptive*|bot*)/tests/**/*.test.js\"",
+    "test": "lerna run build && nyc mocha \"libraries/@(adaptive*|bot*)/*tests/**/*.test.js\"",
     "test:compat": "lerna run test:compat",
     "test:consumer": "node ./run-consumer-test.js",
-    "test:coveralls": "lerna run build && nyc mocha \"libraries/@(adaptive*|bot*)/tests/**/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
-    "test-coverage": "nyc mocha \"libraries/@(adaptive*|bot*)/tests/**/*.test.js\"",
+    "test:coveralls": "lerna run build && nyc mocha \"libraries/@(adaptive*|bot*)/*tests/**/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
+    "test-coverage": "nyc mocha \"libraries/@(adaptive*|bot*)/*tests/**/*.test.js\"",
     "upload-coverage": "nyc report --reporter=text-lcov | coveralls",
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} ${PreviewPackageVersion} adaptive-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-dialogs-adaptive botbuilder-dialogs-declarative botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} ${PreviewPackageVersion} adaptive-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-dialogs-adaptive botbuilder-dialogs-declarative botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot bot-integration-tests && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {
@@ -44,6 +44,7 @@
     "exclude": [
       "**/botframework*/**/generated/**",
       "**/botbuilder*/**/generated/**",
+      "**/bot-integration-tests/**",
       "**/adaptive-expressions/**/generated/**",
       "**/botframework-luis/**",
       "**/tests/**",

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^10.17.27",
-    "@types/restify": "^7.2.1",
+    "@types/restify": "^8.4.2",
     "botbuilder": "4.1.6",
     "botbuilder-ai": "4.1.6",
     "botbuilder-dialogs": "4.1.6"


### PR DESCRIPTION
Fixes # 1727

## Description
This PR Fixes a bug using `del()` method that has been _deprecated_ in **Express 4.x.** and adds integration tests for [ChannelServiceRoutes](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/channelServiceRoutes.ts#L33) into the new `bot-integration-tests` folder.

More information can be found in the PR # 1492.

## Specific Changes
- Fix bug in [ChannelServiceRoutes](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/channelServiceRoutes.ts#L33) only using `del()` to register paths for DELETE methods.
- Add TypeScript Integration tests for `botbuilder` with **restify** and **express.**


## Testing
In the following images there is a sneak peek for `bot-integration-tests`.
![image](https://user-images.githubusercontent.com/62260472/88402330-5a802e00-cda1-11ea-8617-5631089869d5.png)