### PR TITLE
[JSDoc] Add missing documentation for botbuilder-lg root files

### DIFF
--- a/libraries/botbuilder-lg/src/analyzer.ts
+++ b/libraries/botbuilder-lg/src/analyzer.ts
@@ -18,7 +18,7 @@ import { AnalyzerResult } from './analyzerResult';
 import {TemplateErrors} from './templateErrors';
 
 /**
- * Analyzer engine. To to get the static analyzer results.
+ * Analyzer engine. To get the static analyzer results.
  */
 export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implements LGTemplateParserVisitor<AnalyzerResult> {
     /**
@@ -30,6 +30,11 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     private readonly evalutationTargetStack: EvaluationTarget[] = [];
     private readonly _expressionParser: ExpressionParserInterface;
 
+    /**
+     * Creates a new instance of the Analyzer class.
+     * @param templates Template list.
+     * @param expressionParser Expression parser.
+     */
     public constructor(templates: Template[], expressionParser: ExpressionParser) {
         super();
         this.templates = templates;
@@ -69,10 +74,18 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return dependencies;
     }
 
+    /**
+     * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitNormalBody(ctx: lp.NormalBodyContext): AnalyzerResult {
         return this.visit(ctx.normalTemplateBody());
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
         for (const templateStr of ctx.templateString()) {
@@ -82,6 +95,10 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
+     * @param ctx The parse tree.
+     */
     public visitStructuredTemplateBody(ctx: lp.StructuredTemplateBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
 
@@ -98,6 +115,10 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.structuredValue.
+     * @param ctx The parse tree.
+     */
     public visitStructureValue(ctx: lp.KeyValueStructureLineContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
 
@@ -116,6 +137,10 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitIfElseBody(ctx: lp.IfElseBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
 
@@ -133,6 +158,10 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
         const switchCaseNodes: lp.SwitchCaseRuleContext[] = ctx.switchCaseTemplateBody().switchCaseRule();
@@ -149,6 +178,10 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateString(ctx: lp.NormalTemplateStringContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
         
@@ -159,10 +192,17 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * Gets the default value returned by visitor methods.
+     * @returns An instance of the AnalyzerResult class.
+     */
     protected defaultResult(): AnalyzerResult {
         return new AnalyzerResult();
     }
 
+    /**
+     * @private
+     */
     private analyzeExpressionDirectly(exp: Expression): AnalyzerResult {
         const result: AnalyzerResult =  new AnalyzerResult();
 
@@ -185,6 +225,9 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
         return result;
     }
 
+    /**
+     * @private
+     */
     private analyzeExpression(exp: string): AnalyzerResult {
         const result: AnalyzerResult =  new AnalyzerResult();
         exp = TemplateExtensions.trimExpression(exp);

--- a/libraries/botbuilder-lg/src/analyzerResult.ts
+++ b/libraries/botbuilder-lg/src/analyzerResult.ts
@@ -20,6 +20,11 @@ export class AnalyzerResult {
      */
     public TemplateReferences: string[];
 
+    /**
+     * Creates a new instance of the AnalyzerResult class.
+     * @param variables Init varibales.
+     * @param templateRefNames Init template references.
+     */
     public constructor(variables: string[] = [], templateRefNames: string[] = []) {
         this.Variables = Array.from(new Set(variables));
         this.TemplateReferences = Array.from(new Set(templateRefNames));

--- a/libraries/botbuilder-lg/src/customizedMemory.ts
+++ b/libraries/botbuilder-lg/src/customizedMemory.ts
@@ -25,6 +25,11 @@ export class CustomizedMemory implements MemoryInterface {
      */
     public localMemory: MemoryInterface;
 
+    /**
+     * Creates a new instance of the CustomizedMemory class.
+     * @param scope Optional. Scope.
+     * @param localMemory Optional. Local memory.
+     */
     public constructor(scope?: any, localMemory?: MemoryInterface) {
         this.globalMemory = !scope ? undefined : SimpleObjectMemory.wrap(scope);
         this.localMemory = localMemory;
@@ -51,11 +56,21 @@ export class CustomizedMemory implements MemoryInterface {
         return undefined;
     }
 
+    /**
+     * Set value to a given path. This method is not implemented.
+     * @param _path Memory path.
+     * @param _value Value to set.
+     */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public setValue(_path: string, _value: any): void {
         return;
     }
 
+    /**
+     * Used to identify whether a particular memory instance has been updated or not.
+     * If version is not changed, the caller may choose to use the cached result instead of recomputing everything.
+     * @returns A string indicating the version.
+     */
     public  version(): string {
         let result = '';
         if (this.globalMemory) {

--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -29,6 +29,14 @@ export class Diagnostic {
     public source: string;
     public message: string;
 
+    /**
+     * Creates a new instance of the Diagnostic class.
+     * @param range Range where the error or warning occurred.
+     * @param message Error message of the error or warning.
+     * @param severity Severity of the error or warning.
+     * @param source Source of the error or warning occurred.
+     * @param code Code or identifier of the error or warning.
+     */
     public constructor(
         range: Range,
         message: string,
@@ -42,6 +50,10 @@ export class Diagnostic {
         this.code = code;
     }
 
+    /**
+     * Returns a string that represents the current Diagnostic object.
+     * @returns A string that represents the current Diagnostic.
+     */
     public toString(): string {
         // ignore error range if source is "inline content"
         if (this.source === TemplatesParser.inlineContentId) {

--- a/libraries/botbuilder-lg/src/errorListener.ts
+++ b/libraries/botbuilder-lg/src/errorListener.ts
@@ -18,6 +18,12 @@ import { TemplateErrors } from './templateErrors';
 export class ErrorListener implements ANTLRErrorListener<any> {
     private readonly source: string;
     private lineOffset: number;
+    
+    /**
+     * Creates a new instance of the ErrorListener class.
+     * @param errorSource String value that represents the source of the error.
+     * @param lineOffset Offset of the line where the error occurred.
+     */
     public constructor(errorSource: string, lineOffset?: number) {
         this.source = errorSource;
         if (lineOffset === undefined) {
@@ -26,6 +32,15 @@ export class ErrorListener implements ANTLRErrorListener<any> {
         this.lineOffset = lineOffset;
     }
 
+    /**
+     * Notifies any interested parties upon a syntax error.
+     * @param recognizer What parser got the error. From this object, you can access the context as well as the input stream.
+     * @param offendingSymbol Offending token in the input token stream, unless recognizer is a lexer (then it's null).
+     * @param line Line number in the input where the error occurred.
+     * @param charPositionInLine Character position within the line where the error occurred.
+     * @param msg Message to emit.
+     * @param e Exception.
+     */
     public syntaxError<T>(
         recognizer: Recognizer<T, any>,
         offendingSymbol: any,

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -31,6 +31,9 @@ export enum LGCacheScope {
     None = 'none'
 }
 
+/**
+ * Options for evaluating LG templates.
+ */
 export class EvaluationOptions {
     private readonly nullKeyReplaceStrRegex = /\${\s*path\s*}/g;
     private readonly strictModeKey = '@strict';
@@ -48,6 +51,10 @@ export class EvaluationOptions {
      */
     public cacheScope: LGCacheScope | undefined;
 
+    /**
+     * Creates a new instance of the EvaluationOptions class.
+     * @param opt Instance to copy initial settings from.
+     */
     public constructor(opt?: EvaluationOptions | string[]) {
         if (arguments.length === 0) {
             this.strictMode = undefined;
@@ -83,6 +90,12 @@ export class EvaluationOptions {
         }
     }
 
+    /**
+     * Merges an incoming option to current option. If a property in incoming option is not null while it is null in current
+     * option, then the value of this property will be overwritten.
+     * @param opt Incoming option for merging.
+     * @returns Result after merging.
+     */
     public merge(opt: EvaluationOptions): EvaluationOptions {
         const properties = ['strictMode', 'nullSubstitution', 'LineBreakStyle'];
         for (const property of properties) {

--- a/libraries/botbuilder-lg/src/evaluationTarget.ts
+++ b/libraries/botbuilder-lg/src/evaluationTarget.ts
@@ -28,6 +28,12 @@ export class EvaluationTarget {
      * The children templates that this template has evaluated currently. 
      */
     public cachedEvaluatedChildren : Map<string, any>;
+    
+    /**
+     * Creates a new instance of the EvaluationTarget class.
+     * @param templateName Template name.
+     * @param scope Template scope.
+     */
     public constructor(templateName: string, scope: MemoryInterface) {
         this.templateName = templateName;
         this.scope = scope;

--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -51,6 +51,12 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     public static readonly expandTextFunctionName = 'expandText';
     public static readonly ReExecuteSuffix = '!';
 
+    /**
+     * Creates a new instance of the Evaluator class.
+     * @param templates Template list.
+     * @param expressionParser Expression parser.
+     * @param opt Options for LG.
+     */
     public constructor(templates: Template[], expressionParser: ExpressionParser, opt: EvaluationOptions = undefined) {
         super();
         this.templates = templates;
@@ -126,6 +132,10 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
+     * @param ctx The parse tree.
+     */
     public visitStructuredTemplateBody(ctx: lp.StructuredTemplateBodyContext): any {
         const result: any = {};
         const typeName: string = ctx.structuredBodyNameLine().STRUCTURE_NAME().text;
@@ -154,6 +164,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return result;
     }
 
+    /**
+     * @private
+     */
     private visitStructureValue(ctx: lp.KeyValueStructureLineContext): any {
         const values = ctx.keyValueStructureValue();
 
@@ -189,10 +202,18 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return result.length === 1? result[0] : result;
     }
 
+    /**
+     * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitNormalBody(ctx: lp.NormalBodyContext): any {
         return this.visit(ctx.normalTemplateBody());
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): any {
         const normalTemplateStrs: lp.TemplateStringContext[] = ctx.templateString();
         const randomNumber: number = Math.floor(Math.random() * normalTemplateStrs.length);
@@ -200,6 +221,10 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return this.visit(normalTemplateStrs[randomNumber].normalTemplateString());
     }
 
+    /**
+     * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitIfElseBody(ctx: lp.IfElseBodyContext): any {
         const ifRules: lp.IfConditionRuleContext[] = ctx.ifElseTemplateBody().ifConditionRule();
         for (const ifRule of ifRules) {
@@ -211,6 +236,10 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return undefined;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateString(ctx: lp.NormalTemplateStringContext): string {
         const prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(ctx);
         const result: any[] = [];
@@ -248,6 +277,14 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         }).join('');
     }
 
+    /**
+     * Constructs the scope for mapping the values of arguments to the parameters of the template.
+     * Throws errors if certain errors detected TemplateErrors.
+     * @param inputTemplateName Template name to evaluate.
+     * @param args Arguments to map to the template parameters.
+     * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory
+     * with the mapping of the parameter name to the argument value added to the scope.
+     */
     public constructScope(inputTemplateName: string, args: any[]): any {
         var templateName = this.parseTemplateName(inputTemplateName).pureTemplateName;
 
@@ -273,6 +310,10 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return new CustomizedMemory(memory.globalMemory, SimpleObjectMemory.wrap(newScope));
     }
 
+    /**
+     * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): string {
         const switchcaseNodes: lp.SwitchCaseRuleContext[] = ctx.switchCaseTemplateBody().switchCaseRule();
         const length: number = switchcaseNodes.length;
@@ -308,14 +349,29 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return undefined;
     }
 
+    /**
+     * Replaces an expression contained in a text.
+     * @param exp Expression Text.
+     * @param regex Regex to select the text to replace.
+     */
     public wrappedEvalTextContainsExpression(exp: string, regex: RegExp): string {
         return (exp.split('').reverse().join('').replace(regex, (sub: string): any => this.evalExpression(sub.split('').reverse().join('')).toString().split('').reverse().join(''))).split('').reverse().join('');
     }
 
+    /**
+     * Gets the default value returned by visitor methods. 
+     * @returns Empty string.
+     */
     protected defaultResult(): string {
         return '';
     }
 
+    /**
+     * Concatenates two error messages.
+     * @param firstError First error message to concatenate.
+     * @param secondError Second error message to concatenate.
+     * @returns The concatenated error messages.
+     */
     public static concatErrorMsg(firstError: string, secondError: string): string {
         let errorMsg: string;
         if (!firstError) {
@@ -328,6 +384,15 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return errorMsg;
     }
 
+    /**
+     * Checks an Expression Result and throws the corresponding error.
+     * @param exp Expression text.
+     * @param error Error message.
+     * @param result Result.
+     * @param templateName Template name.
+     * @param inlineContent Optional. In line content.
+     * @param errorPrefix Optional. Error prefix.
+     */
     public static checkExpressionResult(exp: string, error: string, result: any, templateName: string, inlineContent: string = '', errorPrefix: string = ''): void {
         let errorMsg = '';
 
@@ -349,18 +414,24 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         throw new Error(Evaluator.concatErrorMsg(childErrorMsg, errorMsg));
     }
 
+    /**
+     * @private
+     */
     private currentTarget(): EvaluationTarget {
         // just don't want to write evaluationTargetStack.Peek() everywhere
         return this.evaluationTargetStack[this.evaluationTargetStack.length - 1];
     }
 
+    /**
+     * @private
+     */
     private evalCondition(condition: lp.IfConditionContext): boolean {
         const expression = condition.expression()[0]; // Here ts is diff with C#, C# use condition.EXPRESSION(0) == null
         // to judge ELSE condition. But in ts lib this action would throw
         // Error
 
         if (!expression) {
-            return true;                                            // no expression means it's else
+            return true; // no expression means it's else
         }
 
         if (this.evalExpressionInCondition(expression, condition.text, `Condition '` + expression.text + `':`)) {
@@ -370,6 +441,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return false;
     }
 
+    /**
+     * @private
+     */
     private evalExpressionInCondition(expressionContext: ParserRuleContext, contentLine: string, errorPrefix: string = ''): boolean {
         const exp = TemplateExtensions.trimExpression(expressionContext.text);
         let result: any;
@@ -394,6 +468,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return true;
     }
 
+    /**
+     * @private
+     */
     private evalExpression(exp: string, expressionContext?: ParserRuleContext, inlineContent: string = '', errorPrefix: string = ''): any
     {
         exp = TemplateExtensions.trimExpression(exp);
@@ -420,6 +497,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return result;
     }
 
+    /**
+     * @private
+     */
     private evalByAdaptiveExpression(exp: string, scope: any): { value: any; error: string } {
         const parse: Expression = this.expressionParser.parse(exp);
         const opt = new Options();
@@ -495,6 +575,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return newTemplates.evaluateText(stringContent, newScope, this.lgOptions);
     }
 
+    /**
+     * @private
+     */
     private getResourcePath(filePath: string): string {
         let resourcePath: string;
         if (path.isAbsolute(filePath)) {
@@ -551,6 +634,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         }
     }
 
+    /**
+     * @private
+     */
     private checkTemplateReference(templateName: string, children: Expression[]): void{
         if (!(templateName in this.templateMap))
         {
@@ -576,6 +662,9 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         return this.checkTemplateReference(expression.type, expression.children);
     }
 
+    /**
+     * @private
+     */
     private parseTemplateName(templateName: string): { reExecute: boolean; pureTemplateName: string } {
         if (!templateName) {
             throw new Error('template name is empty.');

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -49,6 +49,12 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
     private readonly evaluationTargetStack: EvaluationTarget[] = [];
     private readonly lgOptions: EvaluationOptions;
 
+    /**
+     * Creates a new instance of the Expander class.
+     * @param templates Template list.
+     * @param expressionParser Given expression parser.
+     * @param opt Options for LG including strictMode, replaceNull and lineBreakStyle.
+     */
     public constructor(templates: Template[], expressionParser: ExpressionParser, opt: EvaluationOptions = undefined) {
         super();
         this.templates = templates;
@@ -90,10 +96,18 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitNormalBody(ctx: lp.NormalBodyContext): any[] {
         return this.visit(ctx.normalTemplateBody());
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): any[] {
         const normalTemplateStrs: lp.TemplateStringContext[] = ctx.templateString();
         let result: any[] = [];
@@ -104,6 +118,10 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitIfElseBody(ctx: lp.IfElseBodyContext): any[] {
         const ifRules: lp.IfConditionRuleContext[] = ctx.ifElseTemplateBody().ifConditionRule();
         for (const ifRule of ifRules) {
@@ -115,6 +133,10 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return undefined;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.structuredBody.
+     * @param ctx The parse tree.
+     */
     public visitStructuredBody(ctx: lp.StructuredBodyContext): any[] {
         const templateRefValues: Map<string, any> = new Map<string, any>();
         const stb: lp.StructuredTemplateBodyContext = ctx.structuredTemplateBody();
@@ -192,6 +214,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return finalResult;
     }
 
+    /**
+     * @private
+     */
     private visitStructureValue(ctx: lp.KeyValueStructureLineContext): any[] {
         const values = ctx.keyValueStructureValue();
 
@@ -225,6 +250,10 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     * @param ctx The parse tree.
+     */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): any[] {
         const switchcaseNodes: lp.SwitchCaseRuleContext[] = ctx.switchCaseTemplateBody().switchCaseRule();
         const length: number = switchcaseNodes.length;
@@ -262,6 +291,10 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return undefined;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     * @param ctx The parse tree.
+     */
     public visitNormalTemplateString(ctx: lp.NormalTemplateStringContext): any[] {
         var prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(ctx);
         let result: string[] = [''];
@@ -290,6 +323,13 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return result;
     }
 
+    /**
+     * Constructs the scope for mapping the values of arguments to the parameters of the template.
+     * @param templateName The template name to evaluate.
+     * @param args Arguments to map to the template parameters.
+     * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory
+     * with the mapping of the parameter name to the argument value added to the scope.
+     */
     public constructScope(templateName: string, args: any[]): any {
         const parameters: string[] = this.templateMap[templateName].parameters;
 
@@ -304,14 +344,24 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return newScope;
     }
 
+    /**
+     * Gets the default value returned by visitor methods.
+     * @returns Empty string array.
+     */
     protected defaultResult(): string[] {
         return [];
     }
 
+    /**
+     * @private
+     */
     private currentTarget(): EvaluationTarget {
         return this.evaluationTargetStack[this.evaluationTargetStack.length - 1];
     }
 
+    /**
+     * @private
+     */
     private evalCondition(condition: lp.IfConditionContext): boolean {
         const expression = condition.expression()[0];
         if (!expression) {
@@ -325,6 +375,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return false;
     }
 
+    /**
+     * @private
+     */
     private evalExpressionInCondition(expressionContext: ParserRuleContext, contentLine: string, errorPrefix: string = ''): boolean {
         const exp = TemplateExtensions.trimExpression(expressionContext.text);
         let result: any;
@@ -349,6 +402,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return true;
     }
 
+    /**
+     * @private
+     */
     private evalExpression(exp: string, context: ParserRuleContext, inlineContent: string = '', errorPrefix: string = ''): any[] {
         exp = TemplateExtensions.trimExpression(exp);
         let result: any;
@@ -378,6 +434,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return [ result.toString() ];
     }
 
+    /**
+     * @private
+     */
     private evalByAdaptiveExpression(exp: string, scope: any): any {
         const expanderExpression: Expression = this.expanderExpressionParser.parse(exp);
         const evaluatorExpression: Expression = this.evaluatorExpressionParser.parse(exp);
@@ -386,6 +445,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return parse.tryEvaluate(scope);
     }
 
+    /**
+     * @private
+     */
     private stringArrayConcat(array1: string[], array2: string[]): string[] {
         const result: string[] = [];
         for (const item1 of array1) {
@@ -459,6 +521,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return this.expandTemplate(templateName, newScope);
     }
 
+    /**
+     * @private
+     */
     private reconstructExpression(expanderExpression: Expression, evaluatorExpression: Expression, foundPrebuiltFunction: boolean): Expression {
         if (this.templateMap[expanderExpression.type]) {
             if (foundPrebuiltFunction) {
@@ -498,6 +563,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return newTemplates.evaluateText(stringContent, newScope, this.lgOptions);
     }
 
+    /**
+     * @private
+     */
     private getResourcePath(filePath: string): string {
         let resourcePath: string;
         if (path.isAbsolute(filePath)) {
@@ -555,6 +623,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         }
     }
 
+    /**
+     * @private
+     */
     private checkTemplateReference(templateName: string, children: Expression[]): void{
         if (!(templateName in this.templateMap))
         {
@@ -574,6 +645,9 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
         return this.checkTemplateReference(expression.type, expression.children);
     }
 
+    /**
+     * @private
+     */
     private parseTemplateName(templateName: string): { reExecute: boolean; pureTemplateName: string } {
         if (!templateName) {
             throw new Error('template name is empty.');

--- a/libraries/botbuilder-lg/src/extractor.ts
+++ b/libraries/botbuilder-lg/src/extractor.ts
@@ -18,12 +18,21 @@ import { Template } from './template';
 export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implements LGTemplateParserVisitor<Map<string, any>> {
     public readonly templates: Template[];
     public readonly templateMap: {[name: string]: Template};
+    
+    /**
+     * Creates a new instance of the Extractor class.
+     * @param templates Template list.
+     */
     public constructor(templates: Template[]) {
         super();
         this.templates = templates;
         this.templateMap = keyBy(templates, (t: Template): string => t.name);
     }
 
+    /**
+     * Extracts the templates and returns a map with their names and bodys.
+     * @returns Map object with template names and bodies.
+     */
     public extract(): Map<string, any>[] {
         const result: Map<string, any>[] = [];
         this.templates.forEach((template: Template): any => {
@@ -49,6 +58,10 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     * @param context The parse tree.
+     */
     public visitNormalTemplateBody(context: lp.NormalTemplateBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
         for (const templateStr of context.templateString()) {
@@ -58,6 +71,10 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the structuredBody labeled alternative in LGTemplateParser.body.
+     * @param context The parse tree.
+     */
     public visitStructuredBody(context: lp.StructuredBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
         const lineStart = '    ';
@@ -70,6 +87,10 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     * @param context The parse tree.
+     */
     public visitIfElseBody(context: lp.IfElseBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
         const ifRules: lp.IfConditionRuleContext[] = context.ifElseTemplateBody().ifConditionRule();
@@ -101,6 +122,10 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
         return result;
     }
 
+    /**
+     * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     * @param context The parse tree.
+     */
     public visitSwitchCaseBody(context: lp.SwitchCaseBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
         const switchCaseNodes: lp.SwitchCaseRuleContext[] = context.switchCaseTemplateBody().switchCaseRule();
@@ -133,6 +158,10 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
         return result;
     }
 
+    /**
+     * Gets the default value returned by visitor methods.
+     * @returns Empty Map<string, any>.
+     */
     protected defaultResult(): Map<string, any> {
         return new Map<string, any>();
     }

--- a/libraries/botbuilder-lg/src/extractor.ts
+++ b/libraries/botbuilder-lg/src/extractor.ts
@@ -30,7 +30,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     }
 
     /**
-     * Extracts the templates and returns a map with their names and bodys.
+     * Extracts the templates and returns a map with their names and bodies.
      * @returns Map object with template names and bodies.
      */
     public extract(): Map<string, any>[] {

--- a/libraries/botbuilder-lg/src/lgResource.ts
+++ b/libraries/botbuilder-lg/src/lgResource.ts
@@ -26,6 +26,12 @@ export class LGResource {
      * Source of this template
      */
 
+    /**
+     * Creates a new instance of the LGResource class.
+     * @param id Resource id.
+     * @param fullName The full path to the resource on disk.
+     * @param content Resource content.
+     */
     public constructor(id: string, fullName: string, content: string) {
         this.id = id || '';
         this.fullName = fullName || '';

--- a/libraries/botbuilder-lg/src/multiLanguageLG.ts
+++ b/libraries/botbuilder-lg/src/multiLanguageLG.ts
@@ -145,6 +145,9 @@ export class MultiLanguageLG {
         throw new Error(`No LG responses found for locale: ${ locale }`);
     }
 
+    /**
+     * @private
+     */
     private  getDefaultPolicy(defaultLanguages: string[]): Map<string, string[]> {
         if (defaultLanguages === undefined) {
             defaultLanguages = [''];


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder-lg](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-lg) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

_Note: We divided the work for this library into two PRs to easy their review. The PR# 155 contains the rest of the botbuilder-lg fixes._

## Specific Changes

- Added JSDoc comments in all public methods and some of the private ones in the following files:
    - analyzer
    - analyzerResult
    - customizedMemory
    - diagnostic
    - errorListener
    - evaluationOptions
    - evaluationTarget
    - evaluator
    - expander
    - extractor
    - lgResource
    - multiLanguageLG

## Testing
The following image shows the ESLint Report with no JSDoc errors for the files updated.
![image](https://user-images.githubusercontent.com/44245136/94465317-1725af80-0196-11eb-8f0f-88deeb87afbb.png)
