### PR TITLE
[JSDoc] Add missing documentation for botbuilder/skills

### DIFF
--- a/libraries/botbuilder/src/activityValidator.ts
+++ b/libraries/botbuilder/src/activityValidator.ts
@@ -8,6 +8,10 @@
 
 import { Activity, ActivityTimestamps } from 'botbuilder-core';
 
+/**
+ * Validates an activity and formats the timestamp fields.
+ * @param activity Activity to be validated.
+ */
 export function validateAndFixActivity(activity: Activity): Activity {
     if (typeof activity !== 'object') { throw new Error(`validateAndFixActivity(): invalid request body.`); }
     if (typeof activity.type !== 'string') { throw new Error(`validateAndFixActivity(): missing activity type.`); }
@@ -21,7 +25,7 @@ export function validateAndFixActivity(activity: Activity): Activity {
     }
     if (typeof activity.localTimestamp === 'string') {
         (activity as ActivityTimestamps).rawLocalTimestamp = activity.localTimestamp;
-        activity.localTimestamp = new Date(activity.localTimestamp); 
+        activity.localTimestamp = new Date(activity.localTimestamp);
     }
     return activity;
-};
+}

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -33,6 +33,11 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     private static readonly appCredentialMapCache: Map<string, AppCredentials> = new Map<string, AppCredentials>();
     private readonly credentialProvider: ICredentialProvider;
 
+    /**
+     * Creates a new instance of the [BotFrameworkHttpClient](xref:botbuilder.BotFrameworkHttpClient) class
+     * @param credentialProvider An instance of ICredentialProvider.
+     * @param channelService Optional. The channel service.
+     */
     public constructor(credentialProvider: ICredentialProvider, channelService?: string) {
         if (!credentialProvider) {
             throw new Error('BotFrameworkHttpClient(): missing credentialProvider');
@@ -43,7 +48,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     }
 
     /**
-     * Forwards an activity to a another bot.
+     * Forwards an activity to another bot.
      * @remarks
      * 
      * @template T The type of body in the InvokeResponse. 
@@ -56,6 +61,18 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
      */
     public async postActivity<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>>
     public async postActivity(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse>
+    /**
+     * Forwards an activity to another bot.
+     * @remarks
+     * 
+     * @template T The type of body in the InvokeResponse. 
+     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
+     * @param toBotId The MicrosoftAppId of the bot receiving the activity.
+     * @param toUrl The URL of the bot receiving the activity.
+     * @param serviceUrl The callback Url for the skill host.
+     * @param conversationId A conversation ID to use for the conversation with the skill.
+     * @param activity Activity to forward.
+     */
     public async postActivity<T = any>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>> {
         const appCredentials = await this.getAppCredentials(fromBotId, toBotId);
         if (!appCredentials) {
@@ -114,9 +131,9 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
             };
 
             if (token) {
-                config.headers['Authorization'] = `Bearer ${ token }`;
+                config.headers['Authorization'] = `Bearer ${token}`;
             }
-            
+
             const response = await axios.post(toUrl, activity, config);
             const invokeResponse: InvokeResponse<T> = { status: response.status, body: response.data };
 
@@ -130,9 +147,16 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
         }
     }
 
+    /**
+     * Logic to build an AppCredentials object to be used to acquire tokens for this HttpClient.
+     * @param appId The application id.
+     * @param oAuthScope Optional. The OAuth scope.
+     * 
+     * @returns The app credentials to be used to acquire tokens.
+     */
     protected async buildCredentials(appId: string, oAuthScope?: string): Promise<AppCredentials> {
         const appPassword = await this.credentialProvider.getAppPassword(appId);
-        let appCredentials;        
+        let appCredentials;
         if (JwtTokenValidation.isGovernment(this.channelService)) {
             appCredentials = new MicrosoftAppCredentials(appId, appPassword, undefined, oAuthScope);
             appCredentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
@@ -154,7 +178,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
             return new MicrosoftAppCredentials('', '');
         }
 
-        const cacheKey = `${ appId }${ oAuthScope }`;
+        const cacheKey = `${appId}${oAuthScope}`;
         let appCredentials = BotFrameworkHttpClient.appCredentialMapCache.get(cacheKey);
         if (appCredentials) {
             return appCredentials;

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -63,8 +63,6 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     public async postActivity(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse>
     /**
      * Forwards an activity to another bot.
-     * @remarks
-     * 
      * @template T The type of body in the InvokeResponse. 
      * @param fromBotId The MicrosoftAppId of the bot sending the activity.
      * @param toBotId The MicrosoftAppId of the bot receiving the activity.

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -32,6 +32,9 @@ export interface WebServer {
     delete?: (path: string, handler: RouteHandler) => void;
 }
 
+/**
+ * Routes the API calls with the ChannelServiceHandler methods.
+ */
 export class ChannelServiceRoutes {
     /**
      * @param channelServiceHandler 
@@ -59,15 +62,18 @@ export class ChannelServiceRoutes {
 
         // Express 4.x uses the delete() method to register handlers for the DELETE method.
         // Restify 8.x uses the del() method.
-        if (typeof(server.delete) === 'function') {
+        if (typeof (server.delete) === 'function') {
             server.delete(basePath + RouteConstants.ConversationMember, this.processDeleteConversationMember.bind(this));
             server.delete(basePath + RouteConstants.Activity, this.processDeleteActivity.bind(this));
-        } else if (typeof(server.del) === 'function') {
+        } else if (typeof (server.del) === 'function') {
             server.del(basePath + RouteConstants.ConversationMember, this.processDeleteConversationMember.bind(this));
             server.del(basePath + RouteConstants.Activity, this.processDeleteActivity.bind(this));
         }
     }
 
+    /**
+     * @private
+     */
     private processSendToConversation(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
@@ -85,6 +91,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processReplyToActivity(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
@@ -102,6 +111,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processUpdateActivity(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
@@ -119,6 +131,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processDeleteActivity(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler.handleDeleteActivity(authHeader, req.params.conversationId, req.params.activityId)
@@ -129,6 +144,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processGetActivityMembers(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler.handleGetActivityMembers(authHeader, req.params.conversationId, req.params.activityId)
@@ -142,6 +160,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processCreateConversation(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<ConversationParameters>(req)
@@ -158,6 +179,9 @@ export class ChannelServiceRoutes {
             });
     }
 
+    /**
+     * @private
+     */
     private processGetConversations(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler.handleGetConversations(authHeader, req.params.conversationId, req.query.continuationToken)
@@ -171,6 +195,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processGetConversationMembers(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler.handleGetConversationMembers(authHeader, req.params.conversationId)
@@ -184,6 +211,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processGetConversationPagedMembers(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         let pageSize = parseInt(req.query.pageSize);
@@ -205,6 +235,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processDeleteConversationMember(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler.handleDeleteConversationMember(authHeader, req.params.conversationId, req.params.memberId)
@@ -215,6 +248,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processSendConversationHistory(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<Transcript>(req)
@@ -232,6 +268,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private processUploadAttachment(req: WebRequest, res: WebResponse): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<AttachmentData>(req)
@@ -249,6 +288,9 @@ export class ChannelServiceRoutes {
             .catch(err => { ChannelServiceRoutes.handleError(err, res); });
     }
 
+    /**
+     * @private
+     */
     private static readActivity(req: WebRequest): Promise<Activity> {
         return new Promise((resolve, reject) => {
             if (req.body) {
@@ -276,6 +318,9 @@ export class ChannelServiceRoutes {
         });
     }
 
+    /**
+     * @private
+     */
     private static readBody<T>(req: WebRequest): Promise<T> {
         return new Promise((resolve, reject) => {
             if (req.body) {
@@ -301,6 +346,9 @@ export class ChannelServiceRoutes {
         });
     }
 
+    /**
+     * @private
+     */
     private static handleError(err: any, res: WebResponse): void {
         if (err instanceof StatusCodeError) {
             res.send(err.message);

--- a/libraries/botbuilder/src/skills/skillHandler.ts
+++ b/libraries/botbuilder/src/skills/skillHandler.ts
@@ -90,7 +90,7 @@ export class SkillHandler extends ChannelServiceHandler {
     protected async onSendToConversation(claimsIdentity: ClaimsIdentity, conversationId: string, activity: Activity): Promise<ResourceResponse> {
         return await this.processActivity(claimsIdentity, conversationId, null, activity);
     }
-    
+
     /**
      * replyToActivity() API for Skill.
      * @remarks
@@ -116,7 +116,10 @@ export class SkillHandler extends ChannelServiceHandler {
         return await this.processActivity(claimsIdentity, conversationId, activityId, activity);
     }
 
-    private static applyEoCToTurnContextActivity(turnContext: TurnContext,endOfConversationActivity: Activity): void {
+    /**
+     * @private
+     */
+    private static applyEoCToTurnContextActivity(turnContext: TurnContext, endOfConversationActivity: Activity): void {
         // transform the turnContext.activity to be an EndOfConversation Activity.
         turnContext.activity.type = endOfConversationActivity.type;
         turnContext.activity.text = endOfConversationActivity.text;
@@ -131,6 +134,9 @@ export class SkillHandler extends ChannelServiceHandler {
         turnContext.activity.channelData = endOfConversationActivity.channelData;
     }
 
+    /**
+     * @private
+     */
     private static applyEventToTurnContextActivity(turnContext: TurnContext, eventActivity: Activity): void {
         // transform the turnContext.activity to be an Event Activity.
         turnContext.activity.type = eventActivity.type;
@@ -147,6 +153,9 @@ export class SkillHandler extends ChannelServiceHandler {
         turnContext.activity.channelData = eventActivity.channelData;
     }
 
+    /**
+     * @private
+     */
     private async processActivity(claimsIdentity: ClaimsIdentity, conversationId: string, replyToActivityId: string, activity: Activity): Promise<ResourceResponse> {
 
         let skillConversationReference: SkillConversationReference;
@@ -198,7 +207,7 @@ export class SkillHandler extends ChannelServiceHandler {
             context.turnState.set(adapter.ConnectorClientKey, client);
 
             context.activity.id = replyToActivityId;
-            context.activity.callerId = `${ CallerIdConstants.BotToBotPrefix }${ JwtTokenValidation.getAppIdFromClaims(claimsIdentity.claims) }`;
+            context.activity.callerId = `${CallerIdConstants.BotToBotPrefix}${JwtTokenValidation.getAppIdFromClaims(claimsIdentity.claims)}`;
             switch (activity.type) {
                 case ActivityTypes.EndOfConversation:
                     await this.conversationIdFactory.deleteConversationReference(conversationId);
@@ -221,7 +230,7 @@ export class SkillHandler extends ChannelServiceHandler {
         AppCredentials.trustServiceUrl(skillConversationReference.conversationReference.serviceUrl);
 
         await (this.adapter as BotFrameworkAdapter).continueConversation(skillConversationReference.conversationReference, skillConversationReference.oAuthScope, callback);
-        
+
         if (!resourceResponse) {
             resourceResponse = { id: uuid() };
         }

--- a/libraries/botbuilder/src/skills/skillHttpClient.ts
+++ b/libraries/botbuilder/src/skills/skillHttpClient.ts
@@ -15,6 +15,12 @@ import { BotFrameworkHttpClient } from '../botFrameworkHttpClient';
 export class SkillHttpClient extends BotFrameworkHttpClient {
     private readonly conversationIdFactory: SkillConversationIdFactoryBase;
 
+    /**
+     * Creates a new instance of the SkillHttpClient class.
+     * @param credentialProvider An instance of ICredentialProvider.
+     * @param conversationIdFactory An instance of a class derived from SkillConversationIdFactoryBase.
+     * @param channelService Optional. The channel service.
+     */
     public constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string) {
         super(credentialProvider, channelService);
         if (!conversationIdFactory) {
@@ -43,6 +49,14 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
      * @param activity The activity to send.
      */
     public async postToSkill(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
+    /**
+     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
+     * @param audienceOrFromBotId The OAuth audience scope, used during token retrieval or the AppId of the bot sending the activity.
+     * @param fromBotIdOrSkill The AppId of the bot sending the activity or the skill to create the Conversation Id for.
+     * @param toSkillOrCallbackUrl The skill to create the Conversation Id for or the callback Url for the skill host.
+     * @param callbackUrlOrActivity The callback Url for the skill host or the the activity to send.
+     * @param activityToForward Optional. The activity to forward.
+     */
     public async postToSkill<T = any>(audienceOrFromBotId: string, fromBotIdOrSkill: string | BotFrameworkSkill, toSkillOrCallbackUrl: BotFrameworkSkill | string, callbackUrlOrActivity: string | Activity, activityToForward?: Activity): Promise<InvokeResponse<T>> {
         let originatingAudience: string;
         let fromBotId: string;
@@ -60,7 +74,7 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
         const toSkill = typeof toSkillOrCallbackUrl === 'object' ? toSkillOrCallbackUrl : fromBotIdOrSkill as BotFrameworkSkill;
         const callbackUrl = typeof callbackUrlOrActivity === 'string' ? callbackUrlOrActivity : toSkillOrCallbackUrl as string;
         const activity = typeof activityToForward === 'object' ? activityToForward : callbackUrlOrActivity as Activity;
-        
+
         let skillConversationId: string;
         try {
             const createIdOptions: SkillConversationIdFactoryOptions = {

--- a/libraries/botbuilder/src/streaming/streamingHttpClient.ts
+++ b/libraries/botbuilder/src/streaming/streamingHttpClient.ts
@@ -9,6 +9,9 @@
 import { WebResource, HttpOperationResponse, HttpClient } from '@azure/ms-rest-js';
 import { IStreamingTransportServer, StreamingRequest } from 'botframework-streaming';
 
+/**
+ * An implementation of HttpClient that adds compatibility with streaming connections.
+ */
 export class StreamingHttpClient implements HttpClient {
     private readonly server: IStreamingTransportServer;
 
@@ -52,6 +55,9 @@ export class StreamingHttpClient implements HttpClient {
         };
     }
 
+    /**
+     * @private
+     */
     private mapHttpRequestToProtocolRequest(httpRequest: WebResource): StreamingRequest {
         return StreamingRequest.create(httpRequest.method, httpRequest.url, httpRequest.body);
     }

--- a/libraries/botbuilder/src/streaming/tokenResolver.ts
+++ b/libraries/botbuilder/src/streaming/tokenResolver.ts
@@ -28,6 +28,13 @@ import {
 export class TokenResolver {
     private static readonly PollingIntervalMs: number = 1000;
 
+    /**
+     * Checks if we have token responses from OAuth cards.
+     * @param adapter The BotFramework adapter.
+     * @param context The context for this turn.
+     * @param activity The activity to be checked.
+     * @param log Optional. The log to write on.
+     */
     public static checkForOAuthCards(adapter: BotFrameworkAdapter, context: TurnContext, activity: Activity, log?: string[]) {
         if (!activity || !activity.attachments) {
             return;
@@ -54,6 +61,9 @@ export class TokenResolver {
         }
     }
 
+    /**
+     * @private
+     */
     private static pollForToken(adapter: BotFrameworkAdapter, context: TurnContext, activity: Activity, connectionName: string, pollingTimeout: Date, log?: string[]) {
         if (pollingTimeout > new Date()) {
             const tokenApiClientCredentials = context.turnState.get(adapter.TokenApiClientCredentialsKey);
@@ -94,6 +104,9 @@ export class TokenResolver {
         }
     }
 
+    /**
+     * @private
+     */
     private static createTokenResponseActivity(relatesTo: Partial<ConversationReference>, token: string, connectionName: string): Partial<Activity> {
         let tokenResponse: Partial<Activity> = {
             id: this.generate_guid(),
@@ -115,6 +128,9 @@ export class TokenResolver {
         return tokenResponse;
     }
 
+    /**
+     * @private
+     */
     private static generate_guid(): string {
         function s4() {
             return Math.floor((1 + Math.random()) * 0x10000)


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

_Note: We divided the work for this library into two PRs to easy their review. The PR# 144 contains the rest of the botbuilder fixes._

## Specific Changes

- Added JSDoc comments in all public methods and some of the private ones in the following files:
    - activityValidator
    - botFrameworkAdapter
    - botFrameworkHttpClient
    - channelServiceHandler
    - channelServiceRoutes
    - skills/skillHandler
    - skills/skillHttpClient
    - streaming/streamingHttpClient
    - streaming/tokenResolver

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94306887-22849b00-ff4a-11ea-9d63-a2c31f4ce40b.png)

