### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs/choices & /prompts

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
+++ b/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
@@ -135,6 +135,15 @@ export class ChoiceFactory {
         }
     }
 
+
+    /**
+     * Creates a message activity that includes a list of choices that have been added as `HeroCard`'s.
+     * 
+     * @param choices The list of choices to add.
+     * @param text Optional, text of the message.
+     * @param speak Optional, SSML text to be spoken by the bot on a speech-enabled channel.
+     * @returns An activity with choices as HeroCard with buttons.
+     */
     public static heroCard(choices: (string | Choice)[] = [], text = '', speak = ''): Activity {
         const buttons: CardAction[] = ChoiceFactory.toChoices(choices).map(choice => ({
             title: choice.value,

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -155,6 +155,7 @@ export class ActivityPrompt extends Dialog {
      * @param state Contains state for the current instance of the prompt on the dialog stack.
      * @param options A prompt options object constructed from the options initially provided
      * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {
         return { succeeded: true, value: context.activity };

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -29,6 +29,15 @@ export class ActivityPrompt extends Dialog {
         super(dialogId);
     }
 
+    /**
+     * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
+     * @param dc The DialogContext for the current turn of the conversation.
+     * @param options Additional information to pass to the prompt being started.
+     * @returns A Promise representing the asynchronous operation.
+     * @remarks 
+     * If the task is successful, the result indicates whether the prompt is still
+     * active after the turn has been processed by the prompt.
+     */
     public async beginDialog(dc: DialogContext, options: PromptOptions): Promise<DialogTurnResult> {
         // Ensure prompts have input hint set
         const opt: Partial<PromptOptions> = {...options};
@@ -50,6 +59,16 @@ export class ActivityPrompt extends Dialog {
         return Dialog.EndOfTurn;
     }
 
+    /**
+     * Called when a prompt dialog is the active dialog and the user replied with a new activity.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog.
+     * The prompt generally continues to receive the user's replies until it accepts the
+     * user's reply as valid input for the prompt.
+     */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         // Perform base recognition
         const state: any = dc.activeDialog.state as ActivityPromptState;
@@ -82,6 +101,15 @@ export class ActivityPrompt extends Dialog {
         }
     }
 
+    /**
+     * Called when a prompt dialog resumes being the active dialog on the dialog stack, such as
+     * when the previous active dialog on the stack completes.
+     * @param dc The DialogContext for the current turn of the conversation.
+     * @param reason An enum indicating why the dialog resumed.
+     * @param result Optional, value returned from the previous dialog on the stack.
+     * The type of the value returned is dependent on the previous dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         // Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
         // on top of the stack which will result in the prompt receiving an unexpected call to
@@ -93,11 +121,26 @@ export class ActivityPrompt extends Dialog {
         return Dialog.EndOfTurn;
     }
 
+    /**
+     * Called when a prompt dialog has been requested to re-prompt the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param instance The instance of the dialog on the stack.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         const state: ActivityPromptState = instance.state as ActivityPromptState;
         await this.onPrompt(context, state.state, state.options, false);
     }
 
+    /**
+     * When overridden in a derived class, prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry A boolean representing if the prompt is a retry.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: object, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
             await context.sendActivity(options.retryPrompt, undefined, InputHints.ExpectingInput);
@@ -106,6 +149,13 @@ export class ActivityPrompt extends Dialog {
         }
     }
 
+    /**
+     * When overridden in a derived class, attempts to recognize the incoming activity.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     */
     protected async onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {
         return { succeeded: true, value: context.activity };
     }

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -35,7 +35,7 @@ export class ActivityPrompt extends Dialog {
      * @param options Additional information to pass to the prompt being started.
      * @returns A Promise representing the asynchronous operation.
      * @remarks 
-     * If the task is successful, the result indicates whether the prompt is still
+     * If the promise is successful, the result indicates whether the prompt is still
      * active after the turn has been processed by the prompt.
      */
     public async beginDialog(dc: DialogContext, options: PromptOptions): Promise<DialogTurnResult> {
@@ -64,7 +64,7 @@ export class ActivityPrompt extends Dialog {
      * @param dc The DialogContext for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
-     * If the task is successful, the result indicates whether the dialog is still
+     * If the promise is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
      * The prompt generally continues to receive the user's replies until it accepts the
      * user's reply as valid input for the prompt.

--- a/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
@@ -25,6 +25,16 @@ export class AttachmentPrompt extends Prompt<Attachment[]> {
         super(dialogId, validator);
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
             await context.sendActivity(options.retryPrompt, undefined, InputHints.ExpectingInput);
@@ -33,6 +43,14 @@ export class AttachmentPrompt extends Prompt<Attachment[]> {
         }
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<Attachment[]>> {
         const value: Attachment[] = context.activity.attachments;
 

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -81,6 +81,16 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
         }
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         // Determine locale
         const locale = this.determineCulture(context.activity);
@@ -101,6 +111,14 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
         await context.sendActivity(prompt);
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<FoundChoice>> {
 
         const result: PromptRecognizerResult<FoundChoice> = { succeeded: false };
@@ -121,6 +139,9 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
         return result;
     }
 
+    /**
+     * @private
+     */
     private determineCulture(activity: Activity, opt: FindChoicesOptions = null): string {
         const optLocale = opt && opt.locale ? opt.locale : null;
         let culture = PromptCultureModels.mapToNearestLanguage(activity.locale || optLocale || this.defaultLocale || PromptCultureModels.English.locale);

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -83,6 +83,16 @@ export class ConfirmPrompt extends Prompt<boolean> {
         }
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
 
         // Format prompt to send
@@ -101,6 +111,14 @@ export class ConfirmPrompt extends Prompt<boolean> {
         await context.sendActivity(prompt);
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<boolean>> {
         const result: PromptRecognizerResult<boolean> = { succeeded: false };
         const activity: Activity = context.activity;
@@ -131,6 +149,9 @@ export class ConfirmPrompt extends Prompt<boolean> {
         return result;
     }
 
+    /**
+     * @private
+     */
     private determineCulture(activity: Activity): string {
         let culture: string = PromptCultureModels.mapToNearestLanguage(activity.locale || this.defaultLocale);
         if (!culture || !this.choiceDefaults.hasOwnProperty(culture)) {

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -55,6 +55,16 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
         this.defaultLocale = defaultLocale;
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
             await context.sendActivity(options.retryPrompt, undefined, InputHints.ExpectingInput);
@@ -63,6 +73,14 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
         }
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(
         context: TurnContext,
         state: any,

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -40,6 +40,16 @@ export class NumberPrompt extends Prompt<number> {
         this.defaultLocale = defaultLocale;
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
             await context.sendActivity(options.retryPrompt, undefined, InputHints.ExpectingInput);
@@ -48,6 +58,14 @@ export class NumberPrompt extends Prompt<number> {
         }
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<number>> {
         const result: PromptRecognizerResult<number> = { succeeded: false };
         const activity: Activity = context.activity;
@@ -68,6 +86,9 @@ export class NumberPrompt extends Prompt<number> {
         return result;
     }
 
+    /**
+     * @private 
+     */
     private getCultureFormattedForGlobalize(culture: string) {
         // The portions of the Globalize parsing library we use
         // only need the first 2 letters for internationalization culture

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -145,6 +145,15 @@ export class OAuthPrompt extends Dialog {
         super(dialogId);
     }
 
+    /**
+     * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
+     * @param dc The DialogContext for the current turn of the conversation.
+     * @param options Optional, additional information to pass to the prompt being started.
+     * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the prompt is still
+     * active after the turn has been processed by the prompt.
+     */
     public async beginDialog(dc: DialogContext, options?: PromptOptions): Promise<DialogTurnResult> {
         // Ensure prompts have input hint set
         const o: Partial<PromptOptions> = {...options};
@@ -176,6 +185,16 @@ export class OAuthPrompt extends Dialog {
         }
     }
 
+    /**
+     * Called when a prompt dialog is the active dialog and the user replied with a new activity.
+     * @param dc The DialogContext for the current turn of the conversation.
+     * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog.
+     * The prompt generally continues to receive the user's replies until it accepts the
+     * user's reply as valid input for the prompt.
+     */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         // Check for timeout
         const state: OAuthPromptState = dc.activeDialog.state as OAuthPromptState;
@@ -274,6 +293,9 @@ export class OAuthPrompt extends Dialog {
         return adapter.signOutUser(context, this.settings.connectionName, null, this.settings.oAuthAppCredentials);
     }
 
+    /**
+     * @private
+     */
     private async sendOAuthCardAsync(context: TurnContext, prompt?: string|Partial<Activity>): Promise<void> {
         // Validate adapter type
         if (!('getUserToken' in context.adapter)) {
@@ -342,6 +364,9 @@ export class OAuthPrompt extends Dialog {
         await context.sendActivity(msg);
     }
 
+    /**
+     * @private
+     */
     private async recognizeToken(dc: DialogContext): Promise<PromptRecognizerResult<TokenResponse>> {
         const context = dc.context;
         let token: TokenResponse|undefined;
@@ -441,6 +466,9 @@ export class OAuthPrompt extends Dialog {
         return token !== undefined ? { succeeded: true, value: token } : { succeeded: false };
     }
 
+    /**
+     * @private
+     */
     private static createCallerInfo(context: TurnContext) {
         const botIdentity = context.turnState.get(context.adapter.BotIdentityKey);
         if (botIdentity && isSkillClaim(botIdentity.claims)) {
@@ -453,6 +481,9 @@ export class OAuthPrompt extends Dialog {
         return null;
     }
 
+    /**
+     * @private
+     */
     private getTokenExchangeInvokeResponse(status: number, failureDetail: string, id?: string): Activity {
         const invokeResponse: Partial<Activity> = {
             type: 'invokeResponse',
@@ -461,22 +492,34 @@ export class OAuthPrompt extends Dialog {
         return invokeResponse as Activity;
     }
 
+    /**
+     * @private
+     */
     private static isFromStreamingConnection(activity: Activity): boolean {
         return activity && activity.serviceUrl && !activity.serviceUrl.toLowerCase().startsWith('http');
     }
 
+    /**
+     * @private
+     */
     private isTokenResponseEvent(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Event && activity.name === tokenResponseEventName;
     }
 
+    /**
+     * @private
+     */
     private isTeamsVerificationInvoke(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Invoke && activity.name === verifyStateOperationName;
     }
 
+    /**
+     * @private
+     */
     private isOAuthCardSupported(context: TurnContext): boolean {
         // Azure Bot Service OAuth cards are not supported in the community adapters. Since community adapters
         // have a 'name' in them, we cast the adapter to 'any' to check for the name.
@@ -496,13 +539,19 @@ export class OAuthPrompt extends Dialog {
         }
         return this.channelSupportsOAuthCard(context.activity.channelId);
     }
-    
+
+    /**
+     * @private
+     */
     private isTokenExchangeRequestInvoke(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Invoke && activity.name === tokenExchangeOperationName;
     }
 
+    /**
+     * @private
+     */
     private isTokenExchangeRequest(obj: unknown): obj is TokenExchangeInvokeRequest {
         if(obj.hasOwnProperty('token')) {
             return true;
@@ -510,6 +559,9 @@ export class OAuthPrompt extends Dialog {
         return false;
     }
 
+    /**
+     * @private
+     */
     private channelSupportsOAuthCard(channelId: string): boolean {
         switch (channelId) {
             case Channels.Cortana:
@@ -521,7 +573,10 @@ export class OAuthPrompt extends Dialog {
 
         return true;
     }
-    
+
+    /**
+     * @private
+     */
     private channelRequiresSignInLink(channelId: string): boolean {
         switch (channelId) {
             case Channels.Msteams:

--- a/libraries/botbuilder-dialogs/src/prompts/prompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/prompt.ts
@@ -264,7 +264,6 @@ export abstract class Prompt<T> extends Dialog {
     }
 
     /**
-     * @protected
      * Called before an event is bubbled to its parent.
      * @param dc The DialogContext for the current turn of conversation.
      * @param event The event being raised.

--- a/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
@@ -125,6 +125,9 @@ export class PromptCultureModels {
         noInLanguage: 'No',
     }
 
+    /**
+     * @private
+     */
     private static getSupportedCultureCodes(): string[] {
         return this.getSupportedCultures().map((c): string => c.locale);
     }

--- a/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
@@ -27,6 +27,16 @@ export class TextPrompt extends Prompt<string> {
         super(dialogId, validator);
     }
 
+    /**
+     * Prompts the user for input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @param isRetry `true` if this is the first time this prompt dialog instance
+     * on the stack is prompting the user for input; otherwise, false.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
             await context.sendActivity(options.retryPrompt, undefined, InputHints.ExpectingInput);
@@ -35,12 +45,30 @@ export class TextPrompt extends Prompt<string> {
         }
     }
 
+    /**
+     * Attempts to recognize the user's input.
+     * @param context Context for the current turn of conversation with the user.
+     * @param state Contains state for the current instance of the prompt on the dialog stack.
+     * @param options A prompt options object constructed from the options initially provided
+     * in the call to Prompt.
+     * @returns A Promise representing the asynchronous operation.
+     */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<string>> {
         const value: string = context.activity.text;
 
         return typeof value === 'string' && value.length > 0 ? { succeeded: true, value: value } : { succeeded: false };
     }
 
+    /**
+     * Called before an event is bubbled to its parent.
+     * @param dc The DialogContext for the current turn of conversation.
+     * @param event The event being raised.
+     * @returns Whether the event is handled by the current dialog and further processing should stop.
+     * @remarks
+     * This is a good place to perform interception of an event as returning `true` will prevent
+     * any further bubbling of the event to the dialogs parents and will also prevent any child
+     * dialogs from performing their default processing.
+     */
     protected async onPreBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean> {
         return false;
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds all the missing documentation based on the errors thrown for files in the _choices_ and _prompts_ directories of the _botbuilder-dialogs library_.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

Note: the `warn` property is replaced with `error` in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes

  - Added JSDoc comments in all methods. 

## Testing
The following image shows the ESLint Report with no JSDoc errors for the updated files.
**Choices**
![image](https://user-images.githubusercontent.com/64803884/94315788-9a0df680-ff59-11ea-8dfc-5e3fcad472b0.png)

**Prompts**
![image](https://user-images.githubusercontent.com/64803884/94316075-11dc2100-ff5a-11ea-8aef-7846293cd45b.png)
