### PR TITLE
[JSDoc] Add missing documentation for botbuilder-azure

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,7 @@
             "files": ["libraries/botbuilder-azure/src/*.ts", "libraries/botbuilder-azure/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -366,7 +366,10 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
 
     /**
      * Create a Blob Service.
-     * @param param0 Settings required for configuring the Blob Service (storage account or connection string, access key and host).
+     * @param param0 Settings required for configuring the Blob Service.
+     * @param param0.storageAccountOrConnectionString Storage account or connection string.
+     * @param param0.storageAccessKey Storage access key.
+     * @param param0.host Blob Service host.
      */
     private createBlobService({ storageAccountOrConnectionString, storageAccessKey, host }: BlobStorageSettings): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -55,7 +55,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
             throw new Error('Invalid container name.');
         }
 
-        this.settings = {...settings};
+        this.settings = { ...settings };
         this.client = this.createBlobService(this.settings);
     }
 
@@ -148,7 +148,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         const prefix: string = this.getDirName(channelId) + '/';
         const token: azure.common.ContinuationToken = null;
 
-        const container =  await this.ensureContainerExists();
+        const container = await this.ensureContainerExists();
         const transcripts = await this.getTranscriptsFolders([],
             container.name,
             prefix,
@@ -182,7 +182,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         const prefix: string = this.getDirName(channelId, conversationId) + '/';
         const token: azure.common.ContinuationToken = null;
 
-        const container =  await this.ensureContainerExists();
+        const container = await this.ensureContainerExists();
         const conversationBlobs = await this.getConversationsBlobs([], container.name, prefix, token);
         await Promise.all(conversationBlobs.map(blob => this.client.deleteBlobIfExistsAsync(blob.container, blob.name)));
     }
@@ -190,9 +190,10 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
     /**
      * Parse a BlobResult as an activity.
      * @param blob BlobResult to parse as an activity.
+     * @returns The parsed activity.
      */
     private async blobToActivity(blob: azure.BlobService.BlobResult): Promise<Activity> {
-    	const content = await this.client.getBlobToTextAsync(blob.container, blob.name);
+        const content = await this.client.getBlobToTextAsync(blob.container, blob.name);
         const activity: Activity = JSON.parse(content as any) as Activity;
         activity.timestamp = new Date(activity.timestamp);
 
@@ -210,7 +211,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         startDate: Date,
         token: azure.common.ContinuationToken
     ): Promise<azure.BlobService.BlobResult[]> {
-    	const listBlobResult = await this.client.listBlobsSegmentedWithPrefixAsync(container, prefix, token, { include: 'metadata' });
+        const listBlobResult = await this.client.listBlobsSegmentedWithPrefixAsync(container, prefix, token, { include: 'metadata' });
         listBlobResult.entries.some(blob => {
             const timestamp: Date = new Date(blob.metadata.timestamp);
             if (timestamp >= startDate) {
@@ -246,8 +247,8 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         channelId: string,
         token: azure.common.ContinuationToken
     ): Promise<TranscriptInfo[]> {
-    	const result = await this.client.listBlobDirectoriesSegmentedWithPrefixAsync(container, prefix, token);
-    	result.entries.some(blob => {
+        const result = await this.client.listBlobDirectoriesSegmentedWithPrefixAsync(container, prefix, token);
+        result.entries.some(blob => {
             const conversation: TranscriptInfo = {
                 channelId: channelId,
                 id: blob.name.split('/').filter((part: string) => part).slice(-1).pop(),
@@ -281,7 +282,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         prefix: string,
         token: azure.common.ContinuationToken
     ): Promise<azure.BlobService.BlobResult[]> {
-    	const result = await this.client.listBlobsSegmentedWithPrefixAsync(container, prefix, token, null);
+        const result = await this.client.listBlobsSegmentedWithPrefixAsync(container, prefix, token, null);
         blobs = blobs.concat(result.entries.map((blob: azure.BlobService.BlobResult) => {
             blob.container = container;
 
@@ -296,6 +297,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
     /**
      * Check if a container name is valid.
      * @param container String representing the container name to validate.
+     * @returns A boolean value that indicates whether or not the name is valid.
      */
     private checkContainerName(container: string): boolean {
         return ContainerNameCheck.test(container);
@@ -304,6 +306,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
     /**
      * Get the blob name based on the activity.
      * @param activity Activity to get the blob name from.
+     * @returns The blob name.
      */
     private getBlobName(activity: Activity): string {
         const channelId: string = this.sanitizeKey(activity.channelId);
@@ -311,25 +314,27 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         const timestamp: string = this.sanitizeKey(this.getTicks(activity.timestamp));
         const activityId: string = this.sanitizeKey(activity.id);
 
-        return `${ channelId }/${ conversationId }/${ timestamp }-${ activityId }.json`;
+        return `${channelId}/${conversationId}/${timestamp}-${activityId}.json`;
     }
 
     /**
      * Get the directory name.
      * @param channelId Channel Id.
      * @param conversationId Id of the conversation to get the directory name from.
+     * @returns The sanitized directory name.
      */
     private getDirName(channelId: string, conversationId?: string): string {
         if (!conversationId) {
             return this.sanitizeKey(channelId);
         }
 
-        return `${ this.sanitizeKey(channelId) }/${ this.sanitizeKey(conversationId) }`;
+        return `${this.sanitizeKey(channelId)}/${this.sanitizeKey(conversationId)}`;
     }
 
     /**
      * Escape a given key to be compatible for use with BlobStorage.
      * @param key Key to be sanitized(scaped).
+     * @returns The sanitized key.
      */
     private sanitizeKey(key: string): string {
         return escape(key);
@@ -363,7 +368,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * Create a Blob Service.
      * @param param0 Settings required for configuring the Blob Service (storage account or connection string, access key and host).
      */
-    private createBlobService({storageAccountOrConnectionString, storageAccessKey, host}: BlobStorageSettings): BlobServiceAsync {
+    private createBlobService({ storageAccountOrConnectionString, storageAccessKey, host }: BlobStorageSettings): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {
             throw new Error('The storageAccountOrConnectionString parameter is required.');
         }
@@ -377,7 +382,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         // The perfect use case for a Proxy
         return new Proxy(<BlobServiceAsync>{}, {
             get(target: azure.services.blob.blobservice.BlobService, p: PropertyKey): Promise<any> {
-				const prop = p.toString().endsWith('Async') ? p.toString().replace('Async', '') :p;
+                const prop = p.toString().endsWith('Async') ? p.toString().replace('Async', '') : p;
                 return target[p] || (target[p] = denodeify(blobService, blobService[prop]));
             }
         }) as BlobServiceAsync;

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -98,7 +98,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * Get activities for a conversation (Aka the transcript)
      * @param channelId Channel Id.
      * @param conversationId Conversation Id.
-     * @param continuationToken Continuatuation token to page through results.
+     * @param continuationToken Continuation token to page through results.
      * @param startDate Earliest time to include.
      */
     public async getTranscriptActivities(
@@ -187,6 +187,10 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         await Promise.all(conversationBlobs.map(blob => this.client.deleteBlobIfExistsAsync(blob.container, blob.name)));
     }
 
+    /**
+     * Parse a BlobResult as an activity.
+     * @param blob BlobResult to parse as an activity.
+     */
     private async blobToActivity(blob: azure.BlobService.BlobResult): Promise<Activity> {
     	const content = await this.client.getBlobToTextAsync(blob.container, blob.name);
         const activity: Activity = JSON.parse(content as any) as Activity;
@@ -195,6 +199,9 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return activity;
     }
 
+    /**
+     * @private 
+     */
     private async getActivityBlobs(
         blobs: azure.BlobService.BlobResult[],
         container: string,
@@ -228,6 +235,9 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return blobs;
     }
 
+    /**
+     * @private
+     */
     private async getTranscriptsFolders(
         transcripts: TranscriptInfo[],
         container: string,
@@ -262,6 +272,9 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return transcripts;
     }
 
+    /**
+     * @private
+     */
     private async getConversationsBlobs(
         blobs: azure.BlobService.BlobResult[],
         container: string,
@@ -280,10 +293,18 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return blobs;
     }
 
+    /**
+     * Check if a container name is valid.
+     * @param container String representing the container name to validate.
+     */
     private checkContainerName(container: string): boolean {
         return ContainerNameCheck.test(container);
     }
 
+    /**
+     * Get the blob name based on the activity.
+     * @param activity Activity to get the blob name from.
+     */
     private getBlobName(activity: Activity): string {
         const channelId: string = this.sanitizeKey(activity.channelId);
         const conversationId: string = this.sanitizeKey(activity.conversation.id);
@@ -293,6 +314,11 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return `${ channelId }/${ conversationId }/${ timestamp }-${ activityId }.json`;
     }
 
+    /**
+     * Get the directory name.
+     * @param channelId Channel Id.
+     * @param conversationId Id of the conversation to get the directory name from.
+     */
     private getDirName(channelId: string, conversationId?: string): string {
         if (!conversationId) {
             return this.sanitizeKey(channelId);
@@ -301,10 +327,17 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return `${ this.sanitizeKey(channelId) }/${ this.sanitizeKey(conversationId) }`;
     }
 
+    /**
+     * Escape a given key to be compatible for use with BlobStorage.
+     * @param key Key to be sanitized(scaped).
+     */
     private sanitizeKey(key: string): string {
         return escape(key);
     }
 
+    /**
+     * @private
+     */
     private getTicks(timestamp: Date): string {
         const epochTicks = 621355968000000000; // the number of .net ticks at the unix epoch
         const ticksPerMillisecond = 10000; // there are 10000 .net ticks per millisecond
@@ -314,6 +347,9 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return ticks.toString(16);
     }
 
+    /**
+     * Delay Container creation if it does not exist.
+     */
     private ensureContainerExists(): Promise<azure.BlobService.ContainerResult> {
         const key: string = this.settings.containerName;
         if (!AzureBlobTranscriptStore[checkedCollectionsKey][key]) {
@@ -323,6 +359,10 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         return AzureBlobTranscriptStore[checkedCollectionsKey][key];
     }
 
+    /**
+     * Create a Blob Service.
+     * @param param0 Settings required for configuring the Blob Service (storage account or connection string, access key and host).
+     */
     private createBlobService({storageAccountOrConnectionString, storageAccessKey, host}: BlobStorageSettings): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {
             throw new Error('The storageAccountOrConnectionString parameter is required.');

--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -129,6 +129,10 @@ export class BlobStorage implements Storage {
         this.useEmulator = settings.storageAccountOrConnectionString === 'UseDevelopmentStorage=true;';
     }
 
+    /**
+     * Retrieve entities from the configured blob container.
+     * @param keys An array of entity keys.
+     */
     public read(keys: string[]): Promise<StoreItems> {
         if (!keys) {
             throw new Error('Please provide at least one key to read from storage.');
@@ -169,6 +173,10 @@ export class BlobStorage implements Storage {
         }).catch((error: Error) => { throw error; });
     }
 
+    /**
+     * Store a new entity in the configured blob container.
+     * @param changes The changes to write to storage.
+     */
     public write(changes: StoreItems): Promise<void> {
         if (!changes) {
             throw new Error('Please provide a StoreItems with changes to persist.');
@@ -221,6 +229,10 @@ export class BlobStorage implements Storage {
         });
     }
 
+    /**
+     * Delete entity blobs from the configured container.
+     * @param keys An array of entity keys.
+     */
     public delete(keys: string[]): Promise<void> {
         if (!keys) {
             throw new Error('Please provide at least one key to delete from storage.');
@@ -241,7 +253,7 @@ export class BlobStorage implements Storage {
 
     /**
      * Get a blob name validated representation of an entity to be used as a key.
-     * @param key The key used to identify the entity
+     * @param key The key used to identify the entity.
      */
     private sanitizeKey(key: string): string {
         if (!key || key.length < 1) {
@@ -257,10 +269,17 @@ export class BlobStorage implements Storage {
         return escape(validKey).substr(0, 1024);
     }
 
+    /**
+     * Check if a container name is valid.
+     * @param container String representing the container name to validate.
+     */
     private checkContainerName(container: string): boolean {
         return ContainerNameCheck.test(container);
     }
 
+    /**
+     * Delay Container creation if it does not exist.
+     */
     private ensureContainerExists(): Promise<azure.BlobService.ContainerResult> {
         const key: string = this.settings.containerName;
         if (!checkedCollections[key]) {
@@ -270,6 +289,12 @@ export class BlobStorage implements Storage {
         return checkedCollections[key];
     }
 
+    /**
+     * Create a Blob Service.
+     * @param storageAccountOrConnectionString Azure CloudStorageAccount instance or Connection String.
+     * @param storageAccessKey Blob Service Access Key.
+     * @param host Blob Service Host.
+     */
     private createBlobService(storageAccountOrConnectionString: string, storageAccessKey: string, host: any): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {
             throw new Error('The storageAccountOrConnectionString parameter is required.');
@@ -293,7 +318,10 @@ export class BlobStorage implements Storage {
         } as any;
     }
 
-    // turn a cb based azure method into a Promisified one
+    /**
+     * @private
+     * Turn a cb based azure method into a Promisified one.
+     */
     private denodeify<T>(thisArg: any, fn: Function): (...args: any[]) => Promise<T> {
         return (...args: any[]): Promise<T> => {
             return new Promise<T>((resolve: any, reject: any): void => {

--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -132,6 +132,7 @@ export class BlobStorage implements Storage {
     /**
      * Retrieve entities from the configured blob container.
      * @param keys An array of entity keys.
+     * @returns The read items.
      */
     public read(keys: string[]): Promise<StoreItems> {
         if (!keys) {
@@ -272,6 +273,7 @@ export class BlobStorage implements Storage {
     /**
      * Check if a container name is valid.
      * @param container String representing the container name to validate.
+     * @returns A boolean value that indicates whether or not the name is valid.
      */
     private checkContainerName(container: string): boolean {
         return ContainerNameCheck.test(container);
@@ -294,6 +296,7 @@ export class BlobStorage implements Storage {
      * @param storageAccountOrConnectionString Azure CloudStorageAccount instance or Connection String.
      * @param storageAccessKey Blob Service Access Key.
      * @param host Blob Service Host.
+     * @returns the blob services created.
      */
     private createBlobService(storageAccountOrConnectionString: string, storageAccessKey: string, host: any): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {

--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -296,7 +296,7 @@ export class BlobStorage implements Storage {
      * @param storageAccountOrConnectionString Azure CloudStorageAccount instance or Connection String.
      * @param storageAccessKey Blob Service Access Key.
      * @param host Blob Service Host.
-     * @returns the blob services created.
+     * @returns The blob services created.
      */
     private createBlobService(storageAccountOrConnectionString: string, storageAccessKey: string, host: any): BlobServiceAsync {
         if (!storageAccountOrConnectionString) {

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -107,7 +107,7 @@ class DocumentStoreItem {
 }
 
 /**
- * Implements an CosmosDB based storage provider using partitioning for a bot.
+ * Implements a CosmosDB based storage provider using partitioning for a bot.
  */
 export class CosmosDbPartitionedStorage implements Storage {
     private container: Container;
@@ -147,6 +147,10 @@ export class CosmosDbPartitionedStorage implements Storage {
         this.cosmosDbStorageOptions = cosmosDbStorageOptions;
     }
 
+    /**
+     * Read one or more items with matching keys from the Cosmos DB container.
+     * @param keys A collection of Ids for each item to be retrieved.
+     */
     public async read(keys: string[]): Promise<StoreItems> {
         if (!keys) { throw new ReferenceError(`Keys are required when reading.`); }
         else if (keys.length === 0) { return {}; }
@@ -183,6 +187,10 @@ export class CosmosDbPartitionedStorage implements Storage {
         return storeItems;
     }
 
+    /**
+     * Insert or update one or more items into the Cosmos DB container. 
+     * @param changes Dictionary of items to be inserted or updated indexed by key.
+     */
     public async write(changes: StoreItems): Promise<void> {
         if (!changes) { throw new ReferenceError(`Changes are required when writing.`); }
         else if (changes.length === 0) { return; }
@@ -212,6 +220,10 @@ export class CosmosDbPartitionedStorage implements Storage {
         }));
     }
 
+    /**
+     * Delete one or more items from the Cosmos DB container.
+     * @param keys Array of Ids for the items to be deleted.
+     */
     public async delete(keys: string[]): Promise<void> {
 
         await this.initialize();
@@ -249,6 +261,9 @@ export class CosmosDbPartitionedStorage implements Storage {
         }
     }
     
+    /**
+     * @private
+     */
     private async getOrCreateContainer(): Promise<Container> {
         let createIfNotExists = !this.cosmosDbStorageOptions.compatibilityMode;
         let container;
@@ -291,6 +306,9 @@ export class CosmosDbPartitionedStorage implements Storage {
         }
     }
 
+    /**
+     * @private
+     */
     private getPartitionKey(key) {
         return this.compatabilityModePartitionKey ? undefined : key;
     }

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -150,7 +150,7 @@ export class CosmosDbPartitionedStorage implements Storage {
     /**
      * Read one or more items with matching keys from the Cosmos DB container.
      * @param keys A collection of Ids for each item to be retrieved.
-     * @returns the read items.
+     * @returns The read items.
      */
     public async read(keys: string[]): Promise<StoreItems> {
         if (!keys) { throw new ReferenceError(`Keys are required when reading.`); }

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -82,7 +82,7 @@ class DocumentStoreItem {
      * Gets or sets the un-sanitized Id/Key.
      * 
      */
-    public realId: string 
+    public realId: string
     /**
      * Gets or sets the persisted object.
      */
@@ -99,7 +99,7 @@ class DocumentStoreItem {
     }
 
     // We can't make the partitionKey optional AND have it auto-get this.realId, so we'll use a constructor
-    public constructor(storeItem: { id: string; realId: string; document: object; eTag?: string}) {
+    public constructor(storeItem: { id: string; realId: string; document: object; eTag?: string }) {
         for (let prop in storeItem) {
             this[prop] = storeItem[prop];
         }
@@ -133,7 +133,7 @@ export class CosmosDbPartitionedStorage implements Storage {
             cosmosDbStorageOptions.compatibilityMode = true;
         }
         if (cosmosDbStorageOptions.keySuffix) {
-            if (cosmosDbStorageOptions.compatibilityMode){
+            if (cosmosDbStorageOptions.compatibilityMode) {
                 throw new ReferenceError('compatibilityMode cannot be true while using a keySuffix.');
             }
             // In order to reduce key complexity, we do not allow invalid characters in a KeySuffix
@@ -150,6 +150,7 @@ export class CosmosDbPartitionedStorage implements Storage {
     /**
      * Read one or more items with matching keys from the Cosmos DB container.
      * @param keys A collection of Ids for each item to be retrieved.
+     * @returns the read items.
      */
     public async read(keys: string[]): Promise<StoreItems> {
         if (!keys) { throw new ReferenceError(`Keys are required when reading.`); }
@@ -198,7 +199,7 @@ export class CosmosDbPartitionedStorage implements Storage {
         await this.initialize();
 
         await Promise.all(Object.keys(changes).map(async (k: string): Promise<void> => {
-            const changesCopy: any = {...changes[k]};
+            const changesCopy: any = { ...changes[k] };
 
             // Remove eTag from JSON object that was copied from IStoreItem.
             // The ETag information is updated as an _etag attribute in the document metadata.
@@ -236,7 +237,7 @@ export class CosmosDbPartitionedStorage implements Storage {
                     .delete();
             } catch (err) {
                 // If trying to delete a document that doesn't exist, do nothing. Otherwise, throw
-                if (err.code === 404) { } 
+                if (err.code === 404) { }
                 else {
                     this.throwInformativeError('Unable to delete document', err);
                 }
@@ -256,25 +257,25 @@ export class CosmosDbPartitionedStorage implements Storage {
                     ...this.cosmosDbStorageOptions.cosmosClientOptions,
                 });
             }
-            const dbAndContainerKey = `${ this.cosmosDbStorageOptions.databaseId }-${ this.cosmosDbStorageOptions.containerId }`;
+            const dbAndContainerKey = `${this.cosmosDbStorageOptions.databaseId}-${this.cosmosDbStorageOptions.containerId}`;
             this.container = await _doOnce.waitFor(dbAndContainerKey, async (): Promise<Container> => await this.getOrCreateContainer());
         }
     }
-    
+
     /**
      * @private
      */
     private async getOrCreateContainer(): Promise<Container> {
         let createIfNotExists = !this.cosmosDbStorageOptions.compatibilityMode;
         let container;
-        if(this.cosmosDbStorageOptions.compatibilityMode) {
+        if (this.cosmosDbStorageOptions.compatibilityMode) {
             try {
                 container = await this.client
-                                    .database(this.cosmosDbStorageOptions.databaseId)
-                                    .container(this.cosmosDbStorageOptions.containerId);
+                    .database(this.cosmosDbStorageOptions.databaseId)
+                    .container(this.cosmosDbStorageOptions.containerId);
                 const partitionKeyPath = await container.readPartitionKeyDefinition();
                 const paths = partitionKeyPath.resource.paths;
-                if(paths) {
+                if (paths) {
                     // Containers created with CosmosDbStorage had no partition key set, so the default was '/_partitionKey'.
                     if (paths.indexOf('/_partitionKey') !== -1) {
                         this.compatabilityModePartitionKey = true;
@@ -317,11 +318,11 @@ export class CosmosDbPartitionedStorage implements Storage {
      * The Cosmos JS SDK doesn't return very descriptive errors and not all errors contain a body. 
      * This provides more detailed errors and err['message'] prevents ReferenceError
      */
-    private throwInformativeError(prependedMessage: string, err: Error|object|string): void {
+    private throwInformativeError(prependedMessage: string, err: Error | object | string): void {
         if (typeof err === 'string') {
             err = new Error(err);
         }
-        err['message'] = `[${ prependedMessage }] ${ err['message'] }`;
+        err['message'] = `[${prependedMessage}] ${err['message']}`;
         throw err;
     }
 }

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -133,7 +133,11 @@ export class CosmosDbStorage implements Storage {
         this.documentCollectionCreationRequestOption = settings.documentCollectionRequestOptions;
     }
 
-    public read(keys: string[]): Promise<StoreItems> {        
+    /**
+     * Read storage items from storage.
+     * @param keys Keys of the items to read from the store.
+     */
+    public read(keys: string[]): Promise<StoreItems> {
         if (!keys || keys.length === 0) {
             // No keys passed in, no result to return.
             return Promise.resolve({});
@@ -199,6 +203,10 @@ export class CosmosDbStorage implements Storage {
         });
     }
 
+    /**
+     * Write storage items to storage.
+     * @param changes Items to write to storage, indexed by key.
+     */
     public write(changes: StoreItems): Promise<void> {
         if (!changes || Object.keys(changes).length === 0) {
             return Promise.resolve();
@@ -244,6 +252,10 @@ export class CosmosDbStorage implements Storage {
         });
     }
 
+    /**
+     * Delete storage items from storage.
+     * @param keys Keys of the items to remove from the store.
+     */
     public delete(keys: string[]): Promise<void> {
         if (!keys || keys.length === 0) {
             return Promise.resolve();

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -136,7 +136,7 @@ export class CosmosDbStorage implements Storage {
     /**
      * Read storage items from storage.
      * @param keys Keys of the items to read from the store.
-     * @returns the read items.
+     * @returns The read items.
      */
     public read(keys: string[]): Promise<StoreItems> {
         if (!keys || keys.length === 0) {

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -136,6 +136,7 @@ export class CosmosDbStorage implements Storage {
     /**
      * Read storage items from storage.
      * @param keys Keys of the items to read from the store.
+     * @returns the read items.
      */
     public read(keys: string[]): Promise<StoreItems> {
         if (!keys || keys.length === 0) {

--- a/libraries/botbuilder-azure/src/doOnce.ts
+++ b/libraries/botbuilder-azure/src/doOnce.ts
@@ -6,11 +6,19 @@
  * Licensed under the MIT License.
  */
 
+ /**
+  * Task to perform only one time.
+  */
 export class DoOnce<T> {
     private task: {
         [key: string]: Promise<T>;
     } = {};
 
+    /**
+     * Wait for the task to be executed.
+     * @param key Key of the task.
+     * @param fn Function to perform.
+     */
     public waitFor(key: string, fn: () => Promise<T>): Promise<T> {
         if (!this.task[key]) {
             this.task[key] = fn();


### PR DESCRIPTION
Addresses # 2602

## Description
This PR replaces `warn` with `error` in the `jsdoc/require-jsdoc` rule in [.eslintrc.json](https://github.com/microsoft/botbuilder-js/blob/master/.eslintrc.json#L87) file for [botbuilder-azure](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-azure) and adds all the missing documentation based on the errors thrown. 
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes

  - Updated `jsdoc/require-jsdoc` in `.eslintrc.json` from `warn` to `error`.
  - Added JSDoc comments in all public methods and some of the private ones. 

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94269673-598c8980-ff15-11ea-9133-b0fed6673aee.png)
