### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs/Root

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -116,7 +116,7 @@
             "files": ["libraries/botbuilder-dialogs/src/*.ts", "libraries/botbuilder-dialogs/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -192,8 +192,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
     * Called when the dialog is ending.
-    * @remarks 
-    * When this method is called from the parent dialog's context, the component dialog
+    * @remarks When this method is called from the parent dialog's context, the component dialog
     * cancels all of the dialogs on its inner dialog stack before ending.
     * @param context The context object for this turn.
     * @param instance State information associated with the instance of this component

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -80,10 +80,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the dialog is started and pushed onto the parent's dialog stack.
-     * @remarks
-     * If the task is successful, the result indicates whether the dialog is still 
-     * active after the turn has been processed by the dialog.
-     * 
      * By default, this calls the
      * Dialog.BeginDialogAsync(DialogContext, object, CancellationToken) method
      * of the component dialog's initial dialog, as defined by InitialDialogId.
@@ -91,6 +87,9 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * @param outerDC The parent DialogContext for the current turn of conversation.
      * @param options Optional, initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still 
+     * active after the turn has been processed by the dialog.
      */
     public async beginDialog(outerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
         await this.checkForVersionChange(outerDC);
@@ -118,14 +117,13 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when the dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     * If this method is *not* overridden, the dialog automatically ends when the user replies.
+     * @param outerDC The parent DialogContext for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
      * return value.
-     *     
-     * If this method is *not* overridden, the dialog automatically ends when the user replies.
-     * @param outerDC The parent DialogContext for the current turn of conversation.
-     * @returns A Promise representing the asynchronous operation.
      */
     public async continueDialog(outerDC: DialogContext): Promise<DialogTurnResult> {
         await this.checkForVersionChange(outerDC);
@@ -147,24 +145,22 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when a child dialog on the parent's dialog stack completed this turn, returning
      * control to this dialog component.
-     * @remarks
-     * If the task is successful, the result indicates whether this dialog is still
-     * active after this dialog turn has been processed.
-     *
-     * Generally, the child dialog was started with a call to
-     * BeginDialogAsync(DialogContext, object, CancellationToken) in the parent's
-     * context. However, if the
-     * DialogContext.ReplaceDialogAsync(string, object, CancellationToken) method
-     * is called, the logical child dialog may be different than the original.
-     *
-     * If this method is *not* overridden, the dialog automatically calls its
-     * RepromptDialogAsync(ITurnContext, DialogInstance, CancellationToken) when
-     * the user replies.
      * @param outerDc The DialogContext for the current turn of conversation.
      * @param reason Reason why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether this dialog is still
+     * active after this dialog turn has been processed.
+     * Generally, the child dialog was started with a call to
+     * BeginDialogAsync(DialogContext, object, CancellationToken) in the parent's
+     * context. However, if the
+     * DialogContext.ReplaceDialogAsync(string, object, CancellationToken) method
+     * is called, the logical child dialog may be different than the original.
+     * If this method is *not* overridden, the dialog automatically calls its
+     * RepromptDialogAsync(ITurnContext, DialogInstance, CancellationToken) when
+     * the user replies.
      */
     public async resumeDialog(outerDC: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         await this.checkForVersionChange(outerDC);
@@ -218,11 +214,10 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Adds a child dialog or prompt to the components internal `DialogSet`.
-     *
+     * @param dialog The child dialog or prompt to add.
      * @remarks
      * The `Dialog.id` of the first child added to the component will be assigned to the [initialDialogId](#initialdialogid)
      * property.
-     * @param dialog The child dialog or prompt to add.
      */
     public addDialog(dialog: Dialog): this {
         this.dialogs.add(dialog);
@@ -310,10 +305,10 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * @private
-     * @remarks 
-     * You should only call this if you don't have a dc to work with (such as OnResume())
      * @param context Context for the current turn of conversation with the user.
      * @param instance Current state information for this dialog.
+     * @remarks 
+     * You should only call this if you don't have a dc to work with (such as OnResume())
     */
     private createInnerDC(context: TurnContext | DialogContext, instance: DialogInstance): DialogContext {
         if (!instance) {

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -154,13 +154,11 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * If the task is successful, the result indicates whether this dialog is still
      * active after this dialog turn has been processed.
      * Generally, the child dialog was started with a call to
-     * BeginDialogAsync(DialogContext, object, CancellationToken) in the parent's
-     * context. However, if the
-     * DialogContext.ReplaceDialogAsync(string, object, CancellationToken) method
+     * beginDialog(DialogContext, object) in the parent's
+     * context. However, if the DialogContext.replaceDialog(string, object) method
      * is called, the logical child dialog may be different than the original.
      * If this method is *not* overridden, the dialog automatically calls its
-     * RepromptDialogAsync(ITurnContext, DialogInstance, CancellationToken) when
-     * the user replies.
+     * RepromptDialog(ITurnContext, DialogInstance) when the user replies.
      */
     public async resumeDialog(outerDC: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         await this.checkForVersionChange(outerDC);

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -80,7 +80,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the dialog is started and pushed onto the parent's dialog stack.
-     *
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still 
      * active after the turn has been processed by the dialog.
@@ -119,7 +118,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when the dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
-     *
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
@@ -149,7 +147,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when a child dialog on the parent's dialog stack completed this turn, returning
      * control to this dialog component.
-     * 
      * @remarks
      * If the task is successful, the result indicates whether this dialog is still
      * active after this dialog turn has been processed.
@@ -184,7 +181,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
     * Called when the dialog should re-prompt the user for input.
-    * 
     * @param context The context object for this turn.
     * @param instance State information for this dialog.
     * @returns A Promise representing the asynchronous operation.
@@ -200,7 +196,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
     * Called when the dialog is ending.
-    * 
     * @remarks 
     * When this method is called from the parent dialog's context, the component dialog
     * cancels all of the dialogs on its inner dialog stack before ending.
@@ -315,7 +310,6 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * @private
-     * 
      * @remarks 
      * You should only call this if you don't have a dc to work with (such as OnResume())
      * @param context Context for the current turn of conversation with the user.

--- a/libraries/botbuilder-dialogs/src/dialog.ts
+++ b/libraries/botbuilder-dialogs/src/dialog.ts
@@ -326,6 +326,9 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
         return this._id;
     }
 
+    /**
+     * Sets the unique ID of the dialog.
+     */
     public set id(value: string) {
         this._id = value;
     }

--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -11,6 +11,9 @@ import { DialogSet } from './dialogSet';
 import { DialogContext } from './dialogContext';
 import { DialogEvents } from './dialogEvents';
 
+/**
+ * A container for a set of Dialogs.
+ */
 export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
     /**
      * The containers dialog set.

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -67,8 +67,7 @@ export class DialogContext {
 
     /**
       * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @remarks
-      * Passing in a dialog context instance will clone the dialog context.
+    * @remarks Passing in a dialog context instance will clone the dialog context.
       * @param dialogs The dialog set for which to create the dialog context.
       * @param contextOrDC The turn context or dialog context for the current turn of the bot.
       * @param state The state object to use to read and write dialog state to storage.
@@ -303,13 +302,12 @@ export class DialogContext {
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
-     * @param promptOrOptions The text of the initial prompt to send the user, or
-     *      the activity to send as the initial prompt.
-     * @param choices Optional. Array of choices for the user to choose from,
-     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     * @remarks
-     * This helper method formats the object to use as the `options` parameter, and then calls
-     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+     * @param promptOrOptions The text of the initial prompt to send the user, 
+     * or the activity to send as the initial prompt.
+     * @param choices Optional. Array of choices for the user to choose from, 
+     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * @remarks This helper method formats the object to use as the `options` parameter, and then calls
+     * beginDialog to start the specified prompt dialog.
      *
      * ```JavaScript
      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -56,12 +56,11 @@ export interface DialogState {
 export class DialogContext {
     /**
       * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * 
-      * @remarks
-      * Passing in a dialog context instance will clone the dialog context.
       * @param dialogs The dialog set for which to create the dialog context.
       * @param contextOrDC The context object for the current turn of the bot.
       * @param state The state object to use to read and write dialog state to storage.
+      * @remarks
+      * Passing in a dialog context instance will clone the dialog context.
       */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
@@ -308,7 +307,6 @@ export class DialogContext {
      *      the activity to send as the initial prompt.
      * @param choices Optional. Array of choices for the user to choose from,
      *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     * 
      * @remarks
      * This helper method formats the object to use as the `options` parameter, and then calls
      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -66,11 +66,11 @@ export class DialogContext {
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
 
     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-    * @remarks Passing in a dialog context instance will clone the dialog context.
+      * Creates an new instance of the DialogContext class.
       * @param dialogs The dialog set for which to create the dialog context.
       * @param contextOrDC The turn context or dialog context for the current turn of the bot.
       * @param state The state object to use to read and write dialog state to storage.
+      * @remarks Passing in a dialog context instance will clone the dialog context.
       */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
         this.dialogs = dialogs;

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -63,6 +63,15 @@ export class DialogContext {
       * Passing in a dialog context instance will clone the dialog context.
       */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
+
+    /**
+      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+      * @param dialogs The dialog set for which to create the dialog context.
+      * @param contextOrDC The context object for the current turn of the bot.
+      * @param state The state object to use to read and write dialog state to storage.
+      * @remarks
+      * Passing in a dialog context instance will clone the dialog context.
+      */
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
 
     /**

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -68,7 +68,6 @@ export class DialogContext {
 
     /**
       * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * 
       * @remarks
       * Passing in a dialog context instance will clone the dialog context.
       * @param dialogs The dialog set for which to create the dialog context.
@@ -304,7 +303,6 @@ export class DialogContext {
     
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
-     * 
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user, or
      *      the activity to send as the initial prompt.
@@ -546,7 +544,6 @@ export class DialogContext {
 
     /**
      * @private
-     * 
      * @param reason 
      * @param result 
      */

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -65,6 +65,16 @@ export class DialogContext {
       */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
+
+    /**
+      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+      * 
+      * @remarks
+      * Passing in a dialog context instance will clone the dialog context.
+      * @param dialogs The dialog set for which to create the dialog context.
+      * @param contextOrDC The turn context or dialog context for the current turn of the bot.
+      * @param state The state object to use to read and write dialog state to storage.
+      */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
         this.dialogs = dialogs;
         if (contextOrDC instanceof DialogContext) {
@@ -291,6 +301,24 @@ export class DialogContext {
      */
     public async prompt(dialogId: string, promptOrOptions: string | Partial<Activity> | PromptOptions): Promise<DialogTurnResult>;
     public async prompt(dialogId: string, promptOrOptions: string | Partial<Activity> | PromptOptions, choices: (string | Choice)[]): Promise<DialogTurnResult>;
+    
+    /**
+     * Helper function to simplify formatting the options for calling a prompt dialog.
+     * 
+     * @param dialogId ID of the prompt dialog to start.
+     * @param promptOrOptions The text of the initial prompt to send the user, or
+     *      the activity to send as the initial prompt.
+     * @param choices Optional. Array of choices for the user to choose from,
+     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * 
+     * @remarks
+     * This helper method formats the object to use as the `options` parameter, and then calls
+     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+     *
+     * ```JavaScript
+     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+     * ```
+     */
     public async prompt(
         dialogId: string,
         promptOrOptions: string | Partial<Activity>,
@@ -516,6 +544,12 @@ export class DialogContext {
         return false;
     }
 
+    /**
+     * @private
+     * 
+     * @param reason 
+     * @param result 
+     */
     private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
         const instance: DialogInstance<any> = this.activeDialog;
         if (instance) {

--- a/libraries/botbuilder-dialogs/src/dialogEvents.ts
+++ b/libraries/botbuilder-dialogs/src/dialogEvents.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Represents the events related to the "lifecycle" of the dialog.
+ */
 export class DialogEvents {
     /**
      * Event fired by a dialog to indicate that its `beginDialog()` method has been called.

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -20,6 +20,13 @@ import { DialogEvents } from './dialogEvents';
 import { DialogSet } from './dialogSet';
 import { AuthConstants, GovConstants, isSkillClaim } from './prompts/skillsHelpers';
 
+/**
+ * Runs a dialog from a given context and accesor.
+ * 
+ * @param dialog Context for the current turn of conversation with the user.
+ * @param context Context object for the current turn of conversation with the user.
+ * @param accessor Defined methods for accessing the state property created in a BotState object.
+ */
 export async function runDialog(dialog: Dialog, context: TurnContext, accessor: StatePropertyAccessor<DialogState>): Promise<void> {
     if (!dialog) {
         throw new Error('runDialog(): missing dialog');
@@ -120,7 +127,12 @@ export function shouldSendEndOfConversationToParent(context: TurnContext, turnRe
     return false;
 }
 
-// Recursively walk up the DC stack to find the active DC.
+/**
+ * Recursively walk up the DC stack to find the active DC.
+ * 
+ * @param dialogContext Context for the current turn of conversation with the user.
+ * @returns Active dialog context.
+ */
 export function getActiveDialogContext(dialogContext: DialogContext): DialogContext {
     const child = dialogContext.child;
     if (!child) {
@@ -130,6 +142,12 @@ export function getActiveDialogContext(dialogContext: DialogContext): DialogCont
     return getActiveDialogContext(child);
 }
 
+/**
+ * Determines if the skill is acting as a skill parent.
+ * 
+ * @param context Context object for the current turn of conversation with the user.
+ * @returns A boolean representing if the skill is acting as a skill parent.
+ */
 export function isFromParentToSkill(context: TurnContext): boolean {
     // If a SkillConversationReference exists, it was likely set by the SkillHandler and the bot is acting as a parent.
     if (context.turnState.get(SkillConversationReferenceKey)) {

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -22,7 +22,7 @@ import { AuthConstants, GovConstants, isSkillClaim } from './prompts/skillsHelpe
 
 /**
  * Runs a dialog from a given context and accesor.
- * @param dialog Context for the current turn of conversation with the user.
+ * @param dialog The Dialog to run.
  * @param context Context object for the current turn of conversation with the user.
  * @param accessor Defined methods for accessing the state property created in a BotState object.
  */

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -22,7 +22,6 @@ import { AuthConstants, GovConstants, isSkillClaim } from './prompts/skillsHelpe
 
 /**
  * Runs a dialog from a given context and accesor.
- * 
  * @param dialog Context for the current turn of conversation with the user.
  * @param context Context object for the current turn of conversation with the user.
  * @param accessor Defined methods for accessing the state property created in a BotState object.
@@ -129,7 +128,6 @@ export function shouldSendEndOfConversationToParent(context: TurnContext, turnRe
 
 /**
  * Recursively walk up the DC stack to find the active DC.
- * 
  * @param dialogContext Context for the current turn of conversation with the user.
  * @returns Active dialog context.
  */
@@ -144,7 +142,6 @@ export function getActiveDialogContext(dialogContext: DialogContext): DialogCont
 
 /**
  * Determines if the skill is acting as a skill parent.
- * 
  * @param context Context object for the current turn of conversation with the user.
  * @returns A boolean representing if the skill is acting as a skill parent.
  */

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -62,7 +62,6 @@ export class DialogManager extends Configurable {
 
     /**
      * Creates an instance of the DialogManager class.
-     * 
      * @param rootDialog Optional, root dialog to use.
      * @param dialogStateProperty Optional, alternate name for the dialogState property. (Default is "DialogStateProperty")
      */
@@ -106,7 +105,6 @@ export class DialogManager extends Configurable {
 
     /**
      * Gets the root dialog ID.
-     * 
      * @returns The root dialog ID.
      */
     public get rootDialog(): Dialog {
@@ -130,7 +128,6 @@ export class DialogManager extends Configurable {
 
     /**
      * Set configuration settings.
-     * 
      * @param config Configuration settings to apply.
      * @returns The cofigured dialogManager context.
      */
@@ -140,7 +137,6 @@ export class DialogManager extends Configurable {
 
     /**
      * Runs dialog system in the context of an ITurnContext.
-     * 
      * @param context Context for the current turn of conversation with the user.
      * @returns Result of the running the logic against the activity.
      */
@@ -251,7 +247,6 @@ export class DialogManager extends Configurable {
 
     /**
      * Helper to send a trace activity with a memory snapshot of the active dialog DC.
-     * 
      * @param dc Context for the current turn of conversation with the user.
      * @param traceLabel Trace label to set for the activity.
      */
@@ -269,7 +264,6 @@ export class DialogManager extends Configurable {
 
     /**
      * @private
-     * 
      * @param dc Context for the current turn of conversation with the user.
      * @returns A Promise representing the asynchronous operation.
      */

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -320,7 +320,6 @@ export class DialogManager extends Configurable {
 
     /**
      * @private
-     * 
      * @param dc Context for the current turn of conversation with the user.
      * @returns The DialogTurnResult.
      */

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -138,7 +138,7 @@ export class DialogManager extends Configurable {
     /**
      * Runs dialog system in the context of an ITurnContext.
      * @param context Context for the current turn of conversation with the user.
-     * @returns Result of the running the logic against the activity.
+     * @returns Result of running the logic against the activity.
      */
     public async onTurn(context: TurnContext): Promise<DialogManagerResult> {
         // Ensure properly configured

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -52,11 +52,20 @@ export interface DialogManagerConfiguration {
     stateConfiguration?: DialogStateManagerConfiguration;
 }
 
+/**
+ * Class which runs the dialog system.
+ */
 export class DialogManager extends Configurable {
     private _rootDialogId: string;
     private readonly _dialogStateProperty: string;
     private readonly _initialTurnState: TurnContextStateCollection = new TurnContextStateCollection();
 
+    /**
+     * Creates an instance of the DialogManager class.
+     * 
+     * @param rootDialog Optional, root dialog to use.
+     * @param dialogStateProperty Optional, alternate name for the dialogState property. (Default is "DialogStateProperty")
+     */
     public constructor(rootDialog?: Dialog, dialogStateProperty?: string) {
         super();
         if (rootDialog) { this.rootDialog = rootDialog; }
@@ -95,6 +104,11 @@ export class DialogManager extends Configurable {
         }
     }
 
+    /**
+     * Gets the root dialog ID.
+     * 
+     * @returns The root dialog ID.
+     */
     public get rootDialog(): Dialog {
         return this._rootDialogId ? this.dialogs.find(this._rootDialogId) : undefined;
     }
@@ -114,10 +128,22 @@ export class DialogManager extends Configurable {
      */
     public expireAfter?: number;
 
+    /**
+     * Set configuration settings.
+     * 
+     * @param config Configuration settings to apply.
+     * @returns The cofigured dialogManager context.
+     */
     public configure(config: Partial<DialogManagerConfiguration>): this {
         return super.configure(config);
     }
 
+    /**
+     * Runs dialog system in the context of an ITurnContext.
+     * 
+     * @param context Context for the current turn of conversation with the user.
+     * @returns Result of the running the logic against the activity.
+     */
     public async onTurn(context: TurnContext): Promise<DialogManagerResult> {
         // Ensure properly configured
         if (!this._rootDialogId) { throw new Error(`DialogManager.onTurn: the bot's 'rootDialog' has not been configured.`); }
@@ -223,7 +249,12 @@ export class DialogManager extends Configurable {
         return { turnResult: turnResult };
     }
 
-    // Helper to send a trace activity with a memory snapshot of the active dialog DC.
+    /**
+     * Helper to send a trace activity with a memory snapshot of the active dialog DC.
+     * 
+     * @param dc Context for the current turn of conversation with the user.
+     * @param traceLabel Trace label to set for the activity.
+     */
     private async sendStateSnapshotTrace(dc: DialogContext, traceLabel: string): Promise<void> {
         // send trace of memory
         const snapshot: object = getActiveDialogContext(dc).state.getMemorySnapshot();
@@ -236,6 +267,12 @@ export class DialogManager extends Configurable {
         });
     }
 
+    /**
+     * @private
+     * 
+     * @param dc Context for the current turn of conversation with the user.
+     * @returns A Promise representing the asynchronous operation.
+     */
     private async handleSkillOnTurn(dc: DialogContext): Promise<DialogTurnResult> {
         // The bot is running as a skill.
         const turnContext = dc.context;
@@ -287,6 +324,12 @@ export class DialogManager extends Configurable {
         return turnResult;
     }
 
+    /**
+     * @private
+     * 
+     * @param dc Context for the current turn of conversation with the user.
+     * @returns The DialogTurnResult.
+     */
     private async handleBotOnTurn(dc: DialogContext): Promise<DialogTurnResult> {
         let turnResult: DialogTurnResult;
 

--- a/libraries/botbuilder-dialogs/src/dialogTurnStateConstants.ts
+++ b/libraries/botbuilder-dialogs/src/dialogTurnStateConstants.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+  * Defines dialog turn state constants.
+  */
 export class DialogTurnStateConstants {
     static dialogManager = Symbol('dialogManager');
 

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -67,11 +67,11 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is started and pushed onto the dialog stack.
-     * @remarks
-     * If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
      * @param dc The DialogContext for the current turn of conversation.
      * @param options Initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
      */
     public async beginDialog(dc: DialogContext, options: BeginSkillDialogOptions): Promise<DialogTurnResult> {
         const dialogArgs = this.validateBeginDialogArgs(options);
@@ -102,12 +102,12 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     /**
      * Called when the skill dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
      * @remarks 
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
      * return value.
-     * @param dc The DialogContext for the current turn of conversation.
-     * @returns A Promise representing the asynchronous operation.
      */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         if (!this.onValidateActivity(dc.context.activity)) {

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -34,6 +34,12 @@ import { DialogContext } from './dialogContext';
 import { DialogEvents } from './dialogEvents';
 import { SkillDialogOptions } from './skillDialogOptions';
 
+/**
+ * A specialized Dialog that can wrap remote calls to a skill.
+ * @remarks
+ * The options parameter in BeginDialogAsync must be a BeginSkillDialogOptions instance
+ * with the initial parameters for the dialog.
+ */
 export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     protected dialogOptions: SkillDialogOptions;
 
@@ -59,6 +65,14 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         this.dialogOptions = dialogOptions;
     }
 
+    /**
+     * Called when the skill dialog is started and pushed onto the dialog stack.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still active after the turn has been processed by the dialog.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @param options Initial information to pass to the dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async beginDialog(dc: DialogContext, options: BeginSkillDialogOptions): Promise<DialogTurnResult> {
         const dialogArgs = this.validateBeginDialogArgs(options);
 
@@ -85,6 +99,16 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return Dialog.EndOfTurn;
     }
 
+    /**
+     * Called when the skill dialog is _continued_, where it is the active dialog and the
+     * user replies with a new activity.
+     * @remarks 
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog. The result may also contain a
+     * return value.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         if (!this.onValidateActivity(dc.context.activity)) {
             return Dialog.EndOfTurn;
@@ -114,6 +138,13 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return Dialog.EndOfTurn;
     }
 
+    /**
+     * Called when the skill dialog is ending.
+     * @param context The context object for this turn.
+     * @param instance State information associated with the instance of this dialog on the dialog stack.
+     * @param reason Reason why the dialog ended.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
         // Send of of conversation to the skill if the dialog has been cancelled. 
         if (reason == DialogReason.cancelCalled || reason == DialogReason.replaceCalled) {
@@ -133,6 +164,12 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         await super.endDialog(context, instance, reason);
     }
 
+    /**
+     * Called when the skill dialog should re-prompt the user for input
+     * @param context The context object for this turn.
+     * @param instance State information for this dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         // Create and send an envent to the skill so it can resume the dialog.
         const repromptEvent = { type: ActivityTypes.Event, name: DialogEvents.repromptDialog };
@@ -147,6 +184,14 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         await this.sendToSkill(context, activity, skillConversationId);
     }
 
+    /**
+     * Called when a child skill dialog completed its turn, returning control to this dialog.
+     * @param dc The dialog context for the current turn of the conversation.
+     * @param reason Reason why the dialog resumed.
+     * @param result Optional, value returned from the dialog that was called. The type
+     * of the value returned is dependent on the child dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         await this.repromptDialog(dc.context, dc.activeDialog);
         return Dialog.EndOfTurn;
@@ -174,6 +219,10 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return JSON.parse(JSON.stringify(activity));
     }
 
+    /**
+     * @private
+     * @param options
+     */
     private validateBeginDialogArgs(options: BeginSkillDialogOptions): BeginSkillDialogOptions {
         if (!options) {
             throw new TypeError('Missing options parameter');
@@ -186,6 +235,13 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return options;
     }
 
+    /**
+     * @private
+     * @param context 
+     * @param activity 
+     * @param skillConversationId 
+     * @returns A Promise representing the asynchronous operation.
+     */
     private async sendToSkill(context: TurnContext, activity: Activity, skillConversationId: string): Promise<Activity> {
         if (activity.type === ActivityTypes.Invoke) {
             // Force ExpectReplies for invoke activities so we can get the replies right away and send them back to the channel if needed.
@@ -268,6 +324,14 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return false;
     }
 
+    /**
+     * @private
+     * @param incomingActivity 
+     * @param id 
+     * @param connectionName 
+     * @param token 
+     * @returns A Promise representing the asynchronous operation.
+     */
     private async sendTokenExchangeInvokeToSkill(incomingActivity: Activity, id: string, connectionName: string, token: string): Promise<boolean> {
         const ref: Partial<ConversationReference> = TurnContext.getConversationReference(incomingActivity);
         const activity: Activity = TurnContext.applyConversationReference({ ...incomingActivity }, ref) as any;
@@ -283,8 +347,14 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return isSuccessStatusCode(response.status);
     }
 
+    /**
+     * @private
+     * Create a conversationId to interact with the skill and send the activity.
+     * @param context Context for the current turn of conversation with the user.
+     * @param activity Activity to send.
+     * @returns The Skill Conversation ID.
+     */
     private async createSkillConversationId(context: TurnContext, activity: Activity) {
-        // Create a conversationId to interact with the skill and send the activity
         const conversationIdFactoryOptions: SkillConversationIdFactoryOptions = {
             fromBotOAuthScope: context.turnState.get(context.adapter.OAuthScopeKey),
             fromBotId: this.dialogOptions.botId,
@@ -305,6 +375,12 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         return skillConversationId;
     }
 
+    /**
+     * @private
+     * Gets the Skill Conversation ID from a given instance
+     * @param instance Instance from which to look for its ID
+     * @returns Instance conversation ID
+     */
     private getSkillConversationIdFromInstance(instance: DialogInstance): string {
         if (instance && instance.state) {
             return instance.state[this.SkillConversationIdStateKey];

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -37,7 +37,7 @@ import { SkillDialogOptions } from './skillDialogOptions';
 /**
  * A specialized Dialog that can wrap remote calls to a skill.
  * @remarks
- * The options parameter in BeginDialogAsync must be a BeginSkillDialogOptions instance
+ * The options parameter in beginDialog must be a BeginSkillDialogOptions instance
  * with the initial parameters for the dialog.
  */
 export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
@@ -165,7 +165,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     }
 
     /**
-     * Called when the skill dialog should re-prompt the user for input
+     * Called when the skill dialog should re-prompt the user for input.
      * @param context The context object for this turn.
      * @param instance State information for this dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -367,9 +367,9 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * @private
-     * Gets the Skill Conversation ID from a given instance
-     * @param instance Instance from which to look for its ID
-     * @returns Instance conversation ID
+     * Gets the Skill Conversation ID from a given instance.
+     * @param instance Instance from which to look for its ID.
+     * @returns Instance conversation ID.
      */
     private getSkillConversationIdFromInstance(instance: DialogInstance): string {
         if (instance && instance.state) {

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -221,7 +221,6 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * @private
-     * @param options
      */
     private validateBeginDialogArgs(options: BeginSkillDialogOptions): BeginSkillDialogOptions {
         if (!options) {
@@ -237,10 +236,6 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * @private
-     * @param context 
-     * @param activity 
-     * @param skillConversationId 
-     * @returns A Promise representing the asynchronous operation.
      */
     private async sendToSkill(context: TurnContext, activity: Activity, skillConversationId: string): Promise<Activity> {
         if (activity.type === ActivityTypes.Invoke) {
@@ -326,11 +321,6 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * @private
-     * @param incomingActivity 
-     * @param id 
-     * @param connectionName 
-     * @param token 
-     * @returns A Promise representing the asynchronous operation.
      */
     private async sendTokenExchangeInvokeToSkill(incomingActivity: Activity, id: string, connectionName: string, token: string): Promise<boolean> {
         const ref: Partial<ConversationReference> = TurnContext.getConversationReference(incomingActivity);

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -173,7 +173,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     /**
      * Called when the waterfall dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
-     * @param dc The <see cref="DialogContext"/> for the current turn of conversation.
+     * @param dc The DialogContext for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks 
      * If the task is successful, the result indicates whether the dialog is still
@@ -238,7 +238,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     }
 
     /**
-     * Excutes a step of the waterfall dialog.
+     * Executes a step of the waterfall dialog.
      * @param dc The DialogContext for the current turn of conversation.
      * @param index The index of the current waterfall step to execute.
      * @param reason The reason the waterfall step is being executed.
@@ -304,7 +304,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Identifies the step name by its position index.
-     * @param index 
+     * @param index Step position
      * @returns A string that identifies the step name.
      */
     private waterfallStepName(index: number): string {

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -173,12 +173,12 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     /**
      * Called when the waterfall dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     * @param dc The <see cref="DialogContext"/> for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
      * @remarks 
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
-        return value.
-     * @param dc The <see cref="DialogContext"/> for the current turn of conversation.
-     * @returns A Promise representing the asynchronous operation.
+     * return value.
      */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         // Don't do anything for non-message activities

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -90,7 +90,6 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Gets the dialog version, composed of the ID and number of steps.
-     * 
      * @returns Dialog version, composed of the ID and number of steps.
      */
     public getVersion(): string {
@@ -145,7 +144,6 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when the waterfall dialog is started and pushed onto the dialog stack.
-     * 
      * @remarks 
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
@@ -175,7 +173,6 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     /**
      * Called when the waterfall dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
-     * 
      * @remarks 
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
@@ -195,7 +192,6 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when a child waterfall dialog completed its turn, returning control to this dialog.
-     * 
      * @param dc The dialog context for the current turn of the conversation.
      * @param reason Reason why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
@@ -243,7 +239,6 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Excutes a step of the waterfall dialog.
-     * 
      * @param dc The DialogContext for the current turn of conversation.
      * @param index The index of the current waterfall step to execute.
      * @param reason The reason the waterfall step is being executed.

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -88,10 +88,15 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         }
     }
 
+    /**
+     * Gets the dialog version, composed of the ID and number of steps.
+     * 
+     * @returns Dialog version, composed of the ID and number of steps.
+     */
     public getVersion(): string {
         // Simply return the id + number of steps to help detect when new steps have
         // been added to a given waterfall.
-        return `${this.id}:${this.steps.length}`;
+        return `${ this.id }:${ this.steps.length }`;
     }
 
     /**
@@ -138,6 +143,16 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         return this;
     }
 
+    /**
+     * Called when the waterfall dialog is started and pushed onto the dialog stack.
+     * 
+     * @remarks 
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @param options Optional, initial information to pass to the dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
         // Initialize waterfall state
         const state: WaterfallDialogState = dc.activeDialog.state as WaterfallDialogState;
@@ -157,6 +172,17 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         return await this.runStep(dc, 0, DialogReason.beginCalled);
     }
 
+    /**
+     * Called when the waterfall dialog is _continued_, where it is the active dialog and the
+     * user replies with a new activity.
+     * 
+     * @remarks 
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog. The result may also contain a
+        return value.
+     * @param dc The <see cref="DialogContext"/> for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         // Don't do anything for non-message activities
         if (dc.context.activity.type !== ActivityTypes.Message) {
@@ -167,6 +193,15 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         return await this.resumeDialog(dc, DialogReason.continueCalled, dc.context.activity.text);
     }
 
+    /**
+     * Called when a child waterfall dialog completed its turn, returning control to this dialog.
+     * 
+     * @param dc The dialog context for the current turn of the conversation.
+     * @param reason Reason why the dialog resumed.
+     * @param result Optional, value returned from the dialog that was called. The type
+     * of the value returned is dependent on the child dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         // Increment step index and run step
         const state: WaterfallDialogState = dc.activeDialog.state as WaterfallDialogState;
@@ -206,6 +241,15 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         return await this.steps[step.index](step);
     }
 
+    /**
+     * Excutes a step of the waterfall dialog.
+     * 
+     * @param dc The DialogContext for the current turn of conversation.
+     * @param index The index of the current waterfall step to execute.
+     * @param reason The reason the waterfall step is being executed.
+     * @param result Optional, result returned by a dialog called in the previous waterfall step.
+     * @returns A Promise that represents the work queued to execute.
+     */
     protected async runStep(dc: DialogContext, index: number, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         if (index < this.steps.length) {
             // Update persisted step index
@@ -263,6 +307,11 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         }
     }
 
+    /**
+     * Identifies the step name by its position index.
+     * @param index 
+     * @returns A string that identifies the step name.
+     */
     private waterfallStepName(index: number): string {
         // Log Waterfall Step event. Each event has a distinct name to hook up
         // to the Application Insights funnel.


### PR DESCRIPTION
Addresses # 2602

## Description
This PR replaces `warn` with `error` in the `jsdoc/require-jsdoc` rule in [.eslintrc.json](https://github.com/microsoft/botbuilder-js/blob/master/.eslintrc.json#L87) file for [botbuilder-azure](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-azure) and adds all the missing documentation based on the errors thrown for files in the _root_ directory of the _botbuilder-dialogs library_.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

Note: this is the last PR of the series and should be merged last to avoid build errors.

## Specific Changes

  - Added JSDoc comments in all methods. 

## Testing
The following image shows the ESLint Report with no JSDoc errors for the updated files.
![image](https://user-images.githubusercontent.com/64803884/94315710-6c28b200-ff59-11ea-99e9-ed897c3c62b6.png)
