### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs/memory

### DIFF
--- a/libraries/botbuilder-dialogs/src/memory/dialogPath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/dialogPath.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Defines path for available dialogs.
+ */
 export class DialogPath {
     /// Counter of emitted events.
     public static readonly eventCounter = 'dialog.eventCounter';

--- a/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
+++ b/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
@@ -550,7 +550,7 @@ export class DialogStateManager {
     }
 
     /**
-     * Gets the standard dialog state manager configuration.
+     * Creates a standard dialog state manager configuration.
      * @returns A DialogStateManagerConfiguration with the standard configuration.
      */
     public static createStandardConfiguration(): DialogStateManagerConfiguration {

--- a/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
+++ b/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
@@ -412,7 +412,7 @@ export class DialogStateManager {
 
     /**
      * @private
-     * @param path track path to change.
+     * @param path Track path to change.
      */
     private trackChange(path: string): void {
         // Normalize path and scan for any matches or children that match.
@@ -533,7 +533,7 @@ export class DialogStateManager {
     /**
      * @private
      * Gets MemoryScope by name.
-     * @param name name of scope.
+     * @param name Name of scope.
      * @returns The MemoryScope.
      */
     private getMemoryScope(name: string): MemoryScope | undefined {

--- a/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
+++ b/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
@@ -37,6 +37,11 @@ const DIALOG_STATE_MANAGER_CONFIGURATION = 'DialogStateManagerConfiguration';
 export class DialogStateManager {
     private readonly dialogContext: DialogContext;
 
+    /**
+     * Initializes a new instance of the DialogStateManager class.
+     * @param dc The dialog context for the current turn of the conversation.
+     * @param configuration Configuration for the dialog state manager.
+     */
     public constructor(dc: DialogContext, configuration?: DialogStateManagerConfiguration) {
         this.dialogContext = dc;
         this.configuration = configuration ? configuration : dc.context.turnState.get(DIALOG_STATE_MANAGER_CONFIGURATION);
@@ -405,6 +410,10 @@ export class DialogStateManager {
         return found;
     }
 
+    /**
+     * @private
+     * @param path track path to change.
+     */
     private trackChange(path: string): void {
         // Normalize path and scan for any matches or children that match.
         // - We're appending an extra '_' so that we can do substring matches and
@@ -425,6 +434,13 @@ export class DialogStateManager {
         }
     }
 
+    /**
+     * @private
+     * @param memory Object memory to resolve.
+     * @param segments Segments of the memory to resolve.
+     * @param assignment Optional.
+     * @returns The value of the memory segment.
+     */
     private resolveSegments(memory: object, segments: (string | number)[], assignment?: boolean): any {
         let value: any = memory;
         const l = assignment ? segments.length - 1 : segments.length;
@@ -500,6 +516,9 @@ export class DialogStateManager {
         return value;
     }
 
+    /**
+     * @private
+     */
     private findObjectKey(obj: object, key: string): string | undefined {
         const k = key.toLowerCase();
         for (const prop in obj) {
@@ -511,6 +530,12 @@ export class DialogStateManager {
         return undefined;
     }
 
+    /**
+     * @private
+     * Gets MemoryScope by name.
+     * @param name name of scope.
+     * @returns The MemoryScope.
+     */
     private getMemoryScope(name: string): MemoryScope | undefined {
         const key = name.toLowerCase();
         const scopes = this.configuration.memoryScopes;
@@ -524,6 +549,10 @@ export class DialogStateManager {
         return undefined;
     }
 
+    /**
+     * Gets the standard dialog state manager configuration.
+     * @returns A DialogStateManagerConfiguration with the standard configuration.
+     */
     public static createStandardConfiguration(): DialogStateManagerConfiguration {
         const config: DialogStateManagerConfiguration = {
             pathResolvers: [
@@ -548,6 +577,10 @@ export class DialogStateManager {
         return config;
     }
 
+    /**
+     * Gets the version number.
+     * @returns A string with the version number.
+     */
     public version(): string {
         return '0';
     }

--- a/libraries/botbuilder-dialogs/src/memory/scopePath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopePath.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Defines paths for the available scopes.
+ */
 export class ScopePath {
     /**
      * User memory scope root path.

--- a/libraries/botbuilder-dialogs/src/memory/thisPath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/thisPath.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Defines path passed to the active dialog.
+ */
 export class ThisPath {
     /**
      * The options that were passed to the active dialog via options argument of BeginDialog.

--- a/libraries/botbuilder-dialogs/src/memory/turnPath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/turnPath.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Defines path for avaiable turns.
+ */
 export class TurnPath {
     /// The result from the last dialog that was called.
     public static readonly lastResult = 'turn.lastresult';


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds all the missing documentation based on the errors thrown for files in the _memory_ directory of the _botbuilder-dialogs library_.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

Note: the `warn` property is replaced with `error` in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes

  - Added JSDoc comments in all methods. 

## Testing
The following image shows the ESLint Report with no JSDoc errors for the updated files.
![image](https://user-images.githubusercontent.com/64803884/94315855-b742c500-ff59-11ea-9857-b3f4fc25c805.png)
