### PR TITLE
[Engineering] Lower time for botbuilder-azure tests

### DIFF
--- a/libraries/botbuilder-azure/tests/blobStorage.test.js
+++ b/libraries/botbuilder-azure/tests/blobStorage.test.js
@@ -32,7 +32,7 @@ const reset = (done) => {
 
 const checkEmulator = () => {
     if (!fs.existsSync(emulatorPath)) {
-        console.warn('This test requires Azure Storage Emulator! go to https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator#get-the-storage-emulator to download and install.');
+        console.warn('These tests require Azure Storage Emulator! go to https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator#get-the-storage-emulator to download and install.');
     }
     return true;
 };
@@ -54,23 +54,19 @@ describe('BlobStorage - Constructor', function() {
 
 describe('BlobStorage - Base Storage Tests', function() {
     before('cleanup', reset);
+    before('check emulator', checkEmulator);
     after('cleanup', reset);
 
     it('return empty object when reading unknown key', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
         
         assert.strictEqual(testRan, true);
-
         return nockDone();
     });
 
     it('throws when reading null keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
@@ -78,9 +74,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('throws when writing null keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
         
         assert.strictEqual(testRan, true);
@@ -88,9 +82,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('does not throw when writing no items', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
         
         assert.strictEqual(testRan, true);
@@ -98,9 +90,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('create an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -108,9 +98,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('handle crazy keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
@@ -118,9 +106,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('update an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -128,9 +114,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('delete an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -138,9 +122,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('does not throw when deleting an unknown object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -148,9 +130,7 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('performs batch operations', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
@@ -158,13 +138,10 @@ describe('BlobStorage - Base Storage Tests', function() {
     });
 
     it('proceeds through a waterfall dialog', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode);
-
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
         return nockDone();
     });
 });
-

--- a/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
@@ -24,7 +24,7 @@ const getSettings = (partitionKey=undefined) => ({
 
 const checkEmulator = () => {
     if (!fs.existsSync(emulatorPath)) {
-        console.warn('This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.');
+        console.warn('These tests require CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.');
     }
     return true;
 };
@@ -198,23 +198,19 @@ describe('CosmosDbStorage - Constructor Tests', function() {
 
 describe('CosmosDbStorage - Base Storage Tests', function() {
     before('cleanup', reset);
+    before('check emulator', checkEmulator);
     after('cleanup', reset);
 
     it('return empty object when reading unknown key', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
         
         assert.strictEqual(testRan, true);
-
         return nockDone();
     });
 
     it('throws when reading null keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
@@ -222,9 +218,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('throws when writing null keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
         
         assert.strictEqual(testRan, true);
@@ -232,9 +226,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('does not throw when writing no items', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
         
         assert.strictEqual(testRan, true);
@@ -242,9 +234,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('create an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -252,9 +242,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('handle crazy keys', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
@@ -262,9 +250,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('update an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -272,9 +258,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('delete an object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -282,9 +266,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('does not throw when deleting an unknown object', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
@@ -292,9 +274,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('performs batch operations', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
@@ -302,9 +282,7 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
     });
 
     it('proceeds through a waterfall dialog', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
-
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
@@ -322,10 +300,10 @@ describe('CosmosDbStorage - Base Storage Tests', function() {
 // PartitionKeys are deprecated. Tests are here to ensure backwards compatibility of changes
 describe('CosmosDbStorage - PartitionKey Tests', function() {
     before('cleanup', reset);
+    before('check emulator', checkEmulator);
     after('cleanup', reset);
 
     it('create and read an object with partitionKey', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
 
         await storage.write(changes);
@@ -336,7 +314,6 @@ describe('CosmosDbStorage - PartitionKey Tests', function() {
     });
 
     it('update an object with partitionKey', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
 
         await storage.write({ keyUpdate: { count: 1 }, Location: partitionKey });
@@ -355,7 +332,6 @@ describe('CosmosDbStorage - PartitionKey Tests', function() {
     });
 
     it('delete an object with partitionKey', async function() {
-        checkEmulator();
         const { nockDone } = await usingNock(this.test, mode, options);
 
         await storage.write(changes);


### PR DESCRIPTION
Addresses # 2338
## Description
Updates the warnings raised in some tests of the **BotBuilder-Azure** library to be shown once for the describe instead of each test inside it.

## Specific Changes
Update the tests in the files `blobStorage.test.js` and `cosmosDbStorage.test.js` to run the emulator check once in the describes to raise a warning instead of running it in each test of the describe. This change reduces the time for the tests a little bit and makes the test report more readable.

We also updated some eslint warnings in these files.
## Testing
Here you can compare the times for each test running when moving the warning to be shown once for the describe and how it is more readable in the report.
![image](https://user-images.githubusercontent.com/38112957/88810723-1cfa1700-d18c-11ea-9706-4f603d63f25e.png)
![image](https://user-images.githubusercontent.com/38112957/88810776-2e432380-d18c-11ea-9bdd-5b293f5afb26.png)
![image](https://user-images.githubusercontent.com/38112957/88810815-38652200-d18c-11ea-9e7b-15f72dd57efc.png)

**Note:** the times vary in each run, but in general there is a slight reduction in the times.
