### PR TITLE
[Engineering] Lower time for botbuilder-testing tests

### DIFF
--- a/libraries/botbuilder-testing/tests/dialogTestClient.test.js
+++ b/libraries/botbuilder-testing/tests/dialogTestClient.test.js
@@ -37,31 +37,15 @@ describe('DialogTestClient', function() {
         assert(client.dialogTurnResult.status == DialogTurnStatus.complete, 'dialog did not end properly');
     });
 
-    it('should process a single turn waterfall dialog', async function() {
-
-        let dialog = new WaterfallDialog('waterfall', [
-            async(step) => {
-                await step.context.sendActivity('hello');
-                return step.endDialog();
-            }
-        ]);
-
-        let client = new DialogTestClient('test', dialog);
-        let reply = await client.sendActivity('hello');
-        assert(reply.text == 'hello', 'dialog responded with incorrect message');
-        assert(reply.channelId == 'test', 'test channel id didnt get set');
-        assert(client.dialogTurnResult.status == DialogTurnStatus.complete, 'dialog did not end properly');
-    });
-
     it('should process a 2 turn waterfall dialog', async function() {
 
         let dialog = new WaterfallDialog('waterfall', [
-            async(step) => {
+            async (step) => {
                 await step.context.sendActivity('hello');
                 await step.context.sendActivity({type: 'typing'});
                 return step.next();
             },
-            async(step) => {
+            async (step) => {
                 await step.context.sendActivity('hello 2');
                 return step.endDialog();
             },
@@ -85,10 +69,10 @@ describe('DialogTestClient', function() {
                 super(id);
 
                 let dialog = new WaterfallDialog('waterfall', [
-                    async(step) => {
+                    async (step) => {
                         return step.prompt('textPrompt', 'Tell me something');
                     },
-                    async(step) => {
+                    async (step) => {
                         await step.context.sendActivity('you said: ' + step.result);
                         return step.next();
                     },


### PR DESCRIPTION
Addresses # 2338

## Description
This PR optimizes the time for the botbuilder-testing tests having no impact in the code coverage numbers and reducing the execution time approximately from 155ms to 68ms.

## Specific Changes
Changes in dialogTestClient.test.js

- Deleted a duplicate test from the file while maintaining the same code coverage.

## Testing
Before:
![image](https://user-images.githubusercontent.com/67334049/88839341-ca225e80-d18f-11ea-8835-79011535c90f.png)

After:
![image](https://user-images.githubusercontent.com/67334049/88840043-c04d2b00-d190-11ea-9822-8fb87e5ec939.png)