### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs/memory/pathResolver

### DIFF
--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
@@ -15,12 +15,23 @@ export class AliasPathResolver implements PathResolver {
     private readonly prefix: string;
     private readonly postfix: string;
 
+    /**
+     * Initializes a new instance of the AliasPathResolver class.
+     * @param alias Alias name.
+     * @param prefix Prefix name.
+     * @param postfix Postfix name.
+     */
     constructor(alias: string, prefix: string, postfix?: string) {
         this.alias = alias.trim();
         this.prefix = prefix.trim();
         this.postfix = postfix ? postfix.trim() : '';
     }
 
+    /**
+     * Transforms the path.
+     * @param path Path to inspect.
+     * @returns The transformed path.
+     */
     public transformPath(path: string): string {
         const start = path.indexOf(this.alias);
         if (start == 0) {

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/atAtPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/atAtPathResolver.ts
@@ -12,6 +12,9 @@ import { AliasPathResolver } from './aliasPathResolver';
  */
 export class AtAtPathResolver extends AliasPathResolver {
 
+    /**
+     * Initializes a new instance of the AtAtPathResolver class.
+     */
     constructor() {
         super('@@', 'turn.recognized.entities.');
     }

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
@@ -15,10 +15,18 @@ export class AtPathResolver extends AliasPathResolver {
     private readonly _prefix = 'turn.recognized.entities.';
     private readonly _delims = ['.', '['];
 
+    /**
+     * Initializes a new instance of the AtPathResolver class.
+     */
     public constructor() {
         super('@', '');
     }
 
+    /**
+     * Transforms the path.
+     * @param path Path to inspect.
+     * @returns The transformed path.
+     */
     public transformPath(path: string): string {
         path = path.trim();
         if (path.startsWith('@') && path.length > 1 && !path.startsWith('@@')) {

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/dollarPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/dollarPathResolver.ts
@@ -12,6 +12,9 @@ import { AliasPathResolver } from './aliasPathResolver';
  */
 export class DollarPathResolver extends AliasPathResolver {
 
+    /**
+     * Initializes a new instance of the DollarPathResolver class.
+     */
     constructor() {
         super('$', 'dialog.');
     }

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/hashPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/hashPathResolver.ts
@@ -12,6 +12,9 @@ import { AliasPathResolver } from './aliasPathResolver';
  */
 export class HashPathResolver extends AliasPathResolver {
 
+    /**
+     * Initializes a new instance of the HashPathResolver class.
+     */
     constructor() {
         super('#', 'turn.recognized.intents.');
     }

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/percentPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/percentPathResolver.ts
@@ -12,6 +12,9 @@ import { AliasPathResolver } from './aliasPathResolver';
  */
 export class PercentPathResolver extends AliasPathResolver {
 
+    /**
+     * Initializes a new instance of the PercentPathResolver class.
+     */
     constructor() {
         super('%', 'class.');
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds all the missing documentation based on the errors thrown for files in the _memory/pathResolver_ directory of the _botbuilder-dialogs library_.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

Note: the `warn` property is replaced with `error` in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes

  - Added JSDoc comments in all methods. 

## Testing
The following image shows the ESLint Report with no JSDoc errors for the updated files.
![image](https://user-images.githubusercontent.com/64803884/94315845-b27e1100-ff59-11ea-959e-5db6f20b0789.png)
