### PR TITLE
[JSDoc] Add missing documentation for botframework-streaming

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -260,7 +260,7 @@
             "files": ["libraries/botframework-streaming/src/*.ts", "libraries/botframework-streaming/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
+++ b/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
@@ -53,7 +53,7 @@ export class PayloadAssembler {
 
     /**
      * Retrieves the assembler's payload as a stream.
-     * @returns >A `SubscribableStream` of the assembler's payload.
+     * @returns A `SubscribableStream` of the assembler's payload.
      */
     public getPayloadStream(): SubscribableStream {
         if (!this.stream) {

--- a/libraries/botframework-streaming/src/contentStream.ts
+++ b/libraries/botframework-streaming/src/contentStream.ts
@@ -9,11 +9,19 @@ import { SubscribableStream } from './subscribableStream';
 import { PayloadAssembler } from './assemblers';
 import { INodeBuffer } from './interfaces/INodeBuffer';
 
+/**
+ * A stream of fixed or infinite length containing content to be decoded.
+ */
 export class ContentStream {
     public id: string;
     private readonly assembler: PayloadAssembler;
     private stream: SubscribableStream;
 
+    /**
+     * Initializes a new instance of the `ContentStream` class.
+     * @param id The ID assigned to this instance.
+     * @param assembler The `PayloadAssembler` assigned to this instance.
+     */
     public constructor(id: string, assembler: PayloadAssembler) {
         if (!assembler) {
             throw Error('Null Argument Exception');
@@ -22,14 +30,23 @@ export class ContentStream {
         this.assembler = assembler;
     }
 
+    /**
+     * Gets the name of the type of the object contained within this `ContentStream`.
+     */
     public get contentType(): string {
         return this.assembler.payloadType;
     }
 
+    /**
+     * Gets the length of this `ContentStream`.
+     */
     public get length(): number {
         return this.assembler.contentLength;
     }
 
+    /**
+     * Gets the data contained within this `ContentStream`.
+     */
     public getStream(): SubscribableStream {
         if (!this.stream) {
             this.stream = this.assembler.getPayloadStream();
@@ -38,15 +55,26 @@ export class ContentStream {
         return this.stream;
     }
 
+    /**
+     * Closes the assembler.
+     */
     public cancel(): void {
         this.assembler.close();
     }
 
+    /**
+     * Gets the `SubscribableStream` content as a string.
+     * @returns A string Promise with `SubscribableStream` content.
+     */
     public async readAsString(): Promise<string> {
         const { bufferArray } = await this.readAll();
         return (bufferArray || []).map(result => result.toString('utf8')).join('');
     }
 
+    /**
+     * Gets the `SubscribableStream` content as a typed JSON object.
+     * @returns A typed object Promise with `SubscribableStream` content.
+     */
     public async readAsJson<T>(): Promise<T> {
         let stringToParse = await this.readAsString();
         try {
@@ -56,6 +84,9 @@ export class ContentStream {
         }
     }
 
+    /**
+     * @private
+     */
     private async readAll(): Promise<Record<string, any>> {
     // do a read-all
         let allData: INodeBuffer[] = [];

--- a/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
@@ -9,17 +9,29 @@ import { IHeader } from '../interfaces/IHeader';
 import { PayloadTypes } from '../payloads/payloadTypes';
 import { PayloadSender } from '../payloadTransport/payloadSender';
 
+/**
+ * Streaming cancel disassembler.
+ */
 export class CancelDisassembler {
     private readonly sender: PayloadSender;
     private readonly id: string;
     private readonly payloadType: PayloadTypes;
 
+    /**
+     * Initializes a new instance of the `CancelDisassembler` class.
+     * @param sender The `PayloadSender` that this Cancel request will be sent by.
+     * @param id The ID of the Stream to cancel.
+     * @param payloadType The type of the Stream that is being cancelled.
+     */
     public constructor(sender: PayloadSender, id: string, payloadType: PayloadTypes) {
         this.sender = sender;
         this.id = id;
         this.payloadType = payloadType;
     }
 
+    /**
+     * Initiates the process of disassembling the request and signals the `PayloadSender` to begin sending.
+     */
     public disassemble(): void {
         const header: IHeader = {payloadType: this.payloadType, payloadLength: 0, id: this.id, end: true};
         this.sender.sendPayload(header);

--- a/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
@@ -19,11 +19,20 @@ export class HttpContentStreamDisassembler extends PayloadDisassembler {
     public readonly contentStream: HttpContentStream;
     public payloadType: PayloadTypes = PayloadTypes.stream;
 
+    /**
+     * Initializes a new instance of the `HttpContentStreamDisassembler` class.
+     * @param sender The `PayloadSender` to send the disassembled data to.
+     * @param contentStream The `HttpContentStream` to be disassembled.
+     */
     public constructor(sender: PayloadSender, contentStream: HttpContentStream) {
         super(sender, contentStream.id);
         this.contentStream = contentStream;
     }
 
+    /**
+     * Gets the stream this disassembler is operating on.
+     * @returns An `IStreamWrapper` with a Subscribable Strea.
+     */
     public async getStream(): Promise<IStreamWrapper> {
         let stream: SubscribableStream = this.contentStream.content.getStream();
 

--- a/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
@@ -21,11 +21,20 @@ export abstract class PayloadDisassembler {
     private streamLength?: number;
     private readonly id: string;
 
+    /**
+     * Initializes a new instance of the `PayloadDisassembler` class.
+     * @param sender The `PayloadSender` used to send the disassembled payload chunks.
+     * @param id The ID of this disassembler.
+     */
     public constructor(sender: PayloadSender, id: string) {
         this.sender = sender;
         this.id = id;
     }
 
+    /**
+     * Serializes the item into the `IStreamWrapper` that exposes the stream and length of the result.
+     * @param item The item to be serialized.
+     */
     protected static serialize<T>(item: T): IStreamWrapper {
         let stream: SubscribableStream = new SubscribableStream();
 
@@ -35,8 +44,15 @@ export abstract class PayloadDisassembler {
         return {stream, streamLength: stream.length};
     }
 
+    /**
+     * Gets the stream this disassembler is operating on.
+     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     */
     public abstract async getStream(): Promise<IStreamWrapper>;
 
+    /**
+     * Begins the process of disassembling a payload and sending the resulting chunks to the `PayloadSender` to dispatch over the transport.
+     */
     public async disassemble(): Promise<void> {
         let { stream, streamLength }: IStreamWrapper = await this.getStream();
 
@@ -46,6 +62,9 @@ export abstract class PayloadDisassembler {
         return this.send();
     }
 
+    /**
+     * Begins the process of disassembling a payload and signals the `PayloadSender`.
+     */
     private async send(): Promise<void> {
         let header: IHeader = {payloadType: this.payloadType, payloadLength: this.streamLength, id: this.id, end: true};
         this.sender.sendPayload(header, this.stream);

--- a/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
@@ -19,11 +19,21 @@ export class RequestDisassembler extends PayloadDisassembler {
     public request: StreamingRequest;
     public payloadType: PayloadTypes = PayloadTypes.request;
 
+    /**
+     * Initializes a new instance of the `RequestDisassembler` class.
+     * @param sender The `PayloadSender` to send the disassembled data to.
+     * @param id The ID of this disassembler.
+     * @param request The request to be disassembled.
+     */
     public constructor(sender: PayloadSender, id: string, request?: StreamingRequest) {
         super(sender, id);
         this.request = request;
     }
 
+    /**
+     * Gets the stream this disassembler is operating on.
+     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     */
     public async getStream(): Promise<IStreamWrapper> {
         let payload: IRequestPayload = {verb: this.request.verb, path: this.request.path, streams: []};
         if (this.request.streams) {

--- a/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
@@ -19,11 +19,21 @@ export class ResponseDisassembler extends PayloadDisassembler {
     public readonly response: StreamingResponse;
     public readonly payloadType: PayloadTypes = PayloadTypes.response;
 
+    /**
+     * Initializes a new instance of the `ResponseDisassembler` class.
+     * @param sender The `PayloadSender` to send the disassembled data to.
+     * @param id The ID of this disassembler.
+     * @param response The response to be disassembled.
+     */
     public constructor(sender: PayloadSender, id: string, response: StreamingResponse) {
         super(sender, id);
         this.response = response;
     }
 
+    /**
+     * Gets the stream this disassembler is operating on.
+     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     */
     public async getStream(): Promise<IStreamWrapper> {
         let payload: IResponsePayload = {statusCode: this.response.statusCode, streams: []};
         if (this.response.streams) {

--- a/libraries/botframework-streaming/src/httpContentStream.ts
+++ b/libraries/botframework-streaming/src/httpContentStream.ts
@@ -9,11 +9,19 @@ import { SubscribableStream } from './subscribableStream';
 import { generateGuid } from './utilities/protocol-base';
 import { IHttpContentHeaders } from './interfaces/IHttpContentHeaders';
 
+/**
+ * An attachment contained within a StreamingRequest's stream collection,
+ * which itself contains any form of media item.
+ */
 export class HttpContentStream {
     public readonly id: string;
     public readonly content: HttpContent;
     public description: { id: string; type: string; length: number; };
 
+    /**
+     * Initializes a new instance of the `HttpContentStream` class.
+     * @param content The content to assign to the `HttpContentStream`.
+     */
     public constructor(content: HttpContent) {
         this.id = generateGuid();
         this.content = content;
@@ -21,15 +29,26 @@ export class HttpContentStream {
     }
 }
 
+/**
+ * The HttpContent class that contains a SubscribableStream.
+ */
 export class HttpContent {
     public headers: IHttpContentHeaders;
     private readonly stream: SubscribableStream;
 
+    /**
+     * Initializes a new instance of the `HttpContent` class.
+     * @param headers The Streaming Http content header definition.
+     * @param stream The stream of buffered data.
+     */
     public constructor(headers: IHttpContentHeaders, stream: SubscribableStream) {
         this.headers = headers;
         this.stream = stream;
     }
 
+    /**
+     * Gets the data contained within this `HttpContent`.
+     */
     public getStream(): SubscribableStream {
         return this.stream;
     }

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
@@ -29,7 +29,7 @@ export class NamedPipeClient implements IStreamingTransportClient {
     private readonly _protocolAdapter: ProtocolAdapter;
     private readonly _autoReconnect: boolean;
     private _isDisconnecting: boolean;
-    
+
     /**
      * Creates a new instance of the [NamedPipeClient](xref:botframework-streaming.NamedPipeClient) class.
      *
@@ -79,6 +79,9 @@ export class NamedPipeClient implements IStreamingTransportClient {
         return this._protocolAdapter.sendRequest(request);
     }
 
+    /**
+     * @private
+     */
     private onConnectionDisconnected(sender: object, args: any): void {
         if (!this._isDisconnecting) {
             this._isDisconnecting = true;

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
@@ -120,7 +120,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
             this._outgoingServer = null;
         }
     }
-    
+
     /**
      * Task used to send data over this client connection.
      *
@@ -131,6 +131,9 @@ export class NamedPipeServer implements IStreamingTransportServer {
         return this._protocolAdapter.sendRequest(request);
     }
 
+    /**
+     * @private
+     */
     private onConnectionDisconnected(): void {
         if (!this._isDisconnecting) {
             this._isDisconnecting = true;

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeTransport.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeTransport.ts
@@ -101,6 +101,9 @@ export class NamedPipeTransport implements ITransportSender, ITransportReceiver 
         return promise;
     }
 
+    /**
+     * @private
+     */
     private socketReceive(data: INodeBuffer): void {
         if (this._queue && data && data.length > 0) {
             this._queue.push(data);
@@ -108,6 +111,9 @@ export class NamedPipeTransport implements ITransportSender, ITransportReceiver 
         }
     }
 
+    /**
+     * @private
+     */
     private socketClose(): void {
         if (this._activeReceiveReject) {
             this._activeReceiveReject(new Error('Socket was closed.'));
@@ -121,6 +127,9 @@ export class NamedPipeTransport implements ITransportSender, ITransportReceiver 
         this._socket = null;
     }
 
+    /**
+     * @private
+     */
     private socketError(err: Error): void {
         if (this._activeReceiveReject) {
             this._activeReceiveReject(err);
@@ -128,6 +137,9 @@ export class NamedPipeTransport implements ITransportSender, ITransportReceiver 
         this.socketClose();
     }
 
+    /**
+     * @private
+     */
     private trySignalData(): void {
         if (this._activeReceiveResolve) {
             if (!this._active && this._queue.length > 0) {

--- a/libraries/botframework-streaming/src/protocolAdapter.ts
+++ b/libraries/botframework-streaming/src/protocolAdapter.ts
@@ -49,11 +49,6 @@ export class ProtocolAdapter {
         this.payloadReceiver.subscribe((header: IHeader): SubscribableStream => this.assemblerManager.getPayloadStream(header),(header: IHeader, contentStream: SubscribableStream, contentLength: number): void => this.assemblerManager.onReceive(header, contentStream, contentLength));
     }
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="request">The outgoing request to send.</param>
-    /// <param name="cancellationToken">Optional cancellation token.</param>
     /**
      * Sends a request over the attached request manager.
      * @param request The outgoing request to send.

--- a/libraries/botframework-streaming/src/protocolAdapter.ts
+++ b/libraries/botframework-streaming/src/protocolAdapter.ts
@@ -19,6 +19,9 @@ import { generateGuid } from './utilities/protocol-base';
 import { IReceiveResponse, IReceiveRequest } from './interfaces';
 import { IHeader } from './interfaces/IHeader';
 
+/**
+ * Creates a protocol adapter for Streaming.
+ */
 export class ProtocolAdapter {
     private readonly requestHandler: RequestHandler;
     private readonly payloadSender: PayloadSender;
@@ -28,13 +31,13 @@ export class ProtocolAdapter {
     private readonly streamManager: StreamManager;
     private readonly assemblerManager: PayloadAssemblerManager;
 
-    /// <summary>
-    /// Creates a new instance of the protocol adapter class.
-    /// </summary>
-    /// <param name="requestHandler">The handler that will process incoming requests.</param>
-    /// <param name="requestManager">The manager that will process outgoing requests.</param>
-    /// <param name="sender">The sender for use with outgoing requests.</param>
-    /// <param name="receiver">The receiver for use with incoming requests.</param>
+    /**
+     * Creates a new instance of the protocol adapter class.
+     * @param requestHandler The handler that will process incoming requests.
+     * @param requestManager The manager that will process outgoing requests.
+     * @param sender The sender for use with outgoing requests.
+     * @param receiver The receiver for use with incoming requests.
+     */
     public constructor(requestHandler: RequestHandler, requestManager: RequestManager, sender: PayloadSender, receiver: PayloadReceiver) {
         this.requestHandler = requestHandler;
         this.requestManager = requestManager;
@@ -47,10 +50,15 @@ export class ProtocolAdapter {
     }
 
     /// <summary>
-    /// Sends a request over the attached request manager.
+    ///
     /// </summary>
     /// <param name="request">The outgoing request to send.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
+    /**
+     * Sends a request over the attached request manager.
+     * @param request The outgoing request to send.
+     * @returns The response to the specified request.
+     */
     public async sendRequest(request: StreamingRequest): Promise<IReceiveResponse> {
         let requestId: string = generateGuid();
         await this.sendOperations.sendRequest(requestId, request);
@@ -58,11 +66,11 @@ export class ProtocolAdapter {
         return this.requestManager.getResponse(requestId);
     }
 
-    /// <summary>
-    /// Executes the receive pipeline when a request comes in.
-    /// </summary>
-    /// <param name="id">The id the resources created for the response will be assigned.</param>
-    /// <param name="request">The incoming request to process.</param>
+    /**
+     * Executes the receive pipeline when a request comes in.
+     * @param id The id the resources created for the response will be assigned.
+     * @param request The incoming request to process.
+     */
     public async onReceiveRequest(id: string, request: IReceiveRequest): Promise<void> {
         if (this.requestHandler) {
             let response = await this.requestHandler.processRequest(request);
@@ -73,22 +81,19 @@ export class ProtocolAdapter {
         }
     }
 
-    /// <summary>
-    /// Executes the receive pipeline when a response comes in.
-    /// </summary>
-    /// <param name="id">The id the resources created for the response will be assigned.</param>
-    /// <param name="response">The incoming response to process.</param>
+    /**
+     * Executes the receive pipeline when a response comes in.
+     * @param id The id the resources created for the response will be assigned.
+     * @param response The incoming response to process.
+     */
     public async onReceiveResponse(id: string, response: IReceiveResponse): Promise<void> {
         await this.requestManager.signalResponse(id, response);
     }
 
-    /// <summary>
-    /// Executes the receive pipeline when a cancellation comes in.
-    /// </summary>
-    /// <param name="contentStreamAssembler">
-    /// The payload assembler processing the incoming data that this
-    /// cancellation request targets.
-    /// </param>
+    /**
+     * Executes the receive pipeline when a cancellation comes in.
+     * @param contentStreamAssembler The payload assembler processing the incoming data that this cancellation request targets.
+     */
     public onCancelStream(contentStreamAssembler: PayloadAssembler): void {
         this.sendOperations.sendCancelStream(contentStreamAssembler.id)
             .catch();

--- a/libraries/botframework-streaming/src/streamingRequest.ts
+++ b/libraries/botframework-streaming/src/streamingRequest.ts
@@ -8,6 +8,9 @@
 import { HttpContent, HttpContentStream } from './httpContentStream';
 import { SubscribableStream } from './subscribableStream';
 
+/**
+ * The basic request type sent over Bot Framework Protocol 3 with Streaming Extensions transports, equivalent to HTTP request messages.
+ */
 export class StreamingRequest {
 
     /**

--- a/libraries/botframework-streaming/src/streamingResponse.ts
+++ b/libraries/botframework-streaming/src/streamingResponse.ts
@@ -8,6 +8,9 @@
 import { HttpContent, HttpContentStream } from './httpContentStream';
 import { SubscribableStream } from './subscribableStream';
 
+/**
+ * The basic response type sent over Bot Framework Protocol 3 with Streaming Extensions transports, equivalent to HTTP response messages.
+ */
 export class StreamingResponse {
     public statusCode: number;
     public streams: HttpContentStream[] = [];

--- a/libraries/botframework-streaming/src/subscribableStream.ts
+++ b/libraries/botframework-streaming/src/subscribableStream.ts
@@ -7,16 +7,30 @@
  */
 import { Duplex, DuplexOptions } from 'stream';
 
+/**
+ * An extension of `Duplex` that operates in conjunction with a `PayloadAssembler` to convert raw bytes into a consumable form.
+ */
 export class SubscribableStream extends Duplex {
     public length: number = 0;
 
     private readonly bufferList: Buffer[] = [];
     private _onData: (chunk: any) => void;
 
+    /**
+     * Initializes a new instance of the `SubscribableStream` class.
+     * @param options The `DuplexOptions` to use when constructing this stream.
+     */
     public constructor(options?: DuplexOptions) {
         super(options);
     }
 
+    /**
+     * Writes data to the buffered list.
+     * All calls to writable.write() that occur between the time writable._write() is called and the callback is called will cause the written data to be buffered.
+     * @param chunk The Buffer to be written.
+     * @param encoding The encoding.
+     * @param callback Callback for when this chunk of data is flushed.
+     */
     public _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void {
         let buffer = Buffer.from(chunk);
         this.bufferList.push(buffer);
@@ -27,6 +41,12 @@ export class SubscribableStream extends Duplex {
         callback();
     }
 
+    /**
+     * Reads the buffered list.
+     * Once the readable._read() method has been called, it will not be called again until more data is pushed through the readable.push() method.
+     * Empty data such as empty buffers and strings will not cause readable._read() to be called.
+     * @param size Number of bytes to read.
+     */
     public _read(size: number): void {
         if (this.bufferList.length === 0) {
             // null signals end of stream
@@ -42,6 +62,10 @@ export class SubscribableStream extends Duplex {
         }
     }
 
+    /**
+     * Subscribes to the stream when receives data.
+     * @param onData Callback to be called when onData is executed.
+     */
     public subscribe(onData: (chunk: any) => void): void {
         this._onData = onData;
     }

--- a/libraries/botframework-streaming/src/utilities/protocol-base.ts
+++ b/libraries/botframework-streaming/src/utilities/protocol-base.ts
@@ -7,6 +7,10 @@
  */
 import uuidv4 = require('uuid/v4');
 
+/**
+ * Generates an uuid v4 string.
+ * @returns An uuidv4 string.
+ */
 export function generateGuid(): string {
     return uuidv4();
 }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR introduces the change to `jsdoc/require-jsdoc` in the [.eslintrc.json](https://github.com/microsoft/botbuilder-js/blob/master/.eslintrc.json#L263) file from `warn` to `error` and adds all the missing JSDoc documentation for [botframework-streaming](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botframework-streaming) based on the errors thrown. Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

> **Note:** We divided the work for this library into two PRs to ease the review. PR# 151 contains the rest of the botbuilder fixes.

## Specific Changes

  - Updated `jsdoc/require-jsdoc` in `.eslintrc.json` from `warn` to `error`.
  - Private methods' documentation that does not exist on botbuilder-dotnet we added the `@private` tag in the JSDoc comment.
  - Added JSDoc comments in **16 files**.

## Testing
In the following image there is a sneak peek about the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/62260472/94316276-6f706d80-ff5a-11ea-93b6-3afd520d33f6.png)