### PR TITLE
[Engineering] Lower time for botbuilder-dialogs tests

### DIFF
--- a/libraries/botbuilder-dialogs/tests/choices_channel.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_channel.test.js
@@ -5,103 +5,93 @@ const { supportsSuggestedActions, supportsCardActions, hasMessageFeed, getChanne
 describe('channel methods', function() {
     this.timeout(5000);
 
-    it(`should return true for supportsSuggestedActions() with line and 13`, function () {
+    it(`should return true for supportsSuggestedActions() with line and 13`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('line', 13);
         assert(validNumOfSuggestedActions, `returned false.`);
     });
 
-    it(`should return false for supportsSuggestedActions() with line and 14`, function () {
+    it(`should return false for supportsSuggestedActions() with line and 14`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('line', 14);
         assert(validNumOfSuggestedActions === false, `returned true.`);
     });
 
-    it(`should return true for supportsSuggestedActions() with skype and 10`, function () {
+    it(`should return true for supportsSuggestedActions() with skype and 10`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('skype', 10);
         assert(validNumOfSuggestedActions, `returned false.`);
     });
 
-    it(`should return false for supportsSuggestedActions() with skype and 11`, function () {
+    it(`should return false for supportsSuggestedActions() with skype and 11`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('skype', 11);
         assert(validNumOfSuggestedActions === false, `returned true.`);
     });
 
-    it(`should return true for supportsSuggestedActions() with skype and 10`, function () {
-        const validNumOfSuggestedActions = supportsSuggestedActions('skype', 10);
-        assert(validNumOfSuggestedActions, `returned false.`);
-    });
-
-    it(`should return false for supportsSuggestedActions() with skype and 11`, function () {
-        const validNumOfSuggestedActions = supportsSuggestedActions('skype', 11);
-        assert(validNumOfSuggestedActions === false, `returned true.`);
-    });
-
-    it(`should return true for supportsSuggestedActions() with kik and 20`, function () {
+    it(`should return true for supportsSuggestedActions() with kik and 20`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('kik', 20);
         assert(validNumOfSuggestedActions, `returned false.`);
     });
 
-    it(`should return false for supportsSuggestedActions() with kik and 21`, function () {
+    it(`should return false for supportsSuggestedActions() with kik and 21`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('kik', 21);
         assert(validNumOfSuggestedActions === false, `returned true.`);
     });
 
-    it(`should return true for supportsSuggestedActions() with emulator and 100`, function () {
+    it(`should return true for supportsSuggestedActions() with emulator and 100`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('emulator', 100);
         assert(validNumOfSuggestedActions, `returned false.`);
     });
 
-    it(`should return false for supportsSuggestedActions() with emulator and 101`, function () {
+    it(`should return false for supportsSuggestedActions() with emulator and 101`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions('emulator', 101);
         assert(validNumOfSuggestedActions === false, `returned true.`);
     });
 
-    it(`should return true for supportsCardActions() with line and 99`, function () {
+    it(`should return true for supportsCardActions() with line and 99`, function() {
         const validNumOfCardActions = supportsCardActions('line', 99);
         assert(validNumOfCardActions, `returned false.`);
     });
 
-    it(`should return false for supportsCardActions() with line and 100`, function () {
+    it(`should return false for supportsCardActions() with line and 100`, function() {
         const validNumOfCardActions = supportsCardActions('line', 100);
         assert(validNumOfCardActions === false, `returned false.`);
     });
 
-    it(`should return true for supportsCardActions() with cortana and 100`, function () {
+    it(`should return true for supportsCardActions() with cortana and 100`, function() {
         const validNumOfCardActions = supportsCardActions('cortana', 100);
         assert(validNumOfCardActions, `returned false.`);
     });
 
-    it(`should return false for supportsCardActions() with slack and 101`, function () {
+    it(`should return false for supportsCardActions() with slack and 101`, function() {
         const validNumOfCardActions = supportsCardActions('slack', 101);
         assert(validNumOfCardActions === false, `returned true.`);
     });
 
-    it(`should return true for supportsCardActions() with skype and 3`, function () {
+    it(`should return true for supportsCardActions() with skype and 3`, function() {
         const validNumOfCardActions = supportsCardActions('skype', 3);
         assert(validNumOfCardActions, `returned false.`);
     });
 
-    it(`should return false for supportsCardActions() with skype and 5`, function () {
+    it(`should return false for supportsCardActions() with skype and 5`, function() {
         const validNumOfCardActions = supportsCardActions('skype', 5);
         assert(validNumOfCardActions === false, `returned true.`);
     });
 
-    it(`should return false for hasMessageFeed() with cortana`, function () {
+    it(`should return false for hasMessageFeed() with cortana`, function() {
         const hasFeed = hasMessageFeed('cortana');
         assert(hasFeed === false, `returned true.`);
     });
 
-    it(`should return the channelId from context.activity.`, function () {
+    it(`should return the channelId from context.activity.`, function() {
         const channel = getChannelId({ activity: { channelId: 'facebook' } });
         assert(channel === 'facebook', `expected "facebook", instead received ${ channel }`);
     });
 
-    it(`should return an empty string if context.activity.channelId is falsey.`, function () {
-        const channel = getChannelId({ activity: { } });
+    it(`should return an empty string if context.activity.channelId is falsey.`, function() {
+        const channel = getChannelId({ activity: {} });
         assert(channel === '', `expected "", instead received ${ channel }`);
     });
 
     // "directlinespeech" tests
-    it(`should return true for supportsSuggestedActions() with directlinespeech and 100`, function () {
+    it(`should return true for supportsSuggestedActions() with directlinespeech and 100`, function() {
         const validNumOfSuggestedActions = supportsSuggestedActions(Channels.DirectlineSpeech, 100);
         assert(validNumOfSuggestedActions, `returned false.`);
     });

--- a/libraries/botbuilder-dialogs/tests/choices_choiceFactory.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_choiceFactory.test.js
@@ -6,16 +6,16 @@ function assertActivity(received, expected) {
     assert(received, `Activity not returned.`);
     for (let key in expected) {
         const v = received[key];
-        assert(v !== undefined, `Activity.${key} missing.`);
+        assert(v !== undefined, `Activity.${ key } missing.`);
         const ev = expected[key];
-        assert(typeof v === typeof ev, `Activity.${key} has invalid type of '${typeof v}'.`);
+        assert(typeof v === typeof ev, `Activity.${ key } has invalid type of '${ typeof v }'.`);
         if (Array.isArray(ev)) {
-            assert(v.length === ev.length, `Activity.${key} has invalid length of '${v.length}'.`);
-            assert(JSON.stringify(v) === JSON.stringify(ev), `Activity.${key} has invalid contents: ` + JSON.stringify(v));
+            assert(v.length === ev.length, `Activity.${ key } has invalid length of '${ v.length }'.`);
+            assert(JSON.stringify(v) === JSON.stringify(ev), `Activity.${ key } has invalid contents: ` + JSON.stringify(v));
         } else if (typeof ev === 'object') {
-            assert(JSON.stringify(v) === JSON.stringify(ev), `Activity.${key} has invalid contents: ` + JSON.stringify(v));
+            assert(JSON.stringify(v) === JSON.stringify(ev), `Activity.${ key } has invalid contents: ` + JSON.stringify(v));
         } else {
-            assert(v === ev, `Activity.${key} has invalid value of '${v}'.`);
+            assert(v === ev, `Activity.${ key } has invalid value of '${ v }'.`);
         }
     }
 }
@@ -112,14 +112,14 @@ function assertChoices(choices, actionValues, actionType = 'imBack') {
     for (let i = 0; i < choices.length; i++) {
         const choice = choices[i];
         const val = actionValues[i];
-        assert(choice.action.type === actionType, `Expected action.type === ${actionType}, received ${choice.action.type}`);
-        assert(choice.action.value === val, `Expected action.value === ${val}, received ${choice.action.value}`);
-        assert(choice.action.title === val, `Expected action.title === ${val}, received ${choice.action.title}`);
+        assert(choice.action.type === actionType, `Expected action.type === ${ actionType }, received ${ choice.action.type }`);
+        assert(choice.action.value === val, `Expected action.value === ${ val }, received ${ choice.action.value }`);
+        assert(choice.action.title === val, `Expected action.title === ${ val }, received ${ choice.action.title }`);
 
     }
 }
 
-describe('The ChoiceFactory', function () {
+describe('The ChoiceFactory', function() {
     it('should render choices inline.', () => {
         const activity = ChoiceFactory.inline(colorChoices, 'select from:');
         assertActivity(activity, {
@@ -151,12 +151,11 @@ describe('The ChoiceFactory', function () {
     it('should suggest the same action when a suggested action is provided', () => {
         const activity = ChoiceFactory.suggestedAction([{ value: 'Signin', action: { type: ActionTypes.Signin } }]);
         assert.ok(activity.suggestedActions.actions[0].type === ActionTypes.Signin,
-            `Expected the suggestion action to be ${ActionTypes.Signin} but got: ${activity.suggestedActions.actions[0].type}`);
+            `Expected the suggestion action to be ${ ActionTypes.Signin } but got: ${ activity.suggestedActions.actions[0].type }`);
     });
 
     it('should use hero cards for channels that do not support choices (Teams, Cortana)', () => {
-        let activities = ChoiceFactory.forChannel('cortana', colorChoices, 'select from:');
-        assertActivity(activities, {
+        const expectedActivity = {
             'type': 'message',
             'attachmentLayout': 'list',
             'attachments': [
@@ -185,43 +184,20 @@ describe('The ChoiceFactory', function () {
                 }
             ],
             'inputHint': 'expectingInput'
-        });
+        };
+
+        let activities = ChoiceFactory.forChannel('cortana', colorChoices, 'select from:');
+
+
+        assertActivity(activities, expectedActivity);
+
         const choices = colorChoices.map(value => ({
             value,
             action: { type: ActionTypes.ImBack }
         }));
 
         activities = ChoiceFactory.forChannel('msteams', choices, 'select from:');
-        assertActivity(activities, {
-            'type': 'message',
-            'attachmentLayout': 'list',
-            'attachments': [
-                {
-                    'contentType': 'application/vnd.microsoft.card.hero',
-                    'content': {
-                        'text': 'select from:',
-                        'buttons': [
-                            {
-                                'title': 'red',
-                                'type': 'imBack',
-                                'value': 'red'
-                            },
-                            {
-                                'title': 'green',
-                                'type': 'imBack',
-                                'value': 'green'
-                            },
-                            {
-                                'title': 'blue',
-                                'type': 'imBack',
-                                'value': 'blue'
-                            }
-                        ]
-                    }
-                }
-            ],
-            'inputHint': 'expectingInput'
-        });
+        assertActivity(activities, expectedActivity);
     });
 
     it('should render an inline list based on title length, choice length and channel', () => {

--- a/libraries/botbuilder-dialogs/tests/memory_dialogStateManager.test.js
+++ b/libraries/botbuilder-dialogs/tests/memory_dialogStateManager.test.js
@@ -1,14 +1,14 @@
 const { ConversationState, UserState, MemoryStorage, TurnContext, TestAdapter } = require('botbuilder-core');
-const { DialogStateManager, Dialog, DialogSet, DialogContext, DialogContainer, ConversationMemoryScope, UserMemoryScope } =  require('../');
+const { DialogStateManager, Dialog, DialogSet, DialogContext, DialogContainer, ConversationMemoryScope, UserMemoryScope } = require('../');
 const assert = require('assert');
 
-const beginMessage = { 
-    text: `begin`, 
-    type: 'message', 
-    channelId: 'test', 
+const beginMessage = {
+    text: `begin`,
+    type: 'message',
+    channelId: 'test',
     from: { id: 'user' },
     recipient: { id: 'bot' },
-    conversation: { id: 'convo1' } 
+    conversation: { id: 'convo1' }
 };
 
 class TestDialog extends Dialog {
@@ -17,8 +17,8 @@ class TestDialog extends Dialog {
         this.message = message;
         this.dialogType = 'child';
     }
-    
-    async beginDialog(dc, options) {
+
+    async beginDialog(dc) {
         dc.activeDialog.state.isDialog = true;
         await dc.context.sendActivity(this.message);
         return Dialog.EndOfTurn;
@@ -29,8 +29,8 @@ class TestContainer extends DialogContainer {
     constructor(id, child) {
         super(id);
         if (child) {
-            this.dialogs.add(child); 
-            this.childId = child.id; 
+            this.dialogs.add(child);
+            this.childId = child.id;
         }
         this.dialogType = 'container';
     }
@@ -88,7 +88,7 @@ async function createTestDc(storage) {
     dialogs.add(container);
 
     // Create test context
-    const context= new TurnContext(new TestAdapter(), beginMessage);
+    const context = new TurnContext(new TestAdapter(), beginMessage);
     context.turnState.set('ConversationState', convoState);
     context.turnState.set('UserState', userState);
     const dc = await dialogs.createContext(context);
@@ -98,10 +98,12 @@ async function createTestDc(storage) {
     return dc;
 }
 
-describe('Memory - Dialog State Manager', function() {
+describe('Memory - Dialog State Manager', async function() {
     this.timeout(5000);
-    
-    it('Should create a standard configuration.', async function () {
+
+    const dc = await createConfiguredTestDc();
+
+    it('Should create a standard configuration.', async function() {
         // Run test
         const config = DialogStateManager.createStandardConfiguration();
         assert(config, `No config returned`);
@@ -109,14 +111,14 @@ describe('Memory - Dialog State Manager', function() {
         assert(config.memoryScopes.length > 0, `No memory scopes`);
     });
 
-    it('Should create a standard configuration with added conversation state.', async function () {
+    it('Should create a standard configuration with added conversation state.', async function() {
         // Run test
         let convoScopeFound = false;
         const storage = new MemoryStorage();
         const convoState = new ConversationState(storage);
         const config = DialogStateManager.createStandardConfiguration(convoState);
         config.memoryScopes.forEach(scope => {
-            if (scope instanceof ConversationMemoryScope) { 
+            if (scope instanceof ConversationMemoryScope) {
                 convoScopeFound = true;
                 assert(scope.name == 'conversation');
             }
@@ -124,19 +126,18 @@ describe('Memory - Dialog State Manager', function() {
         assert(convoScopeFound, `no conversation scope added`);
     });
 
-    it('Should create a standard configuration with added conversation and user state.', async function () {
+    it('Should create a standard configuration with added conversation and user state.', async function() {
         // Run test
         let convoScopeFound = false;
         let userScopeFound = false;
-        const dc = await createConfiguredTestDc();
         const config = dc.state.configuration;
         config.memoryScopes.forEach(scope => {
-            if (scope instanceof ConversationMemoryScope) { 
+            if (scope instanceof ConversationMemoryScope) {
                 convoScopeFound = true;
-                assert(scope.name == 'conversation'); 
+                assert(scope.name == 'conversation');
             }
-            if (scope instanceof UserMemoryScope) { 
-                userScopeFound = true; 
+            if (scope instanceof UserMemoryScope) {
+                userScopeFound = true;
                 assert(scope.name == 'user');
             }
         });
@@ -144,7 +145,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(userScopeFound, `no user scope added`);
     });
 
-    it('Should create a standard configuration by default.', async function () {
+    it('Should create a standard configuration by default.', async function() {
         // Create test dc
         const dc = await createTestDc();
 
@@ -155,83 +156,77 @@ describe('Memory - Dialog State Manager', function() {
         assert(config.memoryScopes.length > 0, `No memory scopes`);
     });
 
-    it('Should read & write values to TURN memory scope.', async function () {
+    it('Should read & write values to TURN memory scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('turn.foo', 'bar');
         const value = dc.state.getValue('turn.foo');
-        assert(value == 'bar', `value returned: ${value}`);
+        assert(value == 'bar', `value returned: ${ value }`);
     });
 
-    it('Should read values from the SETTINGS memory scope.', async function () {
-        // Create test dc
-        const dc = await createConfiguredTestDc();
-
+    it('Should read values from the SETTINGS memory scope.', async function() {
         // Run test
         let count = 0;
         for (const key in process.env) {
             const expected = process.env[key];
             if (typeof expected == 'string') {
-                count++
-                const value = dc.state.getValue(`settings["${key}"]`);
-                assert (value == expected, `Value returned for "${key}": ${value}`);
+                count++;
+                const value = dc.state.getValue(`settings["${ key }"]`);
+                assert(value == expected, `Value returned for "${ key }": ${ value }`);
             }
         }
         assert(count > 0, `no settings tested`);
     });
 
-    it('Should read & write values to DIALOG memory scope.', async function () {
+    it('Should read & write values to DIALOG memory scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('dialog.foo', 'bar');
         const value = dc.state.getValue('dialog.foo');
-        assert(value == 'bar', `value returned: ${value}`);
+        assert(value == 'bar', `value returned: ${ value }`);
     });
 
-    it('Should read values from the CLASS memory scope.', async function () {
-        // Create test dc
-        const dc = await createConfiguredTestDc();
-
+    it('Should read values from the CLASS memory scope.', async function() {
         // Run test
         assert(dc.state.getValue('class.dialogType') === 'container');
         assert(dc.child.state.getValue('class.dialogType') === 'child');
     });
 
-    it('Should read & write values to THIS memory scope.', async function () {
+    it('Should read & write values to THIS memory scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('this.foo', 'bar');
         const value = dc.state.getValue('this.foo');
-        assert(value == 'bar', `value returned: ${value}`);
+        assert(value == 'bar', `value returned: ${ value }`);
     });
 
-    it('Should read & write values to CONVERSATION memory scope.', async function () {
+    it('Should read & write values to CONVERSATION memory scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('conversation.foo', 'bar');
         const value = dc.state.getValue('conversation.foo');
-        assert(value == 'bar', `value returned: ${value}`);
+        assert(value == 'bar', `value returned: ${ value }`);
     });
 
-    it('Should read & write values to USER memory scope.', async function () {
+    it('Should read & write values to USER memory scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('user.foo', 'bar');
         const value = dc.state.getValue('user.foo');
-        assert(value == 'bar', `value returned: ${value}`);
+        assert(value == 'bar', `value returned: ${ value }`);
     });
 
-    it('Should read & write values using $ alias.', async function () {
+    it('Should read & write values using $ alias.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
@@ -241,7 +236,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('$foo') == 'bar', `getValue() failed to use alias.`);
     });
 
-    it('Should read & write values using # alias.', async function () {
+    it('Should read & write values using # alias.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
@@ -251,18 +246,18 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('#foo') == 'bar', `getValue() failed to use alias.`);
     });
 
-    it('Should read & write values using @@ alias.', async function () {
+    it('Should read & write values using @@ alias.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
         // Run test
         dc.state.setValue('@@foo', ['bar']);
-        const value = dc.state.getValue('turn.recognized.entities.foo'); 
+        const value = dc.state.getValue('turn.recognized.entities.foo');
         assert(Array.isArray(value) && value.length == 1, `setValue() failed to use alias.`);
         assert(value[0] == 'bar');
     });
 
-    it('Should read entities using @ alias.', async function () {
+    it('Should read entities using @ alias.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
@@ -279,15 +274,15 @@ describe('Memory - Dialog State Manager', function() {
         assert.equal(dc.state.getValue('turn.recognized.entities.single.first()'), 'test1');
         assert.equal(dc.state.getValue('turn.recognized.entities.double.first()'), 'testx');
 
-        dc.state.setValue('turn.recognized.entities.single', [{name: 'test1'}, {name: 'test2'}, {name: 'test3'}]);
-        dc.state.setValue('turn.recognized.entities.double', [[{name: 'testx'}, {name: 'testy'}, {name: 'testz'}], [{name: 'test1'}, {name: 'test2'}, {name: 'test3'}]]);
+        dc.state.setValue('turn.recognized.entities.single', [{ name: 'test1' }, { name: 'test2' }, { name: 'test3' }]);
+        dc.state.setValue('turn.recognized.entities.double', [[{ name: 'testx' }, { name: 'testy' }, { name: 'testz' }], [{ name: 'test1' }, { name: 'test2' }, { name: 'test3' }]]);
         assert.equal(dc.state.getValue('@single.name'), 'test1');
         assert.equal(dc.state.getValue('@double.name'), 'testx');
         assert.equal(dc.state.getValue('turn.recognized.entities.single.first().name'), 'test1');
         assert.equal(dc.state.getValue('turn.recognized.entities.double.first().name'), 'testx');
     });
 
-    it('Should write a entity using @ alias.', async function () {
+    it('Should write a entity using @ alias.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
@@ -296,16 +291,13 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('@foo') == 'bar', `Entity not round tripping.`);
     });
 
-    it('Should read values using % alias.', async function () {
-        // Create test dc
-        const dc = await createConfiguredTestDc();
-
+    it('Should read values using % alias.', async function() {
         // Run test
         assert(dc.state.getValue('%dialogType') === 'container');
         assert(dc.child.state.getValue('%dialogType') === 'child');
     });
 
-    it('Should delete values in a scope.', async function () {
+    it('Should delete values in a scope.', async function() {
         // Create test dc
         const dc = await createConfiguredTestDc();
 
@@ -313,10 +305,10 @@ describe('Memory - Dialog State Manager', function() {
         dc.state.setValue('turn.foo', 'bar');
         dc.state.deleteValue('turn.foo');
         const value = dc.state.getValue('turn.foo');
-        assert(value == undefined, `value returned: ${value}`);
+        assert(value == undefined, `value returned: ${ value }`);
     });
 
-    it('Should persist conversation & user values when saved.', async function () {
+    it('Should persist conversation & user values when saved.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -332,27 +324,15 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('conversation.foo') == 'bar', `conversation state not saved`);
     });
 
-    it('Should return default value when getValue() called with empty path.', async function () {
-        // Create test dc
-        const storage = new MemoryStorage();
-        let dc = await createConfiguredTestDc(storage);
-
+    it('Should return default value when getValue() called with empty path.', async function() {
         assert(dc.state.getValue('', 'default') == 'default');
     });
 
-    it('Should support passing a function to getValue() for the default.', async function () {
-        // Create test dc
-        const storage = new MemoryStorage();
-        let dc = await createConfiguredTestDc(storage);
-
+    it('Should support passing a function to getValue() for the default.', async function() {
         assert(dc.state.getValue('', () => 'default') == 'default');
     });
 
-    it('Should raise an error if getValue() called with an invalid scope.', async function () {
-        // Create test dc
-        const storage = new MemoryStorage();
-        let dc = await createConfiguredTestDc(storage);
-
+    it('Should raise an error if getValue() called with an invalid scope.', async function() {
         // Run test
         let = error = false;
         try {
@@ -363,22 +343,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error if getValue() called with an invalid scope.', async function () {
-        // Create test dc
-        const storage = new MemoryStorage();
-        let dc = await createConfiguredTestDc(storage);
-
-        // Run test
-        let = error = false;
-        try {
-            dc.state.getValue('foo.bar');
-        } catch (err) {
-            error = true;
-        }
-        assert(error);
-    });
-
-    it('Should raise an error if setValue() called with missing path.', async function () {
+    it('Should raise an error if setValue() called with missing path.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -393,7 +358,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error if setValue() called with an invalid scope.', async function () {
+    it('Should raise an error if setValue() called with an invalid scope.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -408,17 +373,17 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should overwrite memory when setValue() called with just a scope.', async function () {
+    it('Should overwrite memory when setValue() called with just a scope.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn',  { foo: 'bar' });
+        dc.state.setValue('turn', { foo: 'bar' });
         assert(dc.state.getValue('turn.foo') == 'bar');
     });
 
-    it('Should raise an error if deleteValue() called with < 2 path path.', async function () {
+    it('Should raise an error if deleteValue() called with < 2 path path.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -433,7 +398,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error if deleteValue() called with an invalid scope.', async function () {
+    it('Should raise an error if deleteValue() called with an invalid scope.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -448,39 +413,39 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should read & write array values.', async function () {
+    it('Should read & write array values.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.foo',  ['bar']);
+        dc.state.setValue('turn.foo', ['bar']);
         assert(dc.state.getValue('turn.foo[0]') == 'bar');
     });
 
-    it('Should delete array values by index.', async function () {
+    it('Should delete array values by index.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.test',  ['foo', 'bar']);
-        dc.state.deleteValue('turn.test[0]')
+        dc.state.setValue('turn.test', ['foo', 'bar']);
+        dc.state.deleteValue('turn.test[0]');
         assert(dc.state.getValue('turn.test[0]') == 'bar');
     });
 
-    it('Should ignore array deletions that are out of range.', async function () {
+    it('Should ignore array deletions that are out of range.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
         dc.state.setValue('turn.test', []);
-        dc.state.deleteValue('turn.test[0]')
+        dc.state.deleteValue('turn.test[0]');
         assert(dc.state.getValue('turn.test').length == 0);
     });
 
-    it('Should ignore property deletions off non-object properties.', async function () {
+    it('Should ignore property deletions off non-object properties.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -494,7 +459,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('turn.bar') == 'test');
     });
 
-    it('Should ignore property deletions of missing object properties.', async function () {
+    it('Should ignore property deletions of missing object properties.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -510,81 +475,81 @@ describe('Memory - Dialog State Manager', function() {
         assert(count == 1);
     });
 
-    it('Should resolve nested expressions.', async function () {
+    it('Should resolve nested expressions.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.addresses', { 
-            'work': { 
-                street: 'one microsoft way', 
+        dc.state.setValue('turn.addresses', {
+            'work': {
+                street: 'one microsoft way',
                 city: 'Redmond',
                 state: 'wa',
-                zip: '98052' 
-            } 
+                zip: '98052'
+            }
         });
-        dc.state.setValue('turn.addressKeys', ['work'])
+        dc.state.setValue('turn.addressKeys', ['work']);
         dc.state.setValue('turn.preferredAddress', 0);
         const value = dc.state.getValue('turn.addresses[turn.addressKeys[turn.preferredAddress]].zip');
         assert(value == '98052');
     });
 
-    it('Should find a property quoted with single quotes.', async function () {
+    it('Should find a property quoted with single quotes.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.addresses', { 
-            'work': { 
-                street: 'one microsoft way', 
+        dc.state.setValue('turn.addresses', {
+            'work': {
+                street: 'one microsoft way',
                 city: 'Redmond',
                 state: 'wa',
-                zip: '98052' 
-            } 
+                zip: '98052'
+            }
         });
         const value = dc.state.getValue(`turn.addresses['work'].zip`);
         assert(value == '98052');
     });
 
-    it('Should find a property quoted with double quotes.', async function () {
+    it('Should find a property quoted with double quotes.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.addresses', { 
-            'work': { 
-                street: 'one microsoft way', 
+        dc.state.setValue('turn.addresses', {
+            'work': {
+                street: 'one microsoft way',
                 city: 'Redmond',
                 state: 'wa',
-                zip: '98052' 
-            } 
+                zip: '98052'
+            }
         });
         const value = dc.state.getValue(`turn.addresses["work"].zip`);
         assert(value == '98052');
     });
 
-    it('Should find a property containing embedded quotes.', async function () {
+    it('Should find a property containing embedded quotes.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
 
         // Run test
-        dc.state.setValue('turn.addresses', { 
-            '"work"': { 
-                street: 'one microsoft way', 
+        dc.state.setValue('turn.addresses', {
+            '"work"': {
+                street: 'one microsoft way',
                 city: 'Redmond',
                 state: 'wa',
-                zip: '98052' 
-            } 
+                zip: '98052'
+            }
         });
         const value = dc.state.getValue(`turn.addresses['\\"work\\"'].zip`);
         assert(value == '98052');
     });
 
-    it('Should raise an error for paths with miss-matched quotes.', async function () {
+    it('Should raise an error for paths with miss-matched quotes.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -592,13 +557,13 @@ describe('Memory - Dialog State Manager', function() {
         // Run test
         let error = false;
         try {
-            dc.state.setValue('turn.addresses', { 
-                'work': { 
-                    street: 'one microsoft way', 
+            dc.state.setValue('turn.addresses', {
+                'work': {
+                    street: 'one microsoft way',
                     city: 'Redmond',
                     state: 'wa',
-                    zip: '98052' 
-                } 
+                    zip: '98052'
+                }
             });
             dc.state.getValue(`turn.addresses['work"].zip`);
         } catch (err) {
@@ -607,7 +572,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error for segments with invalid path chars.', async function () {
+    it('Should raise an error for segments with invalid path chars.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -615,13 +580,13 @@ describe('Memory - Dialog State Manager', function() {
         // Run test
         let error = false;
         try {
-            dc.state.setValue('turn.addresses', { 
-                '~work': { 
-                    street: 'one microsoft way', 
+            dc.state.setValue('turn.addresses', {
+                '~work': {
+                    street: 'one microsoft way',
                     city: 'Redmond',
                     state: 'wa',
-                    zip: '98052' 
-                } 
+                    zip: '98052'
+                }
             });
             dc.state.getValue(`turn.addresses.~work.zip`);
         } catch (err) {
@@ -630,7 +595,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error for assignments to a negative array index.', async function () {
+    it('Should raise an error for assignments to a negative array index.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -645,7 +610,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error for array assignments to non-array values.', async function () {
+    it('Should raise an error for array assignments to non-array values.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -661,7 +626,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should raise an error for un-matched brackets.', async function () {
+    it('Should raise an error for un-matched brackets.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -676,7 +641,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(error);
     });
 
-    it('Should alow indexer based path lookups.', async function () {
+    it('Should alow indexer based path lookups.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -687,7 +652,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(value == 'bar');
     });
 
-    it('Should return "undefined" for index lookups again non-arrays.', async function () {
+    it('Should return "undefined" for index lookups again non-arrays.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -697,7 +662,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('turn.foo[2]') == undefined);
     });
 
-    it('Should return "undefined" when first() called for empty array.', async function () {
+    it('Should return "undefined" when first() called for empty array.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -707,7 +672,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('turn.foo.first()') == undefined);
     });
 
-    it('Should return "undefined" when first() called for empty nested array.', async function () {
+    it('Should return "undefined" when first() called for empty nested array.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -717,7 +682,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(dc.state.getValue('turn.foo.first()') == undefined);
     });
 
-    it('Should return "undefined" for a missing segment.', async function () {
+    it('Should return "undefined" for a missing segment.', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);
@@ -728,7 +693,7 @@ describe('Memory - Dialog State Manager', function() {
         assert(value == undefined);
     });
 
-    it('Should raise an error for paths starting with a ".".', async function () {
+    it('Should raise an error for paths starting with a ".".', async function() {
         // Create test dc
         const storage = new MemoryStorage();
         let dc = await createConfiguredTestDc(storage);


### PR DESCRIPTION
Addresses # 2338

## Description
This PR optimizes the time for the botbuilder-dialogs tests having no impact in the code coverage numbers and reducing the execution time approximately from **4s** to **3s**.

## Specific Changes

`choices_channel.test.js`
- Removed duplicated tests `should return true for supportsSuggestedActions() with skype and 10` and `should return false for supportsSuggestedActions() with skype and 11`.
- Fixed eslint warnings.

`choices_choiceFactory.test.js`
- Created a variable called `expectedActivity` for Teams and Cortana tests. 
- Fixed eslint warnings.

`dialogSet.test.js`
- Moved some `ConversationState` instances at the top of the `describe` to reuse the same instance.
- Fixed eslint warnings.

`memory_dialogStateManager.test.js`
- Moved some `createConfiguredTestDc` function calls at the top of the `describe` to reuse the same `DialogContext` instance.
- Removed duplicated test `Should raise an error if getValue() called with an invalid scope.`.
- Fixed eslint warnings.

## Testing
![image](https://user-images.githubusercontent.com/62260472/88847704-c6a5cc00-d1bd-11ea-9e85-d37e928d4a4e.png)