### PR TITLE
Add Chrome functional tests back to .yaml

### DIFF
--- a/libraries/browser-functional-tests/browser-tests-build-ci.yml
+++ b/libraries/browser-functional-tests/browser-tests-build-ci.yml
@@ -73,13 +73,13 @@ steps:
     workingDir: 'libraries/browser-functional-tests'
     verbose: false
 
-#- task: Npm@1
-#  displayName: 'run chrome tests'
-#  inputs:
-#    command: custom
-#    workingDir: ''
-#    verbose: false
-#    customCommand: 'run browser-functional-test chrome'
+- task: Npm@1
+  displayName: 'run chrome tests'
+  inputs:
+   command: custom
+   workingDir: ''
+   verbose: false
+   customCommand: 'run browser-functional-test chrome'
 
 - task: Npm@1
   displayName: 'run firefox tests'

--- a/libraries/browser-functional-tests/package.json
+++ b/libraries/browser-functional-tests/package.json
@@ -4,7 +4,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^83.0.0",
+    "chromedriver": "^85.0.0",
     "dotenv": "^8.0.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.2.4",


### PR DESCRIPTION
Fixes # 2770

## Description
This PRs solves the issue with Chrome Functional Tests by upgrading the _chromedriver_ version from `^83.0.0` to `^85.0.0`.

The reason was that on the latest windows-agent image, Chrome was updated from 84 to 85 version. This update changed location where chrome is installed ([more details](https://developercommunity.visualstudio.com/content/problem/1170486/selenium-ui-test-can-no-longer-find-chrome-binary.html)).

## Specific Changes
  - Upgraded chromedriver version in [package.json](https://github.com/microsoft/botbuilder-js/blob/master/libraries/browser-functional-tests/package.json). 
  - Enable Chrome tests in [browser-tests-build-ci.yml](https://github.com/microsoft/botbuilder-js/blob/master/libraries/browser-functional-tests/browser-tests-build-ci.yml). 

## Testing
The following image shows the tests passing after upgrading the _chromedriver_  version.

![image](https://user-images.githubusercontent.com/44245136/94032678-8fefca80-fd96-11ea-8f6d-10e41b76ee07.png)

