### PR TITLE
[Engineering] Lower time for adaptive-expressions tests

### DIFF
--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const {ExpressionParser} = require('../');
+const { ExpressionParser } = require('../');
 const assert = require('assert');
 
 const invalidExpressions = [
@@ -459,36 +459,44 @@ const scope = {
 
 describe('expression functional test', () => {
     it('should get exception results for bad expressions', () => {
+        const errors = [];
+
         for (const expression of badExpressions) {
             let isFail = false;
             const input = expression;
             try {
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                var {value: actual, error} = new ExpressionParser().parse(input).tryEvaluate(scope);
+                var { value: actual, error } = new ExpressionParser().parse(input).tryEvaluate(scope);
                 if (error === undefined) {
                     isFail = true;
                 } else {
-                    console.log(error);
+                    errors.push(error);
                 }
             } catch (e) {
-                console.log(e.message);
+                errors.push(e.message);
             }
 
             if (isFail) {
                 assert.fail(`Test method ${input} did not throw expected exception`);
             }
         }
+
+        console.log(errors.join('\n'));
     });
 
     it('should get exception results for invalid expressions', () => {
+        const errors = [];
+
         for (const expression of invalidExpressions) {
             const input = expression;
             try {
                 new ExpressionParser().parse(input);
                 assert.fail(`Test expression ${input} did not throw expected exception`);
             } catch (e) {
-                console.log(e.message);
+                errors.push(e.message);
             }
         }
+
+        console.log(errors.join('\n'));
     });
 });

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -835,9 +835,12 @@ const scope = {
 
 describe('expression parser functional test', () => {
     it('should get right evaluate result', () => {
+        const inputs = [];
+
         for (const data of dataSource) {
             const input = data[0].toString();
-            console.log(input);
+            inputs.push(input);
+
             var parsed = Expression.parse(input);
             assert(parsed !== undefined);
             var {value: actual, error} = parsed.tryEvaluate(scope);
@@ -864,6 +867,8 @@ describe('expression parser functional test', () => {
             const newActual = newExpr.tryEvaluate(scope).value;
             assertObjectEquals(actual, newActual);
         }
+
+        console.log(inputs.join('\n'));
     }).timeout(5000);
 
     it('Test AccumulatePath', () => {


### PR DESCRIPTION
Addresses # 2338

## Description
This PR optimizes the time for the adaptive-expressions tests having no impact in the code coverage numbers and reducing the execution time approximately from **3s** to **1s**.

## Specific Changes
- Moved `console.log` outside the `for of` loop, so it's printed in the console once.

## Testing
![image](https://user-images.githubusercontent.com/62260472/88594175-232aaf00-d037-11ea-938b-4bf9a0921642.png)