### PR TITLE
[JSDoc] Add missing documentation for botbuilder

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
             "files": ["libraries/botbuilder/src/*.ts", "libraries/botbuilder/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder/src/eventFactory.ts
+++ b/libraries/botbuilder/src/eventFactory.ts
@@ -57,7 +57,7 @@ export class EventFactory {
         if (!state) {
             throw new TypeError('EventFactory.createHandoffStatus(): missing state.');
         }
-        
+
         const value: any = { state, message };
 
         const handoffEvent = this.createHandoffEvent(HandoffEventNames.HandoffStatus, value, conversation);
@@ -65,6 +65,9 @@ export class EventFactory {
         return handoffEvent;
     }
 
+    /**
+     * @private
+     */
     private static createHandoffEvent(name: string, value: any, conversation: ConversationAccount): Activity {
         const handoffEvent: Activity = {} as any;
 

--- a/libraries/botbuilder/src/fileTranscriptStore.ts
+++ b/libraries/botbuilder/src/fileTranscriptStore.ts
@@ -150,15 +150,15 @@ export class FileTranscriptStore implements TranscriptStore {
 
         const exists = await pathExists(transcriptFolder);
         if (!exists) {
-        	return pagedResult;
+            return pagedResult;
         }
 
         let transcriptFolderContents = await readdir(transcriptFolder);
         const include = includeWhen(fileName => !continuationToken || parse(fileName).name === continuationToken);
         const items = transcriptFolderContents.filter(transcript =>
             transcript.endsWith('.json') &&
-			withDateFilter(startDate, transcript) &&
-			include(transcript));
+            withDateFilter(startDate, transcript) &&
+            include(transcript));
 
         pagedResult.items = await Promise.all(items
             .slice(0, FileTranscriptStore.PageSize)
@@ -168,7 +168,7 @@ export class FileTranscriptStore implements TranscriptStore {
                 return parseActivity(json);
             })
         );
-        const {length} = pagedResult.items;
+        const { length } = pagedResult.items;
         if (length === FileTranscriptStore.PageSize && items[length]) {
             pagedResult.continuationToken = parse(items[length]).name;
         }
@@ -188,14 +188,14 @@ export class FileTranscriptStore implements TranscriptStore {
 
         const exists = await pathExists(channelFolder);
         if (!exists) {
-        	return pagedResult;
+            return pagedResult;
         }
         const channels = await readdir(channelFolder);
         const items = channels.filter(includeWhen(di => !continuationToken || di === continuationToken));
         pagedResult.items = items
             .slice(0, FileTranscriptStore.PageSize)
-            .map(i => ({channelId: channelId,	id: i,	created: null}));
-        const {length} = pagedResult.items;
+            .map(i => ({ channelId: channelId, id: i, created: null }));
+        const { length } = pagedResult.items;
         if (length === FileTranscriptStore.PageSize && items[length]) {
             pagedResult.continuationToken = items[length];
         }
@@ -218,28 +218,46 @@ export class FileTranscriptStore implements TranscriptStore {
         return remove(transcriptFolder);
     }
 
+    /**
+     * Saves the activity as a JSON file.
+     * @param activity The activity to transcript.
+     * @param transcriptPath The path where the transcript will be saved.
+     * @param activityFilename The name for the file.
+     */
     private async saveActivity(activity: Activity, transcriptPath: string, activityFilename: string): Promise<void> {
         const json: string = JSON.stringify(activity, null, '\t');
 
         const exists = await pathExists(transcriptPath);
         if (!exists) {
-        	await mkdirp(transcriptPath);
+            await mkdirp(transcriptPath);
         }
         return writeFile(join(transcriptPath, activityFilename), json, 'utf8');
     }
 
+    /**
+     * @private
+     */
     private getActivityFilename(activity: Activity): string {
-        return `${ getTicks(activity.timestamp) }-${ this.sanitizeKey(activity.id) }.json`;
+        return `${getTicks(activity.timestamp)}-${this.sanitizeKey(activity.id)}.json`;
     }
 
+    /**
+     * @private
+     */
     private getChannelFolder(channelId: string): string {
         return join(this.rootFolder, this.sanitizeKey(channelId));
     }
 
+    /**
+     * @private
+     */
     private getTranscriptFolder(channelId: string, conversationId: string): string {
         return join(this.rootFolder, this.sanitizeKey(channelId), this.sanitizeKey(conversationId));
     }
 
+    /**
+     * @private
+     */
     private sanitizeKey(key: string): string {
         return filenamify(key);
     }

--- a/libraries/botbuilder/src/handoffEventNames.ts
+++ b/libraries/botbuilder/src/handoffEventNames.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Defines values for handoff event names.
+ */
 export class HandoffEventNames {
 
     public static readonly InitiateHandoff: string = 'handoff.initiate';

--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -185,6 +185,12 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         this.credentials = new MicrosoftAppCredentials(credentials.appId, credentials.appPassword);
     }
 
+    /**
+     * Indentifies open and attach commands and calls the appropriate method.
+     * @param turnContext The context for this turn.
+     * 
+     * @returns True if the command is open or attached, otherwise false.
+     */
     public async processCommand(turnContext: TurnContext): Promise<any> {
 
         if (turnContext.activity.type == ActivityTypes.Message && turnContext.activity.text !== undefined) {
@@ -212,6 +218,11 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         return false;
     }
 
+    /**
+     * Processes inbound activities.
+     * @param turnContext The context for this turn.
+     * @param traceActivity The trace activity.
+     */
     protected async inbound(turnContext: TurnContext, traceActivity: Partial<Activity>): Promise<any> {
 
         if (await this.processCommand(turnContext)) {
@@ -231,6 +242,11 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         }
     }
 
+    /**
+     * Processes outbound activities.
+     * @param turnContext The context for this turn.
+     * @param traceActivities A collection of trace activities.
+     */
     protected async outbound(turnContext: TurnContext, traceActivities: Partial<Activity>[]): Promise<any> {
 
         var session = await this.findSession(turnContext);
@@ -245,6 +261,10 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         }
     }
 
+    /**
+     * Processes the state management object.
+     * @param turnContext The context for this turn.
+     */
     protected async traceState(turnContext: TurnContext): Promise<any> {
 
         var session = await this.findSession(turnContext);
@@ -271,6 +291,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         }
     }
 
+    /**
+     * @private
+     */
     private async processOpenCommand(turnContext: TurnContext): Promise<any> {
         var sessions = await this.inspectionStateAccessor.get(turnContext, InspectionSessionsByStatus.DefaultValue);
         var sessionId = this.openCommand(sessions, TurnContext.getConversationReference(turnContext.activity));
@@ -278,6 +301,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         await this.inspectionState.saveChanges(turnContext, false);
     }
 
+    /**
+     * @private
+     */
     private async processAttachCommand(turnContext: TurnContext, sessionId: string): Promise<any> {
         var sessions = await this.inspectionStateAccessor.get(turnContext, InspectionSessionsByStatus.DefaultValue);
         if (this.attachCommand(this.getAttachId(turnContext.activity), sessions, sessionId)) {
@@ -290,6 +316,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         await this.inspectionState.saveChanges(turnContext, false);
     }
 
+    /**
+     * @private
+     */
     private openCommand(sessions: InspectionSessionsByStatus, conversationReference: Partial<ConversationReference>): string {
         function generate_guid() {
             function s4() {
@@ -306,6 +335,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         return sessionId;
     }
 
+    /**
+     * @private
+     */
     private attachCommand(attachId: string, sessions: InspectionSessionsByStatus, sessionId: string): boolean {
         var inspectionSessionState = sessions.openedSessions[sessionId];
         if (inspectionSessionState !== undefined) {
@@ -316,6 +348,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         return false;
     }
 
+    /**
+     * @private
+     */
     private async findSession(turnContext: TurnContext): Promise<any> {
         var sessions = await this.inspectionStateAccessor.get(turnContext, InspectionSessionsByStatus.DefaultValue);
 
@@ -327,6 +362,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         return undefined;
     }
 
+    /**
+     * @private
+     */
     private async invokeSend(turnContext: TurnContext, session: InspectionSession, activity: Partial<Activity>): Promise<any> {
 
         if (await session.send(activity)) {
@@ -337,6 +375,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         }
     }
 
+    /**
+     * @private
+     */
     private async cleanUpSession(turnContext: TurnContext): Promise<any> {
         var sessions = await this.inspectionStateAccessor.get(turnContext, InspectionSessionsByStatus.DefaultValue);
 
@@ -344,6 +385,9 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         await this.inspectionState.saveChanges(turnContext, false);
     }
 
+    /**
+     * @private
+     */
     private getAttachId(activity: Activity) : string {
         // If we are running in a Microsoft Teams Team the conversation Id will reflect a particular thread the bot is in.
         // So if we are in a Team then we will associate the "attach" with the Team Id rather than the more restrictive conversation Id.
@@ -396,12 +440,20 @@ class InspectionSessionsByStatus {
  */
 export class InspectionState extends BotState {
 
+    /**
+     * Creates a new instance of the InspectionState class.
+     * @param storage The storage layer this state management object will use to store and retrieve state.
+     */
     constructor(storage: Storage) {
         super(storage, (context: TurnContext) => {
             return Promise.resolve(this.getStorageKey(context));
         });
     }
-    
+
+    /**
+     * Gets the key to use when reading and writing state to and from storage.
+     * @param turnContext The context for this turn.
+     */
     protected getStorageKey(turnContext: TurnContext) {
         return 'InspectionState';
     }

--- a/libraries/botbuilder/src/statusCodeError.ts
+++ b/libraries/botbuilder/src/statusCodeError.ts
@@ -8,8 +8,17 @@
 
 import { StatusCodes } from 'botbuilder-core';
 
+/**
+ * Extends Error to provide specialized error messages.
+ */
 export class StatusCodeError extends Error {
     public readonly statusCode: StatusCodes;
+
+    /**
+     * Creates a new instance of the StatusCodeError class.
+     * @param statusCode The status code.
+     * @param message Optional. The error message.
+     */
     public constructor(statusCode: StatusCodes, message?: string) {
         super(message);
         this.statusCode = statusCode;

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -30,6 +30,10 @@ import {
 } from 'botbuilder-core';
 import { TeamsInfo } from './teamsInfo';
 
+/**
+ * The TeamsActivityHandler is derived from ActivityHandler. It adds support for 
+ * the Microsoft Teams specific events and interactions.
+ */
 export class TeamsActivityHandler extends ActivityHandler {
 
     /**

--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -27,6 +27,12 @@ export function teamsGetChannelId(activity: Activity): string {
     return channel && channel.id ? channel.id : null;
 }
 
+/**
+ * Gets the Team Id from the current activity.
+ * @param activity The current activity.
+ * 
+ * @returns The current activity's team's Id, or null.
+ */
 export function teamsGetTeamId(activity: Activity): string {
     if (!activity) {
         throw new Error('Missing activity parameter');
@@ -37,6 +43,10 @@ export function teamsGetTeamId(activity: Activity): string {
     return team && team.id ? team.id : null;
 }
 
+/**
+ * Configures the current activity to generate a notification within Teams.
+ * @param activity The current activity.
+ */
 export function teamsNotifyUser(activity: Activity): void {
     if (!activity) {
         throw new Error('Missing activity parameter');
@@ -48,8 +58,14 @@ export function teamsNotifyUser(activity: Activity): void {
 
     const channelData: TeamsChannelData = activity.channelData as TeamsChannelData;
     channelData.notification = { alert: true } as NotificationInfo;
-}    
+}
 
+/**
+ * Gets the TeamsInfo object from the current activity.
+ * @param activity The current activity.
+ * 
+ * @returns The current activity's team's info, or null.
+ */
 export function teamsGetTeamInfo(activity: Activity): TeamInfo {
     if (!activity) {
         throw new Error('Missing activity parameter');

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -24,8 +24,15 @@ import { ConnectorClient, TeamsConnectorClient, TeamsConnectorModels} from 'botf
 
 import { BotFrameworkAdapter } from './botFrameworkAdapter';
 
-
+/**
+ * Provides utility methods for the events and interactions that occur within Microsoft Teams.
+ */
 export class TeamsInfo {
+    /**
+     * Gets the details for the given team id. This only works in teams scoped conversations.
+     * @param context The context for this turn.
+     * @param teamId The id of the Teams team.
+     */
     public static async getTeamDetails(context: TurnContext, teamId?: string): Promise<TeamDetails> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
@@ -35,6 +42,14 @@ export class TeamsInfo {
         return await this.getTeamsConnectorClient(context).teams.fetchTeamDetails(t);
     }
 
+    /**
+     * Creates a new thread in a Teams chat and sends an activity to that new thread.
+     * @param context The context for this turn.
+     * @param activity The activity to send.
+     * @param teamsChannelId Id of the Teams channel.
+     * 
+     * @returns The Conversation Reference and the id of the activity (if sent).
+     */
     public static async sendMessageToTeamsChannel(context: TurnContext, activity: Activity, teamsChannelId: string): Promise<[ConversationReference, string]> {
         if (!context) {
             throw new Error("TurnContext cannot be null");
@@ -61,9 +76,16 @@ export class TeamsInfo {
         const conversationResourceResponse = await connectorClient.conversations.createConversation(convoParams);
         const conversationReference = TurnContext.getConversationReference(context.activity);
         conversationReference.conversation.id = conversationResourceResponse.id;
-        return [conversationReference as ConversationReference, conversationResourceResponse.activityId];       
+        return [conversationReference as ConversationReference, conversationResourceResponse.activityId];
     }
 
+    /**
+     * Returns a list of channels in a Team. This only works in teams scoped conversations.
+     * @param context The context for this turn.
+     * @param teamId ID of the Teams team.
+     * 
+     * @returns The list of ChannelInfo objects with the conversations.
+     */
     public static async getTeamChannels(context: TurnContext, teamId?: string): Promise<ChannelInfo[]> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
@@ -74,6 +96,12 @@ export class TeamsInfo {
         return channelList.conversations;
     }
 
+    /**
+     * Gets the conversation members of a one-on-one or group chat.
+     * @param context The context for this turn.
+     * 
+     * @returns The list of TeamsChannelAccounts.
+     */
     public static async getMembers(context: TurnContext): Promise<TeamsChannelAccount[]> {
         const teamId = this.getTeamId(context);
         if (teamId) {
@@ -85,6 +113,14 @@ export class TeamsInfo {
         }
     }
 
+    /**
+     * Gets a pagined list of members of one-on-one, group, or team conversation.
+     * @param context The context for this turn.
+     * @param pageSize Suggested number of entries on a page.
+     * @param continuationToken A continuation token.
+     * 
+     * @returns The TeamsPagedMembersResult with the list of members.
+     */
     public static async getPagedMembers(context: TurnContext, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult> {
         const teamId = this.getTeamId(context);
         const options: TeamsConnectorModels.ConversationsGetConversationPagedMembersOptionalParams = {
@@ -100,6 +136,13 @@ export class TeamsInfo {
         }
     }
 
+    /**
+     * Gets the account of a single conversation member.
+     * @param context The context for this turn.
+     * @param userId ID of the user in question.
+     * 
+     * @returns The TeamsChannelAccount of the member.
+     */
     public static async getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount> {
         const teamId = this.getTeamId(context);
         if (teamId) {
@@ -111,6 +154,13 @@ export class TeamsInfo {
         }
     }
 
+    /**
+     * Gets the list of TeamsChannelAccounts within a team.
+     * @param context The context for this turn.
+     * @param teamId ID of the Teams team.
+     * 
+     * @returns The list of TeamsChannelAccount of the members.
+     */
     public static async getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
@@ -119,6 +169,15 @@ export class TeamsInfo {
         return await this.getMembersInternal(this.getConnectorClient(context), t);
     }
 
+    /**
+     * Gets a paginated list of members of a team.
+     * @param context The context for this turn.
+     * @param teamId ID of the Teams team.
+     * @param pageSize The number of entries on the page.
+     * @param continuationToken The continuationToken token.
+     * 
+     * @returns A TeamsPagedMembersResult with the list of members.
+     */
     public static async getPagedTeamMembers(context: TurnContext, teamId?: string, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
@@ -132,6 +191,14 @@ export class TeamsInfo {
         return await this.getPagedMembersInternal(this.getConnectorClient(context), t, options);
     }
 
+    /**
+     * Gets the account of a member in a teams scoped conversation.
+     * @param context The context for this turn.
+     * @param teamId ID of the Teams team.
+     * @param userId ID of the Teams user.
+     * 
+     * @returns The TeamsChannelAccount of the member.
+     */
     public static async getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
@@ -140,6 +207,9 @@ export class TeamsInfo {
         return await this.getMemberInternal(this.getConnectorClient(context), t, userId);
     }
 
+    /**
+     * @private
+     */
     private static async getMembersInternal(connectorClient: ConnectorClient, conversationId: string): Promise<TeamsChannelAccount[]> {
         if (!conversationId) {
             throw new Error('The getMembers operation needs a valid conversationId.');
@@ -153,6 +223,9 @@ export class TeamsInfo {
         return teamMembers as TeamsChannelAccount[];
     }
 
+    /**
+     * @private
+     */
     private static async getPagedMembersInternal(connectorClient: ConnectorClient, conversationId: string, options: TeamsConnectorModels.ConversationsGetConversationPagedMembersOptionalParams): Promise<TeamsPagedMembersResult> {
         if (!conversationId) {
             throw new Error('The getPagedMembers operation needs a valid conversationId.');
@@ -168,6 +241,9 @@ export class TeamsInfo {
         return teamsPagedMembersResult;
     }
 
+    /**
+     * @private
+     */
     private static async getMemberInternal(connectorClient: ConnectorClient, conversationId: string, userId: string): Promise<TeamsChannelAccount> {
         if (!conversationId) {
             throw new Error('The getMember operation needs a valid conversationId.');
@@ -182,6 +258,9 @@ export class TeamsInfo {
         return teamMember as TeamsChannelAccount;
     }
 
+    /**
+     * @private
+     */
     private static getTeamId(context: TurnContext): string {
         if (!context) {
             throw new Error('Missing context parameter');
@@ -197,6 +276,9 @@ export class TeamsInfo {
         return teamId;
     }
 
+    /**
+     * @private
+     */
     private static getConnectorClient(context: TurnContext): ConnectorClient {
         if (!context.adapter || !('createConnectorClient' in context.adapter)) {
             throw new Error('This method requires a connector client.');
@@ -205,6 +287,9 @@ export class TeamsInfo {
         return (context.adapter as BotFrameworkAdapter).createConnectorClient(context.activity.serviceUrl);
     }
 
+    /**
+     * @private
+     */
     private static getTeamsConnectorClient(context: TurnContext): TeamsConnectorClient {
         const connectorClient = this.getConnectorClient(context);
         return new TeamsConnectorClient(connectorClient.credentials, { baseUri: context.activity.serviceUrl });


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

_Note: We divided the work for this library into two PRs to easy their review. PR# 143 contains the rest of the botbuilder fixes._

## Specific Changes
- Updated `jsdoc/require-jsdoc` in `.eslintrc.json` from `warn` to `error`.
- Added JSDoc comments in all public methods and some of the private ones in the following files:
    - eventFactory
    - fileTranscriptStore
    - handoffEventNames
    - inspectionMiddleware
    - statusCodeError
    - teamsActivityHandler
    - teamsActivityHelpers
    - teamsInfo

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94306887-22849b00-ff4a-11ea-9d63-a2c31f4ce40b.png)