### PR TITLE
[Engineering] Lower time for botframework-config tests

### DIFF
--- a/libraries/botframework-config/tests/connect.test.js
+++ b/libraries/botframework-config/tests/connect.test.js
@@ -5,24 +5,40 @@ let bf = require('../lib');
 const testBotPath = require.resolve("./test.bot");
 
 describe("ServiceManipulation", () => {
+    let config;
+
+    before(async () => {
+        config = await bf.BotConfiguration.load(testBotPath);
+    });
+
+    function mapServices(baseConfig, targetConfig) {
+        for (let service of baseConfig.services) {
+            targetConfig.connectService(service);
+        }
+
+        let map = {};
+        for (let service of targetConfig.services) {
+            map[service.id] = service;
+        }
+        return map;
+    };
+
     it("ConnectAssignsUniqueIds", async () => {
         var config = await bf.BotConfiguration.load(testBotPath);
         var config2 = new bf.BotConfiguration();
-        for(let service of config.services) {
+        for (let service of config.services) {
             service.id = undefined;
             config2.connectService(service);
         }
 
-        let map ={};
-        for(let service of config2.services) {
+        let map = {};
+        for (let service of config2.services) {
             assert.ok(!map.hasOwnProperty(service.id), "Duplicate Id assigned");
             map[service.id] = service;
         }
     });
-    
+
     it("FindServices", async () => {
-        var config = await bf.BotConfiguration.load(testBotPath);
-        
         assert.ok(config.findServiceByNameOrId("3"), "should find by id");
         assert.ok(config.findServiceByNameOrId("testInsights"), "should find by name");
         assert.ok(config.findService("3"), "should find by id");
@@ -30,58 +46,32 @@ describe("ServiceManipulation", () => {
     });
 
     it("DisconnectServicesById", async () => {
-        var config = await bf.BotConfiguration.load(testBotPath);
         var config2 = new bf.BotConfiguration();
-        for(let service of config.services) {
-            config2.connectService(service);
-        }
+        var map = mapServices(config, config2);
 
-        let map ={};
-        for(let service of config2.services) {
-            map[service.id] = service;
-        }
-
-        for(let prop in map) {
+        for (let prop in map) {
             config2.disconnectService(map[prop].id);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");
     });
 
     it("DisconnectServicesByNameOrId_UsingId", async () => {
-        var config = await bf.BotConfiguration.load(testBotPath);
         var config2 = new bf.BotConfiguration();
-        for(let service of config.services) {
-            config2.connectService(service);
-        }
+        var map = mapServices(config, config2);
 
-        let map ={};
-        for(let service of config2.services) {
-            map[service.id] = service;
-        }
-
-        for(let prop in map) {
+        for (let prop in map) {
             config2.disconnectServiceByNameOrId(map[prop].id);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");
     });
 
     it("DisconnectByNameOrId_UsingName", async () => {
-        var config = await bf.BotConfiguration.load(testBotPath);
         var config2 = new bf.BotConfiguration();
-        for(let service of config.services) {
-            config2.connectService(service);
-        }
+        var map = mapServices(config, config2);
 
-        let map ={};
-        for(let service of config2.services) {
-            map[service.id] = service;
-        }
-
-        for(let prop in map) {
+        for (let prop in map) {
             config2.disconnectServiceByNameOrId(map[prop].name);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");
     });
-
 });
-

--- a/libraries/botframework-config/tests/encryption.test.js
+++ b/libraries/botframework-config/tests/encryption.test.js
@@ -2,58 +2,50 @@ let assert = require('assert');
 let encrypt = require('../lib/encrypt');
 
 describe("EncryptionTests", () => {
-    it("EncryptDecrypt", () => {
-        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
-        let value = "1234567890";
+    const secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+    const value = "1234567890";
+
+    function encriptDecriptString(value, secret) {
         let encrypted = encrypt.encryptString(value, secret);
         assert.ok(value != encrypted, "encryption failed");
 
         let decrypted = encrypt.decryptString(encrypted, secret);
         assert.ok(value === decrypted, "decryption failed");
+    };
+
+    function encriptDecriptStringDoesNothing(value, secret) {
+        let encrypted = encrypt.encryptString(value, secret);
+        assert.ok(value == encrypted, "encryption failed");
+
+        let decrypted = encrypt.decryptString(encrypted, secret);
+        assert.ok(value === decrypted, "decryption failed");
+    };
+
+    it("EncryptDecrypt", () => {
+        encriptDecriptString(value, secret);
     });
 
     it("EncryptDecryptEmptyDoesNothing", () => {
-        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
         let value = "";
-        let encrypted = encrypt.encryptString(value, secret);
-        assert.ok(value == encrypted, "encryption failed");
-
-        let decrypted = encrypt.decryptString(encrypted, secret);
-        assert.ok(value === decrypted, "decryption failed");
+        encriptDecriptStringDoesNothing(value, secret);
     });
 
     it("EncryptDecryptNullDoesNothing", () => {
-        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
         let value = null;
-        let encrypted = encrypt.encryptString(value, secret);
-        assert.ok(value == encrypted, "encryption failed");
-
-        let decrypted = encrypt.decryptString(encrypted, secret);
-        assert.ok(value === decrypted, "decryption failed");
+        encriptDecriptStringDoesNothing(value, secret);
     });
 
     it("EncryptDecryptUndefinedDoesNothing", () => {
-        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
         let value = undefined;
-        let encrypted = encrypt.encryptString(value, secret);
-        assert.ok(value == encrypted, "encryption failed");
-
-        let decrypted = encrypt.decryptString(encrypted, secret);
-        assert.ok(value === decrypted, "decryption failed");
+        encriptDecriptStringDoesNothing(value, secret);
     });
 
     it("GenerateKeyWorks", () => {
         let secret = encrypt.generateKey();
-        let value = "1234567890";
-        let encrypted = encrypt.encryptString(value, secret);
-        assert.ok(value != encrypted, "encryption failed");
-
-        let decrypted = encrypt.decryptString(encrypted, secret);
-        assert.ok(value === decrypted, "decryption failed");
+        encriptDecriptString(value, secret)
     });
 
     it("EncryptWithNullSecretThrows", () => {
-        let value = "1234567890";
         try {
             encrypt.encryptString(value);
             assert.fail("did not throw error or exception");
@@ -64,27 +56,24 @@ describe("EncryptionTests", () => {
     });
 
     it("DecryptWithNullSecretThrows", () => {
-        let value = "1234567890";
         let secret = encrypt.generateKey();
         let encrypted = encrypt.encryptString(value, secret);
 
         try {
-            let nonresult = encrypt.decryptString(encrypted, null);
+            encrypt.decryptString(encrypted, null);
             assert.fail("did not throw error or exception");
         }
         catch (Error) {
             assert.ok(true);
         }
-
     });
 
     it("DecryptWithBadSecretThrows", () => {
-        let value = "1234567890";
         let secret = encrypt.generateKey();
         let encrypted = encrypt.encryptString(value, secret);
 
         try {
-            let nonresult = encrypt.decryptString(encrypted, "bad");
+            encrypt.decryptString(encrypted, "bad");
             assert.fail("did not throw error or exception");
         }
         catch (Error) {
@@ -92,12 +81,11 @@ describe("EncryptionTests", () => {
         }
 
         try {
-            let nonresult = encrypt.decryptString(encrypted, encrypt.generateKey());
+            encrypt.decryptString(encrypted, encrypt.generateKey());
             assert.fail("Decrypt with different key should throw");
         }
         catch (Error) {
             assert.ok(true);
         }
-
     });
 });


### PR DESCRIPTION
Addresses # 2338

## Description
This PR optimizes the time for the [botframework-config](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botframework-config) tests having no impact in the code coverage and reducing the execution time approximately from **184ms** to **135ms**.

## Specific Changes

`connect.test.js`
- Moved multiple `BotConfiguration` instances to a single one at the top of the file to be reused.
- Created the _mapServices_ function to reduce duplicated code in the tests.
- Fixed eslint warnings.

`encryption.test.js`
- Moved  `secret` and `value` variables as constants outside the tests to be reused.
- Created the _encriptDecriptString_ function to reduce duplicated code.

## Testing
Total coverage has not been affected.
![image](https://user-images.githubusercontent.com/44245136/88967951-e6ec8e00-d284-11ea-89b4-4bf9bd0a66c0.png)

The execution time was reduced.
![image](https://user-images.githubusercontent.com/44245136/88968096-2b782980-d285-11ea-8876-630a99c1286c.png)
