### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs/memory/scopes

### DIFF
--- a/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
@@ -49,6 +49,13 @@ export class BotStateMemoryScope extends MemoryScope {
         throw new Error(`You cannot replace the root BotState object.`);
     }
 
+    /**
+     * Populates the state cache for this BotState from the storage layer.
+     * @param dc The DialogContext object for this turn.
+     * @param force >Optional, `true` to overwrite any existing state cache;
+     * or `false` to load state from storage only if the cache doesn't already exist.
+     * @returns A Promise that represents the work queued to execute.
+     */
     public async load(dc: DialogContext, force = false): Promise<void> {
         const botState: BotState = dc.context.turnState.get(this.stateKey);
         if (botState) {
@@ -56,6 +63,13 @@ export class BotStateMemoryScope extends MemoryScope {
         }
     }
 
+    /**
+     * Writes the state cache for this BotState to the storage layer.
+     * @param dc The DialogContext object for this turn.
+     * @param force Optional, `true` to save the state cache to storage;
+     * or `false` to save state to storage only if a property in the cache has changed.
+     * @returns A Promise that represents the work queued to execute.
+     */
     public async saveChanges(dc: DialogContext, force = false): Promise<void> {
         const botState: BotState = dc.context.turnState.get(this.stateKey);
         if (botState) {
@@ -63,6 +77,11 @@ export class BotStateMemoryScope extends MemoryScope {
         }
     }
 
+    /**
+     * Deletes any state in storage and the cache for this BotState.
+     * @param dc The DialogContext object for this turn.
+     * @returns A Promise that represents the work queued to execute.
+     */
     public async delete(dc: DialogContext): Promise<void> {
         return Promise.resolve();
     }

--- a/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
@@ -52,7 +52,7 @@ export class BotStateMemoryScope extends MemoryScope {
     /**
      * Populates the state cache for this BotState from the storage layer.
      * @param dc The DialogContext object for this turn.
-     * @param force >Optional, `true` to overwrite any existing state cache;
+     * @param force Optional, `true` to overwrite any existing state cache;
      * or `false` to load state from storage only if the cache doesn't already exist.
      * @returns A Promise that represents the work queued to execute.
      */

--- a/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
@@ -14,10 +14,19 @@ import { Dialog } from '../../dialog';
  * ClassMemoryScope maps "class" -> dc.activeDialog.properties
  */
 export class ClassMemoryScope extends MemoryScope {
+    /**
+     * Initializes a new instance of the ClassMemoryScope class.
+     * @param name Name of the scope class.
+     */
     public constructor(name = ScopePath.class) {
         super(name, false);
     }
 
+    /**
+     * Gets the backing memory for this scope.
+     * @param dc The DialogContext object for this turn.
+     * @returns The memory for the scope.
+     */
     public getMemory(dc: DialogContext): object {
         // if active dialog is a container dialog then "dialog" binds to it
         if (dc.activeDialog) {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/conversationMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/conversationMemoryScope.ts
@@ -13,6 +13,9 @@ import { ScopePath } from '../scopePath';
  */
 export class ConversationMemoryScope extends BotStateMemoryScope {
     protected stateKey = 'ConversationState';
+    /**
+     * Initializes a new instance of the ConversationMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.conversation);
     }

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
@@ -15,10 +15,18 @@ import { DialogContainer } from '../../dialogContainer';
  * DialogClassMemoryScope maps "dialogClass" -> dc.parent.activeDialog.properties
  */
 export class DialogClassMemoryScope extends ClassMemoryScope {
+    /**
+     * Initializes a new instance of the DialogClassMemoryScope class.
+     */
     constructor() {
         super(ScopePath.dialogClass);
     }
 
+    /**
+     * @protected
+     * @param dc The DialogContext object for this turn.
+     * @retuns The current Dialog.
+     */
     protected onFindDialog(dc: DialogContext): Dialog {
         // Is the active dialog a container?
         let dialog = dc.findDialog(dc.activeDialog.id);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
@@ -14,10 +14,18 @@ import { DialogContainer } from '../../dialogContainer';
  * DialogMemoryScope maps "dialog" -> dc.parent.activeDialog.state || dc.activeDialog.state
  */
 export class DialogMemoryScope extends MemoryScope {
+    /**
+     * Initializes a new instance of the DialogMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.dialog);
     }
 
+    /**
+     * Gets the backing memory for this scope
+     * @param dc The DialogContext object for this turn.
+     * @returns The memory for the scope.
+     */
     public getMemory(dc: DialogContext): object {
         // If active dialog is a container dialog then "dialog" binds to it.
         // Otherwise the "dialog" will bind to the dialogs parent assuming it 
@@ -31,6 +39,11 @@ export class DialogMemoryScope extends MemoryScope {
         return parent.activeDialog ? parent.activeDialog.state : undefined;
     }
 
+    /**
+     * Changes the backing object for the memory scope.
+     * @param dc The DialogContext object for this turn.
+     * @param memory Memory object to set for the scope.
+     */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
             throw new Error(`DialogMemoryScope.setMemory: undefined memory object passed in.`);
@@ -50,6 +63,11 @@ export class DialogMemoryScope extends MemoryScope {
         parent.activeDialog.state = memory;
     }
 
+    /**
+     * @private
+     * @param dc The DialogContext object for this turn.
+     * @returns A boolean indicating whether is a cointainer or not.
+     */
     private isContainer(dc: DialogContext): boolean {
         if (dc != undefined && dc.activeDialog != undefined) {
             var dialog = dc.findDialog(dc.activeDialog.id);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
@@ -22,7 +22,7 @@ export class DialogMemoryScope extends MemoryScope {
     }
 
     /**
-     * Gets the backing memory for this scope
+     * Gets the backing memory for this scope.
      * @param dc The DialogContext object for this turn.
      * @returns The memory for the scope.
      */

--- a/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
@@ -11,6 +11,12 @@ import { DialogContext } from '../../dialogContext';
  * Abstract base class for all memory scopes.
  */
 export abstract class MemoryScope {
+    /**
+     * Initializes a new instance of the MemoryScope class.
+     * @param name Name of the scope.
+     * @param includeInSnapshot Boolean value indicating whether this memory 
+     * should be included in snapshot. Default value is true.
+     */
     public constructor(name: string, includeInSnapshot = true)
     {
         this.includeInSnapshot = includeInSnapshot;

--- a/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
@@ -13,10 +13,18 @@ import { DialogContext } from '../../dialogContext';
  * SettingsMemoryScope maps "settings" -> dc.context.turnState['settings']
  */
 export class SettingsMemoryScope extends MemoryScope {
+    /**
+     * Initializes a new instance of the SettingsMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.settings, false);
     }
 
+    /**
+     * Gets the backing memory for this scope.
+     * @param dc The DialogContext object for this turn.
+     * @returns The memory for the scope.
+     */
     public getMemory(dc: DialogContext): object {
         let settings: object = {};
         if (dc.context.turnState.has(ScopePath.settings)) {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
@@ -13,14 +13,27 @@ import { DialogContext } from '../../dialogContext';
  * ThisMemoryScope maps "this" -> dc.activeDialog.state
  */
 export class ThisMemoryScope extends MemoryScope {
+    /**
+     * Initializes a new instance of the ThisMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.this);
     }
 
+    /**
+     * Gets the backing memory for this scope.
+     * @param dc The DialogContext object for this turn.
+     * @returns The memory for the scope.
+     */
     public getMemory(dc: DialogContext): object {
         return dc.activeDialog ? dc.activeDialog.state : undefined;
     }
 
+    /**
+     * Changes the backing object for the memory scope.
+     * @param dc The DialogContext object for this turn.
+     * @param memory Memory object to set for the scope.
+     */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
             throw new Error(`ThisMemoryScope.setMemory: undefined memory object passed in.`);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
@@ -18,10 +18,18 @@ const TURN_STATE = Symbol('turn');
  * TurnMemoryScope represents memory scoped to the current turn.
  */
 export class TurnMemoryScope extends MemoryScope {
+    /**
+     * Initializes a new instance of the TurnMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.turn);
     }
 
+    /**
+     * Get the backing memory for this scope.
+     * @param dc The DialogContext for this turn.
+     * @returns The memory for the scope.
+     */
     public getMemory(dc: DialogContext): object {
         let memory = dc.context.turnState.get(TURN_STATE);
         if (typeof memory != 'object') {
@@ -32,6 +40,11 @@ export class TurnMemoryScope extends MemoryScope {
         return memory;
     }
 
+    /**
+     * Changes the backing object for the memory scope.
+     * @param dc The DialogContext for this turn.
+     * @param memory Memory object to set for the scope.
+     */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
             throw new Error(`TurnMemoryScope.setMemory: undefined memory object passed in.`);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/userMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/userMemoryScope.ts
@@ -13,6 +13,9 @@ import { ScopePath } from '../scopePath';
  */
 export class UserMemoryScope extends BotStateMemoryScope {
     protected stateKey = 'UserState';
+    /**
+     * Initializes a new instance of the UserMemoryScope class.
+     */
     public constructor() {
         super(ScopePath.user);
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds all the missing documentation based on the errors thrown for files in the _memory/scopes_ directory of the _botbuilder-dialogs library_.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

Note: the `warn` property is replaced with `error` in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes

  - Added JSDoc comments in all methods. 

## Testing
The following image shows the ESLint Report with no JSDoc errors for the updated files.
![image](https://user-images.githubusercontent.com/64803884/94315825-a8f4a900-ff59-11ea-88e1-f48092a252f8.png)
