### PR TITLE
[Engineering] Lower time for botbuilder-dialogs-adaptive tests

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
@@ -20,7 +20,6 @@ describe('ActivityFactoryTest', function() {
     it('inlineActivityFactory', function() {
         let result = ActivityFactory.fromObject('text');
         assert(result.text === 'text');
-        assert(result.text === 'text');
         assert(result.speak === 'text');
         assert(result.inputHint === undefined);
 
@@ -594,7 +593,6 @@ function assertAnimationCardActivity(activity) {
     assert.strictEqual(card.title, 'Animation Card');
     assert.strictEqual(card.subtitle, 'look at it animate');
     assert.strictEqual(card.autostart, true);
-    assert.strictEqual(card.autostart, true);
     assert.strictEqual(card.image.url, 'https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png');
     assert.strictEqual(card.media[0].url, 'http://oi42.tinypic.com/1rchlx.jpg');
 }
@@ -635,6 +633,4 @@ function assertReceiptCardActivity(activity) {
     assert.strictEqual(items[1].image.url, 'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png');
     assert.strictEqual(items[1].price, '$ 45.00');
     assert.strictEqual(items[1].quantity, '720');
-    
 }
-

--- a/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
@@ -9,65 +9,63 @@ interface Bar {
     choices: ChoiceSet;
 }
 
-describe('ChoiceSetTests', function () {
+function testValues(value){
+    assert.equal('test1', value[0].value);
+    assert.equal('test2', value[1].value);
+    assert.equal('test3', value[2].value);
+}
+
+describe('ChoiceSetTests', function() {
     this.timeout(10000);
 
     it('TestExpression', async () => {
         const state = {
             choices: [
-                { value: "test1" } as Choice,
-                { value: "test2" } as Choice,
-                { value: "test3" } as Choice,
+                { value: 'test1' } as Choice,
+                { value: 'test2' } as Choice,
+                { value: 'test3' } as Choice,
             ]
-        }
-        const ep = new ObjectExpression<ChoiceSet>("choices");
-        const { value, error } = ep.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        };
+        const ep = new ObjectExpression<ChoiceSet>('choices');
+        const { value } = ep.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestValue', async () => {
-        const state = {}
+        const state = {};
         const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }]));
-        const { value, error } = ep.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        const { value } = ep.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestStringArrayAccess', async () => {
-        const state = {}
-        const stringArr = ['test1', 'test2', 'test3']
+        const state = {};
+        const stringArr = ['test1', 'test2', 'test3'];
         const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet(stringArr));
-        const { value, error } = ep.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        const { value } = ep.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestConverterExpressionAccess', async () => {
         const state = {
             test: [
-                { value: "test1" } as Choice,
-                { value: "test2" } as Choice,
-                { value: "test3" } as Choice,
+                { value: 'test1' } as Choice,
+                { value: 'test2' } as Choice,
+                { value: 'test3' } as Choice,
             ]
-        }
+        };
 
         const sample = {
             choices: 'test'
-        }
+        };
 
         const ep = new ObjectExpression<ChoiceSet>(sample.choices);
-        const { value, error } = ep.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        const { value } = ep.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestConvertObjectAccess', async () => {
-        const state = {}
+        const state = {};
 
         const sample = {
             choices: [
@@ -75,21 +73,19 @@ describe('ChoiceSetTests', function () {
                 { value: 'test2' },
                 { value: 'test3' }
             ]
-        }
+        };
 
-        const json = JSON.stringify(sample)
-        const bar = JSON.parse(json) as Bar
+        const json = JSON.stringify(sample);
+        const bar = JSON.parse(json) as Bar;
         
         // TS doesn't run 'new' automatically unlike C#
         const choicesBar = new ObjectExpression<ChoiceSet>(bar.choices);
-        const { value, error } = choicesBar.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        const { value } = choicesBar.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestConvertStringAccess', async () => {
-        const state = {}
+        const state = {};
 
         const sample = {
             choices: [
@@ -97,33 +93,27 @@ describe('ChoiceSetTests', function () {
                 'test2',
                 'test3',
             ]
-        }
+        };
 
-        const json = JSON.stringify(sample)
-        const bar = JSON.parse(json) as Bar
-        bar.choices = new ChoiceSet(bar.choices)
+        const json = JSON.stringify(sample);
+        const bar = JSON.parse(json) as Bar;
+        bar.choices = new ChoiceSet(bar.choices);
 
         // TS doesn't run 'new' automatically unlike C#
         const choicesBar = new ObjectExpression<ChoiceSet>(bar.choices);
-        const { value, error } = choicesBar.tryGetValue(state);
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        const { value } = choicesBar.tryGetValue(state);
+        testValues(value);
     });
 
     it('TestConvertStringArray', async () => {
-        const state = {}
+        const sample = [];
+        sample.push('test1');
+        sample.push('test2');
+        sample.push('test3');
 
-        const sample = []
-        sample.push('test1')
-        sample.push('test2')
-        sample.push('test3')
+        const json = JSON.stringify(sample);
+        const value = new ChoiceSet(JSON.parse(json));
 
-        const json = JSON.stringify(sample)
-        const value = new ChoiceSet(JSON.parse(json))
-
-        assert.equal('test1', value[0].value);
-        assert.equal('test2', value[1].value);
-        assert.equal('test3', value[2].value);
+        testValues(value);
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
@@ -9,7 +9,7 @@ interface Bar {
     choices: ChoiceSet;
 }
 
-function testValues(value){
+function assertValues(value){
     assert.equal('test1', value[0].value);
     assert.equal('test2', value[1].value);
     assert.equal('test3', value[2].value);
@@ -28,14 +28,14 @@ describe('ChoiceSetTests', function() {
         };
         const ep = new ObjectExpression<ChoiceSet>('choices');
         const { value } = ep.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestValue', async () => {
         const state = {};
         const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }]));
         const { value } = ep.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestStringArrayAccess', async () => {
@@ -43,7 +43,7 @@ describe('ChoiceSetTests', function() {
         const stringArr = ['test1', 'test2', 'test3'];
         const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet(stringArr));
         const { value } = ep.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestConverterExpressionAccess', async () => {
@@ -61,7 +61,7 @@ describe('ChoiceSetTests', function() {
 
         const ep = new ObjectExpression<ChoiceSet>(sample.choices);
         const { value } = ep.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestConvertObjectAccess', async () => {
@@ -81,7 +81,7 @@ describe('ChoiceSetTests', function() {
         // TS doesn't run 'new' automatically unlike C#
         const choicesBar = new ObjectExpression<ChoiceSet>(bar.choices);
         const { value } = choicesBar.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestConvertStringAccess', async () => {
@@ -102,7 +102,7 @@ describe('ChoiceSetTests', function() {
         // TS doesn't run 'new' automatically unlike C#
         const choicesBar = new ObjectExpression<ChoiceSet>(bar.choices);
         const { value } = choicesBar.tryGetValue(state);
-        testValues(value);
+        assertValues(value);
     });
 
     it('TestConvertStringArray', async () => {
@@ -114,6 +114,6 @@ describe('ChoiceSetTests', function() {
         const json = JSON.stringify(sample);
         const value = new ChoiceSet(JSON.parse(json));
 
-        testValues(value);
+        assertValues(value);
     });
 });


### PR DESCRIPTION
Addresses # 2338
## Description
Updates tests for BotBuilder-dialogs-adaptive tests by removing duplicated asserts and moving repetitive asserts to a function.

## Specific Changes
**activityFactory.test.js**:
- Removed duplicated asserts.
- Removed a line at end of file (now there is only a single line at eof).

**choiceSet.test.ts**:
- Moved repetitive asserts to a function to assert the values.
- Fixed eslint warnings.
- Added eof line.

## Testing
Here you can see the updated test with a slight decrease in time. Note that the times vary between test runs, but in general a slight decrease in time is present.
![image](https://user-images.githubusercontent.com/38112957/88845546-b93b1280-d1ba-11ea-96e8-f0f0935788d6.png)
![image](https://user-images.githubusercontent.com/38112957/88845559-bd673000-d1ba-11ea-8938-d03bbde8f038.png)
