### PR TITLE
[Engineering] Lower time for botframework-streaming tests

### DIFF
--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -6,64 +6,58 @@ const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
 const PayloadAssemblerManager = require('../lib/payloads/payloadAssemblerManager');
 var expect = chai.expect;
 
-describe('ReceiveRequestAssembler', () => {
 
-});
+const streamManager = new StreamManager.StreamManager();
 
 describe('PayloadAssembler', () => {
     it('constructs correctly.', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header});
+        let header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
 
         expect(rra.id).equals('100');
-        expect(rra._streamManager).equals(sm);
+        expect(rra._streamManager).equals(streamManager);
     });
 
     it('closes without throwing', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
+        let header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '99', end: true };
 
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header});
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
 
-        expect(() => {rra.close();}).to.not.throw;
+        expect(() => { rra.close(); }).to.not.throw;
     });
 
     it('returns a new stream.', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
+        let header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
 
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header});
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
 
         expect(rra.createPayloadStream()).to.be.instanceOf(SubscribableStream.SubscribableStream);
     });
 
     it('processes a Request without throwing.', (done) => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
+        let header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: '98', end: true };
         let s = new SubscribableStream.SubscribableStream();
         s.write('12345');
-        let rp = {verb: 'POST', path: '/some/path'};
+        let rp = { verb: 'POST', path: '/some/path' };
         rp.streams = s;
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header, onCompleted: function() {done();} });
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header, onCompleted: function() { done(); } });
         rra.onReceive(header, s, 5);
         rra.close();
     });
 
     it('processes a Response without throwing.', (done) => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
+        let header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '100', end: true };
         let s = new SubscribableStream.SubscribableStream();
         s.write('12345');
-        let rp = {statusCode: 200};
+        let rp = { statusCode: 200 };
         rp.streams = s;
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header, onCompleted: function() {done();} });
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header, onCompleted: function() { done(); } });
         rra.onReceive(header, s, 5);
     });
 
     it('assigns values when constructed', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: undefined};
-        let csa = new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {header: header});
+        let header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: undefined };
+        let csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
         expect(csa.id)
             .equals('1');
         expect(csa.contentLength)
@@ -75,15 +69,15 @@ describe('PayloadAssembler', () => {
     });
 
     it('returns a Stream', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: true};
-        let csa = new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {header: header});
+        let header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: true };
+        let csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
         expect(csa.createPayloadStream())
             .instanceOf(SubscribableStream.SubscribableStream);
     });
 
     it('closes a Stream', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: true};
-        let csa = new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {header: header});
+        let header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '97', end: true };
+        let csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
         expect(csa.createPayloadStream())
             .instanceOf(SubscribableStream.SubscribableStream);
         expect(csa.close()).to.not.throw;
@@ -92,23 +86,23 @@ describe('PayloadAssembler', () => {
 
 describe('PayloadAssemblerManager', () => {
     it('cretes a response stream', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
         expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream.SubscribableStream);
         done();
     });
 
 
     it('cretes a request stream', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
         expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream.SubscribableStream);
         done();
     });
 
     it('does not throw when receiving a request', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
         let s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
@@ -116,8 +110,8 @@ describe('PayloadAssemblerManager', () => {
     });
 
     it('does not throw when receiving a stream', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: '42', id: '100', end: true };
         let s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
@@ -125,8 +119,8 @@ describe('PayloadAssemblerManager', () => {
     });
 
     it('does not throw when receiving a response', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
         let s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
@@ -134,8 +128,8 @@ describe('PayloadAssemblerManager', () => {
     });
 
     it('returns undefined when asked to create an existing stream', (done) => {
-        let p = new PayloadAssemblerManager.PayloadAssemblerManager(new StreamManager.StreamManager(), () => done(), () => done());
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true};
+        let p = new PayloadAssemblerManager.PayloadAssemblerManager(streamManager, () => done(), () => done());
+        let head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
         let s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
         expect(p.getPayloadStream(head)).to.be.undefined;
@@ -143,25 +137,23 @@ describe('PayloadAssemblerManager', () => {
     });
 
     it('throws if not given an ID', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: undefined, end: true};
-        let sm = new StreamManager.StreamManager();
-        try{
-            let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header, onCompleted: function() {done();} });
-        } catch(result) {
+        let header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: undefined, end: true };
+        try {
+            new PayloadAssembler.PayloadAssembler(streamManager, { header: header, onCompleted: function() { done(); } });
+        } catch (result) {
             expect(result.message).to.equal('An ID must be supplied when creating an assembler.');
         }
     });
 
     it('processes a response with streams without throwing.', (done) => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '100', end: true};
-        let sm = new StreamManager.StreamManager();
+        let header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '96', end: true };
         let s = new SubscribableStream.SubscribableStream();
         s.write('{"statusCode": "12345","streams": [{"id": "1","contentType": "text","length": "2"},{"id": "2","contentType": "text","length": "2"},{"id": "3","contentType": "text","length": "2"}]}');
-        let rp = {verb: 'POST', path: '/some/path'};
+        let rp = { verb: 'POST', path: '/some/path' };
         rp.streams = [];
         rp.streams.push(s);
 
-        let rra = new PayloadAssembler.PayloadAssembler(sm, {header: header, onCompleted: function() {done();} });
+        let rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header, onCompleted: function() { done(); } });
         rra.onReceive(header, s, 5);
         rra.close();
     });

--- a/libraries/botframework-streaming/tests/ContentStream.test.js
+++ b/libraries/botframework-streaming/tests/ContentStream.test.js
@@ -1,16 +1,15 @@
-const  ContentStream  = require('../lib/contentStream');
-const  PayloadAssembler  = require('../lib/assemblers/payloadAssembler');
-const  chai  = require('chai');
+const ContentStream = require('../lib/contentStream');
+const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
+const chai = require('chai');
 const StreamManager = require('../lib/payloads/streamManager');
 const SubscribableStream = require('../lib/subscribableStream');
 const PayloadTypes = require('../lib/payloads/payloadTypes');
-const protocol = require('../lib');
 var expect = chai.expect;
 
-class TestPayloadAssembler{
-    constructor(content){
+class TestPayloadAssembler {
+    constructor(content) {
         this.stream1 = new SubscribableStream.SubscribableStream();
-        if(content){
+        if (content) {
             this.stream1.write(content);
         } else {
             this.stream1.write('hello');
@@ -20,16 +19,20 @@ class TestPayloadAssembler{
         this.contentLength = 5;
     }
 
-    getPayloadStream(){
+    getPayloadStream() {
         return this.stream1;
     }
 
-    close(){}
+    close() { }
 }
 
 describe('Streaming Extensions ContentStream Tests ', () => {
+    const streamManager = new StreamManager.StreamManager();
+
+    const header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true };
+
     it('assigns ID when constructed', () => {
-        let csa = new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1'});
+        let csa = new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1' });
         let cs = new ContentStream.ContentStream('1', csa);
 
         expect(cs.id)
@@ -42,32 +45,28 @@ describe('Streaming Extensions ContentStream Tests ', () => {
     });
 
     it('can return payload type', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
         expect(cs.contentType)
             .equal('S');
     });
 
     it('can return length', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
         expect(cs.length)
             .equal(42);
     });
 
     it('can return ID', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
         expect(cs.id)
             .equal('1');
     });
 
     it('does not return the stream when it is is undefined', () => {
-        let header = {PayloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
         expect(cs.getStream())
             .to
@@ -77,8 +76,7 @@ describe('Streaming Extensions ContentStream Tests ', () => {
     });
 
     it('reads a stream of length 0 and returns an empty string', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 0, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: { ...header, payloadLength: 0 } }));
 
         return cs.readAsString()
             .then(data => {
@@ -88,8 +86,10 @@ describe('Streaming Extensions ContentStream Tests ', () => {
     });
 
     it('throws when reading an empty stream as JSON', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.stream, PayloadLength: 0, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(new StreamManager.StreamManager(), {id:'csa1', header: header}));
+        const assemblerHeader = { ...header, PayloadLength: 0 };
+        delete assemblerHeader.payloadLength;
+
+        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: assemblerHeader }));
 
         return cs.readAsJson()
             .then(data => {
@@ -106,27 +106,25 @@ describe('Streaming Extensions ContentStream Tests ', () => {
             });
     });
 
-    it('reads a stream as a string',  () => {
+    it('reads a stream as a string', () => {
         let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler());
         let result = cs.readAsString();
 
         result.then(function(data) {
             expect(data).to.equal('hello');
-
         });
     });
 
-    it('reads a stream as a json',  () => {
+    it('reads a stream as a json', () => {
         let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler('{"message":"hello"}'));
         let result = cs.readAsJson();
 
         result.then(function(data) {
             expect(data.message).to.equal('hello');
-
         });
     });
 
-    it('reads a stream before receiving all the bits',  () => {
+    it('reads a stream before receiving all the bits', () => {
         let tcsa = new TestPayloadAssembler();
         tcsa.contentLength = 10;
         let cs = new ContentStream.ContentStream('cs1', tcsa);
@@ -134,13 +132,12 @@ describe('Streaming Extensions ContentStream Tests ', () => {
 
         result.then(function(data) {
             expect(data).to.equal('hello');
-
         });
     });
 
-    it('can cancel',  () => {
+    it('can cancel', () => {
         let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler());
-        let result = cs.readAsString();
+        cs.readAsString();
 
         expect(cs.cancel()).to.not.throw;
     });

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -3,12 +3,12 @@ const np = require('../lib');
 const npt = require('../lib/namedPipe/namedPipeTransport');
 const { createNodeServer, getServerFactory } = require('../lib/utilities/createNodeServer');
 const protocol = require('../lib');
-const  chai  = require('chai');
+const chai = require('chai');
 var expect = chai.expect;
 
-class FauxSock{
-    constructor(contentString){
-        if(contentString){
+class FauxSock {
+    constructor(contentString) {
+        if (contentString) {
             this.contentString = contentString;
             this.position = 0;
         }
@@ -16,46 +16,45 @@ class FauxSock{
         this.exists = true;
     }
 
-    write(buffer){
+    write(buffer) {
         this.buffer = buffer;
     }
 
-    send(buffer){
+    send(buffer) {
         return buffer.length;
     };
 
-    receive(readLength){
-        if(this.contentString[this.position])
-        {
+    receive(readLength) {
+        if (this.contentString[this.position]) {
             this.buff = Buffer.from(this.contentString[this.position]);
             this.position++;
 
             return this.buff.slice(0, readLength);
         }
 
-        if(this.receiver.isConnected)
+        if (this.receiver.isConnected)
             this.receiver.disconnect();
     }
-    close(){};
-    end(){
+    close() { };
+    end() {
         this.exists = false;
     };
-    destroyed(){
+    destroyed() {
         return this.exists;
     };
 
-    setReceiver(receiver){
+    setReceiver(receiver) {
         this.receiver = receiver;
     }
 
-    on(action, handler){
-        if(action === 'error'){
+    on(action, handler) {
+        if (action === 'error') {
             this.errorHandler = handler;
         }
-        if(action === 'data'){
+        if (action === 'data') {
             this.messageHandler = handler;
         }
-        if(action === 'close'){
+        if (action === 'close') {
             this.closeHandler = handler;
         }
 
@@ -80,7 +79,7 @@ class TestServer {
         });
 
         this._server = net.createServer(() => {
-            this.transport = new npt.NamedPipeTransport(new FauxSock , pipeName);
+            this.transport = new npt.NamedPipeTransport(new FauxSock, pipeName);
             connectResolve();
         });
         this._server.listen(pipeName);
@@ -183,7 +182,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket1');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
         it('creates a new transport and connects', () => {
@@ -194,7 +193,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket2');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
             expect(transport.isConnected).to.be.true;
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
         it('closes the transport without throwing', () => {
@@ -219,7 +218,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             let buff = Buffer.from('hello', 'utf8');
             let sent = transport.send(buff);
             expect(sent).to.equal(5);
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
         it('returns 0 when attepmting to write to a closed socket', () => {
@@ -234,7 +233,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             let buff = Buffer.from('hello', 'utf8');
             let sent = transport.send(buff);
             expect(sent).to.equal(0);
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
         it('throws when reading from a dead socket', () => {
@@ -246,7 +245,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
             expect(transport.isConnected).to.be.true;
             expect(transport.receive(5)).to.throw;
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
         it('can read from the socket', () => {
@@ -260,7 +259,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             transport.receive(12).catch();
             transport.socketReceive(Buffer.from('Hello World!', 'utf8'));
 
-            expect( () => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw;
         });
 
 
@@ -312,30 +311,28 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
     });
 
     describe('NamedPipe Client Tests', () => {
+        const client = new np.NamedPipeClient('pipeA', new protocol.RequestHandler(), false);
+
         it('creates a new client', () => {
-            let client = new np.NamedPipeClient('pipeA', new protocol.RequestHandler(), false);
             expect(client).to.be.instanceOf(np.NamedPipeClient);
             expect(client.disconnect()).to.not.throw;
         });
 
         it('connects without throwing', () => {
-            let client = new np.NamedPipeClient('pipeA', new protocol.RequestHandler(), false);
             expect(client.connect()).to.not.throw;
             expect(client.disconnect()).to.not.throw;
         });
 
         it('disconnects without throwing', () => {
-            let client = new np.NamedPipeClient('pipeA', new protocol.RequestHandler(), false);
             expect(client.disconnect()).to.not.throw;
         });
 
         it('sends without throwing', (done) => {
-            let client = new np.NamedPipeClient('pipeA', new protocol.RequestHandler(), false);
             let req = new protocol.StreamingRequest();
             req.Verb = 'POST';
             req.Path = 'some/path';
             req.setBody('Hello World!');
-            client.send(req).catch(err => {expect(err).to.be.undefined;}).then(done());
+            client.send(req).catch(err => { expect(err).to.be.undefined; }).then(done());
         });
 
     });
@@ -378,16 +375,19 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             expect(server.isConnected).to.be.false;
             server._receiver = { isConnected: true };
             server._sender = { isConnected: true };
-            expect(server.isConnected).to.be.true;            
+            expect(server.isConnected).to.be.true;
         });
 
         it('sends without throwing', (done) => {
             let server = new np.NamedPipeServer('pipeA', new protocol.RequestHandler(), false);
             expect(server).to.be.instanceOf(np.NamedPipeServer);
             expect(server.start()).to.not.throw;
-            let req = {verb: 'POST', path: '/api/messages', streams: []};
-            server.send(req).catch(err => {expect(err).to.be.undefined;}).then(
-                expect(server.disconnect()).to.not.throw).then(done());
+            let req = { verb: 'POST', path: '/api/messages', streams: [] };
+            server
+                .send(req)
+                .catch(err => { expect(err).to.be.undefined; })
+                .then(expect(server.disconnect()).to.not.throw)
+                .then(done());
         });
 
         it('handles being disconnected', (done) => {
@@ -416,7 +416,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             done();
         });
 
-        
+
         it('calling createNodeServer() should throw if passing in a callback that\'s not a function', () => {
             const stringCallback = 'Not a real callback function.';
             expect(() => createNodeServer(stringCallback)).to.throw(TypeError);
@@ -443,8 +443,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
         });
 
         it('should throw if the callback isn\'t a valid connection listener callback', () => {
-            const notASocket = 'not a Socket';
-            const callback = (notASocket) => { };
+            const callback = () => { };
             const serverFactory = getServerFactory();
             expect(serverFactory(callback)).to.throw;
         });

--- a/libraries/botframework-streaming/tests/StreamingRequest.test.js
+++ b/libraries/botframework-streaming/tests/StreamingRequest.test.js
@@ -1,7 +1,7 @@
-const StreamingRequest = require( '../lib/streamingRequest');
+const StreamingRequest = require('../lib/streamingRequest');
 const HttpContent = require('../lib/httpContentStream');
 const SubscribableStream = require('../lib/subscribableStream');
-const chai = require( 'chai');
+const chai = require('chai');
 var expect = chai.expect;
 
 
@@ -15,10 +15,6 @@ describe('Streaming Extensions Request tests', () => {
     });
 
     it('creates a new instance and a new stream', () => {
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContent.HttpContent(headers, stream1);
         let r = StreamingRequest.StreamingRequest.create('POST', 'some/where', 'hello');
 
         expect(r).to.be.instanceOf(StreamingRequest.StreamingRequest);
@@ -29,7 +25,7 @@ describe('Streaming Extensions Request tests', () => {
     it('creates a new instance with an existing stream', () => {
         let stream1 = new SubscribableStream.SubscribableStream();
         stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
+        let headers = { contentLength: '5', contentType: 'text/plain' };
         let hc = new HttpContent.HttpContent(headers, stream1);
         let r = StreamingRequest.StreamingRequest.create('POST', 'some/where', hc);
 
@@ -39,20 +35,16 @@ describe('Streaming Extensions Request tests', () => {
     });
 
     it('throws when adding an undefined stream to an existing request', () => {
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContent.HttpContent(headers, stream1);
         let r = StreamingRequest.StreamingRequest.create('POST', 'some/where', 'hello');
 
         expect(r).to.be.instanceOf(StreamingRequest.StreamingRequest);
         expect(r.verb).to.equal('POST');
         expect(r.path).to.equal('some/where');
 
-        try{
+        try {
             r.addStream(undefined);
         }
-        catch(err) {
+        catch (err) {
             expect(err.message).to.equal('Argument Undefined Exception: content undefined.');
         }
     });
@@ -93,7 +85,7 @@ describe('Streaming Extensions Request tests', () => {
     });
 
     it('gets the unaltered stream', () => {
-        let h = {contentType: 'stuff'};
+        let h = { contentType: 'stuff' };
         let s = new SubscribableStream.SubscribableStream();
         s.push('text');
         let b = new HttpContent.HttpContent(h, s);
@@ -105,14 +97,12 @@ describe('Streaming Extensions Request tests', () => {
     });
 
     it('can create a request with a body', () => {
-        let h = {contentType: 'stuff'};
+        let h = { contentType: 'stuff' };
         let s = new SubscribableStream.SubscribableStream();
         s.push('text');
         let b = new HttpContent.HttpContent(h, s);
-        let sb = JSON.stringify(b);
         let r = StreamingRequest.StreamingRequest.create('POST');
         r.addStream(b);
-        let c = new HttpContent.HttpContentStream(b);
 
         expect(r.streams[0].content.getStream())
             .equals(b.getStream());

--- a/libraries/botframework-streaming/tests/StreamingResponse.test.js
+++ b/libraries/botframework-streaming/tests/StreamingResponse.test.js
@@ -1,26 +1,15 @@
 const SubscribableStream = require('../lib/subscribableStream');
 const HttpContentStream = require('../lib/httpContentStream');
 const StreamingResponse = require('../lib/streamingResponse');
-const  chai  = require('chai');
+const chai = require('chai');
 var expect = chai.expect;
 
 describe('Streaming Extensions Response Tests', () => {
 
-    it('creates a new instance', () => {
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContentStream.HttpContent(headers, stream1);
-        let r = StreamingResponse.StreamingResponse.create(200, hc);
-
-        expect(r).to.be.instanceOf(StreamingResponse.StreamingResponse);
-        expect(r.statusCode).to.equal(200);
-    });
-
     it('can set the response body', () => {
         let stream1 = new SubscribableStream.SubscribableStream();
         stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
+        let headers = { contentLength: '5', contentType: 'text/plain' };
         let hc = new HttpContentStream.HttpContent(headers, stream1);
         let r = StreamingResponse.StreamingResponse.create(200, hc);
         r.setBody('This is a new body.');


### PR DESCRIPTION
Addresses # 2338

## Description
This PR optimizes the time for the botframework-streaming tests having no impact in the code coverage numbers and reducing the execution time approximately from **561ms** to **298ms**.

## Specific Changes

`Assembler.test.js`
- Moved multiple `StreamManager` instances to a single one at the top of the file to be reused.
- Fixed eslint warnings.

`ContentStream.test.js`
- Moved multiple `StreamManager` instances to a single one at the top of the `describe` to be reused.
- Declared a single `header` to be reused in each test.
- Fixed eslint warnings.

`NamedPipe.test.js`
- Moved multiple `NamedPipeClient` instances to a single one at the top of the `'NamedPipe Client Tests' describe` to be reused.
- Fixed eslint warnings.

`StreamingRequest.test.js`
- Removed unused code.
- Fixed eslint warnings.

`StreamingResponse.test.js`
- Removed `creates a new instance` test since it's contemplated as a part of the `can set the response body` test.
- Fixed eslint warnings.


## Testing
Total coverage has not been affected.
![image](https://user-images.githubusercontent.com/62260472/88961504-84db5b00-d27b-11ea-9d0d-5fac8dffdf08.png)

**botframework-streaming** coverage has not been affected as well.
![image](https://user-images.githubusercontent.com/62260472/88961497-82790100-d27b-11ea-8571-f826be63c92a.png)