### PR TITLE
Port AssertReply_Assertions_Failed script from .NET

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
@@ -38,7 +38,7 @@ export class AssertReplyActivity implements TestAction {
                 const assertion = this.assertions[i];
                 const { value, error } = engine.parse(assertion).tryEvaluate(activity);
                 if (!value || error) {
-                    throw new Error(`${ this.description } ${ assertion }`);
+                    throw new Error(`${ this.description } ${ assertion } ${ JSON.stringify(activity) }`);
                 }
             }
         }

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_AssertReply_Assertions_Failed.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_AssertReply_Assertions_Failed.test.dialog
@@ -1,0 +1,19 @@
+{
+    "$schema": "../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test AssertReply",
+    "dialog": "simpleHello",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hello"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "hi User1",
+            "assertions": [
+                "text.length == 0"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
@@ -1,3 +1,4 @@
+const assert = require ('assert');
 const path = require('path');
 const { TestRunner } = require('../lib');
 
@@ -7,6 +8,15 @@ describe('TestScriptTests', function() {
 
     it('AssertReply_Assertions', async () => {
         await testRunner.runTestScript('TestScriptTests_AssertReply_Assertions');
+    });
+
+    it('AssertReply_Assertions_Failed', async () => {
+        try {
+            await testRunner.runTestScript('TestScriptTests_AssertReply_Assertions_Failed');
+        } 
+        catch (error) {
+            assert(error.message.includes('\"text\":\"hi User1\"'), `assertion should have failed.`);
+        }
     });
 
     it('AssertReply_Exact', async () => {


### PR DESCRIPTION
Addresses # 2731

## Description
This PR ports from .NET a new test script `TestScriptTests_AssertReply_Assertions_Failed.test.dialog` and the unit test for it.

## Specific Changes
  - Added new `TestScriptTests_AssertReply_Assertions_Failed.test.dialog` file with a new test script.
  - Updated [testScript.test](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js) file to add a new unit test for the new script.
  - Updated [AssertReplyActivity](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts) class to return the activity in the error message in _validateReply_ method.

## Testing
The following image shows the new test passing.
![image](https://user-images.githubusercontent.com/44245136/93929646-87de4f00-fcf2-11ea-9d8d-7c44fed93f0c.png)
