### PR TITLE
[Engineering] Lower time for botbuilder tests

### DIFF
--- a/libraries/botbuilder/tests/inspectionMiddleware.test.js
+++ b/libraries/botbuilder/tests/inspectionMiddleware.test.js
@@ -22,6 +22,11 @@ afterEach(function(done) {
 });
 
 describe('InspectionMiddleware', function() {
+    const storage = new MemoryStorage();
+    const inspectionState = new InspectionState(storage);
+    const userState = new UserState(storage);
+    const conversationState = new ConversationState(storage);
+
     it('should not change behavior when inspection middleware is added', async function() {
 
         var inspectionState = new InspectionState(new MemoryStorage());
@@ -313,15 +318,9 @@ describe('InspectionMiddleware', function() {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
-
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
-
         const openActivity = MessageFactory.text('/INSPECT open');
 
         const inspectionAdapter = new TestAdapter(async (turnContext) => {
@@ -376,11 +375,6 @@ describe('InspectionMiddleware', function() {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
-
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
@@ -438,15 +432,9 @@ describe('InspectionMiddleware', function() {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
-
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
-
         const openActivity = MessageFactory.text('/INSPECT open');
 
         const inspectionAdapter = new TestAdapter(async (turnContext) => {
@@ -475,10 +463,6 @@ describe('InspectionMiddleware', function() {
     });
 
     it('should invokeInbound throw an error', async () => {
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -493,10 +477,6 @@ describe('InspectionMiddleware', function() {
     });
 
     it('should invokeOutbound throw an error', async () => {
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -511,10 +491,6 @@ describe('InspectionMiddleware', function() {
     });
 
     it('should invokeTraceState throw an error', async () => {
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -529,10 +505,6 @@ describe('InspectionMiddleware', function() {
     });
 
     it('should attachCommand return false', async () => {
-        const storage = new MemoryStorage();
-        const inspectionState = new InspectionState(storage);
-        const userState = new UserState(storage);
-        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         const result = await inspectionMiddleware.attachCommand('', { openedSessions: { 'session-1': undefined } }, 'session-1');

--- a/libraries/botbuilder/tests/skills/skillHandler.test.js
+++ b/libraries/botbuilder/tests/skills/skillHandler.test.js
@@ -11,17 +11,19 @@ const { ConversationIdFactory } = require('./conversationIdFactory');
 
 describe('SkillHandler', function() {
     this.timeout(3000);
+    const adapter = new BotFrameworkAdapter({});
+    const bot = new ActivityHandler();
+    const factory = new ConversationIdFactory();
+    factory.disableCreateWithOptions = true;
+    factory.disableGetSkillConversationReference = true;
+    const creds = new SimpleCredentialProvider('', '');
+    const authConfig = new AuthenticationConfiguration();
+
     it('should fail construction without required adapter', () => {
         try {
             const handler = new SkillHandler(undefined, {}, {}, {}, {});
         } catch (e) {
             strictEqual(e.message, 'missing adapter.');
-        }
-
-        try {
-            const handler = new SkillHandler({}, undefined, {}, {}, {});
-        } catch (e) {
-            strictEqual(e.message, 'missing conversationIdFactory.');
         }
     });
 
@@ -34,19 +36,10 @@ describe('SkillHandler', function() {
     });
 
     it('should successfully construct', () => {
-        const adapter = new BotFrameworkAdapter({});
-        const bot = new ActivityHandler();
-        const creds = new SimpleCredentialProvider('', '');
-        const authConfig = new AuthenticationConfiguration();
-
-        const handler = new SkillHandler(adapter, bot, new ConversationIdFactory(), creds, authConfig);
+        const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
     });
 
     it('should call processActivity() from onReplyToActivity()', async () => {
-        const adapter = new BotFrameworkAdapter({});
-        const bot = new ActivityHandler();
-        const creds = new SimpleCredentialProvider('', '');
-        const authConfig = new AuthenticationConfiguration();
         const identity = new ClaimsIdentity([]);
         const convId = 'convId';
         const actualReplyToId = '1';
@@ -66,10 +59,6 @@ describe('SkillHandler', function() {
     });
 
     it('should call processActivity() from onSendToConversation()', async () => {
-        const adapter = new BotFrameworkAdapter({});
-        const bot = new ActivityHandler();
-        const creds = new SimpleCredentialProvider('', '');
-        const authConfig = new AuthenticationConfiguration();
         const identity = new ClaimsIdentity([]);
         const convId = 'convId';
         const skillActivity = { type: ActivityTypes.Message };
@@ -88,16 +77,10 @@ describe('SkillHandler', function() {
     });
 
     describe('private methods', () => {
+        const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
+
         describe('processActivity()', () => {
             it('should fail without a conversationReference', async () => {
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 try {
                     await handler.processActivity({}, 'convId', 'replyId', {});
                 } catch (e) {
@@ -107,14 +90,6 @@ describe('SkillHandler', function() {
 
             /* This test should be the first successful test to pass using the built-in logic for SkillHandler.processActivity() */
             it(`should add the original activity's ServiceUrl to the TrustedServiceUrls in AppCredentials`, async () => {
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 factory.refs['convId'] = { serviceUrl, conversation: { id: 'conversationId' } };
                 const skillActivity = {
@@ -131,14 +106,6 @@ describe('SkillHandler', function() {
 
             const identity =  new ClaimsIdentity([{ type: 'aud', value: 'audience' }]);
             it('should cache the ClaimsIdentity, ConnectorClient and SkillConversationReference on the turnState', async () => {
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 factory.refs['convId'] = { serviceUrl, conversation: { id: 'conversationId' } };
                 const skillActivity = {
@@ -157,14 +124,6 @@ describe('SkillHandler', function() {
             });
 
             it('should call bot logic for Event activities from a skill and modify context.activity', async () => {
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 const name = 'eventName';
                 const relatesTo = { activityId: 'activityId' };
@@ -203,14 +162,6 @@ describe('SkillHandler', function() {
                 const skillConsumerAppId = '00000000-0000-0000-0000-000000000001';
                 const skillAppId = '00000000-0000-0000-0000-000000000000';
 
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 const text = 'bye';
                 const replyToId = 'replyToId';
@@ -253,14 +204,6 @@ describe('SkillHandler', function() {
             });
 
             it('should forward activity from Skill for other ActivityTypes', async () => {
-                const adapter = new BotFrameworkAdapter({});
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
-                const creds = new SimpleCredentialProvider('', '');
-                const authConfig = new AuthenticationConfiguration();
-                const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 factory.refs['convId'] = { serviceUrl, conversation: { id: 'conversationId' } };
                 const text = 'Test';
@@ -288,7 +231,7 @@ describe('SkillHandler', function() {
             it(`should use the skill's appId to set the callback's activity.callerId`, async () => {
                 const skillAppId = '00000000-0000-0000-0000-000000000000';
                 const skillConsumerAppId = '00000000-0000-0000-0000-000000000001';
-                
+
                 const adapter = new BotFrameworkAdapter({});
                 adapter.credentialsProvider.isAuthenticationDisabled = async () => false;
                 const identity = new ClaimsIdentity([
@@ -296,12 +239,7 @@ describe('SkillHandler', function() {
                     { type: AuthenticationConstants.AppIdClaim, value: skillAppId },
                     { type: AuthenticationConstants.VersionClaim, value: '1.0' },
                 ], true);
-                const bot = new ActivityHandler();
-                const factory = new ConversationIdFactory();
-                factory.disableCreateWithOptions = true;
-                factory.disableGetSkillConversationReference = true;
                 const creds = new SimpleCredentialProvider(skillConsumerAppId, '');
-                const authConfig = new AuthenticationConfiguration();
                 const handler = new SkillHandler(adapter, bot, factory, creds, authConfig);
                 const serviceUrl = 'http://localhost/api/messages';
                 factory.refs['convId'] = { serviceUrl, conversation: { id: 'conversationId' } };


### PR DESCRIPTION
Address # 2338

## Description
Removed duplicated tests for missing `conversationIdFactory` in `skillHandler` tests and moved variables to be reused in `skillHandler` and `inspectionMiddleware` tests.

## Specific Changes
Changes in `skillHandler.tests.js`
- Removed validation for error when creating a `SkillHandler` without a `conversationIdFactory` because that's already tested in another it.
- Moved the variables `adapter`, `bot`, `factory`, `creds` and `authConfig` to the top of the describe to be reused by all the tests instead of creating new ones without modification for each one.

Changes in `inspectionMiddleware.tests.js`
- Moved variables `storage`, `inspectionState`, `userState` and `conversationState` to the top of the describe to be reused in all the tests instead of creating new ones without modification for each one.

## Testing
The time is decreased by 1 second and the code coverage remains the same.
![image](https://user-images.githubusercontent.com/38112957/88586952-94646500-d02b-11ea-9ceb-35ec660864f1.png)
![image](https://user-images.githubusercontent.com/38112957/88587306-21a7b980-d02c-11ea-9d3f-3600869156c7.png)