### PR TITLE
[JSDoc] Add missing documentation for botframework-config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -212,7 +212,7 @@
             "files": ["libraries/botframework-config/src/*.ts", "libraries/botframework-config/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -126,6 +126,9 @@ export class BotConfiguration extends BotConfigurationBase {
         return encrypt.generateKey();
     }
 
+    /**
+     * @private
+     */
     private static internalLoad(json: string, secret?: string): BotConfiguration {
         const bot: BotConfiguration = BotConfiguration.fromJSON(JSON.parse(json));
 
@@ -317,6 +320,9 @@ export class BotConfiguration extends BotConfigurationBase {
         }
     }
 
+    /**
+     * @private
+     */
     private savePrep(secret?: string): void {
         if (!!secret) {
             this.validateSecret(secret);

--- a/libraries/botframework-config/src/botRecipe.ts
+++ b/libraries/botframework-config/src/botRecipe.ts
@@ -87,6 +87,11 @@ export class BotRecipe {
         // noop
     }
 
+    /**
+     * Creates a new `BotRecipe` instance from a JSON object.
+     * @param source JSON object of `BotRecipe` type.
+     * @returns A new `BotRecipe` instance.
+     */
     public static fromJSON(source: Partial<BotRecipe> = {}): BotRecipe {
         const botRecipe: BotRecipe = new BotRecipe();
         const { version, resources } = source;
@@ -96,6 +101,10 @@ export class BotRecipe {
         return botRecipe;
     }
 
+    /**
+     * Creates a JSON object from `this` class instance.
+     * @returns A JSON object of `BotRecipe` type;
+     */
     public toJSON(): Partial<BotRecipe> {
         const { version, resources } = this;
 

--- a/libraries/botframework-config/src/models/appInsightsService.ts
+++ b/libraries/botframework-config/src/models/appInsightsService.ts
@@ -36,6 +36,11 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
         this.apiKeys = this.apiKeys || {};
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {
@@ -48,6 +53,11 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
         }
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {

--- a/libraries/botframework-config/src/models/blobStorageService.ts
+++ b/libraries/botframework-config/src/models/blobStorageService.ts
@@ -30,12 +30,22 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
         super(source, ServiceTypes.BlobStorage);
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.connectionString && this.connectionString.length > 0) {
             this.connectionString = encryptString(this.connectionString, secret);
         }
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.connectionString && this.connectionString.length > 0) {
             this.connectionString = decryptString(this.connectionString, secret);

--- a/libraries/botframework-config/src/models/botService.ts
+++ b/libraries/botframework-config/src/models/botService.ts
@@ -25,10 +25,20 @@ export class BotService extends AzureService implements IBotService {
         super(source, ServiceTypes.Bot);
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         return;
     }

--- a/libraries/botframework-config/src/models/cosmosDbService.ts
+++ b/libraries/botframework-config/src/models/cosmosDbService.ts
@@ -40,14 +40,22 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
         super(source, ServiceTypes.CosmosDB);
     }
 
-    // encrypt keys in service
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.key && this.key.length > 0) {
             this.key = encryptString(this.key, secret);
         }
     }
 
-    // decrypt keys in service
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.key && this.key.length > 0) {
             this.key = decryptString(this.key, secret);

--- a/libraries/botframework-config/src/models/endpointService.ts
+++ b/libraries/botframework-config/src/models/endpointService.ts
@@ -42,12 +42,22 @@ export class EndpointService extends ConnectedService implements IEndpointServic
         super(source, ServiceTypes.Endpoint);
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.appPassword && this.appPassword.length > 0) {
             this.appPassword = encryptString(this.appPassword, secret);
         }
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.appPassword && this.appPassword.length > 0) {
             this.appPassword = decryptString(this.appPassword, secret);

--- a/libraries/botframework-config/src/models/fileService.ts
+++ b/libraries/botframework-config/src/models/fileService.ts
@@ -25,10 +25,20 @@ export class FileService extends ConnectedService implements IFileService {
         super(source, ServiceTypes.File);
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         return;
     }

--- a/libraries/botframework-config/src/models/genericService.ts
+++ b/libraries/botframework-config/src/models/genericService.ts
@@ -30,6 +30,11 @@ export class GenericService extends ConnectedService implements IGenericService 
         super(source, ServiceTypes.Generic);
     }
 
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         const that: GenericService = this;
         if (this.configuration) {
@@ -39,6 +44,11 @@ export class GenericService extends ConnectedService implements IGenericService 
         }
     }
 
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         const that: GenericService = this;
         if (this.configuration) {

--- a/libraries/botframework-config/src/models/luisService.ts
+++ b/libraries/botframework-config/src/models/luisService.ts
@@ -52,7 +52,7 @@ export class LuisService extends ConnectedService implements ILuisService {
         super(source, serviceType || ServiceTypes.Luis);
     }
 
-    /** 
+    /**
      * Get endpoint for the luis service. If a customEndpoint is set then this is returned
      * otherwise the endpoint is automatically generated based on the region set.
      */
@@ -64,24 +64,28 @@ export class LuisService extends ConnectedService implements ILuisService {
             return this.customEndpoint;
         }
 
-        let reg  = this.region.toLowerCase(); 
+        let reg  = this.region.toLowerCase();
 
         // usgovvirginia is that actual azure region name, but the cognitive service team called their endpoint 'virginia' instead of 'usgovvirginia'
         // We handle both region names as an alias for virginia.api.cognitive.microsoft.us
-        if (reg === 'virginia' || reg === 'usgovvirginia') 
-        { 
-            return `https://virginia.api.cognitive.microsoft.us`; 
-        } 
+        if (reg === 'virginia' || reg === 'usgovvirginia')
+        {
+            return `https://virginia.api.cognitive.microsoft.us`;
+        }
         // regardless, if it starts with usgov or usdod then it is us TLD (ex: api.cognitive.microsoft.us )
-        else if (reg.startsWith('usgov') || reg.startsWith('usdod')) 
-        { 
-            return `https://${ this.region }.api.cognitive.microsoft.us`; 
-        } 
- 
-        return `https://${ this.region }.api.cognitive.microsoft.com`;     
+        else if (reg.startsWith('usgov') || reg.startsWith('usdod'))
+        {
+            return `https://${ this.region }.api.cognitive.microsoft.us`;
+        }
+
+        return `https://${ this.region }.api.cognitive.microsoft.com`;
     }
 
-    // encrypt keys in service
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.authoringKey && this.authoringKey.length > 0) {
             this.authoringKey = encryptString(this.authoringKey, secret);
@@ -91,7 +95,11 @@ export class LuisService extends ConnectedService implements ILuisService {
         }
     }
 
-    // decrypt keys in service
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.authoringKey && this.authoringKey.length > 0) {
             this.authoringKey = decryptString(this.authoringKey, secret);

--- a/libraries/botframework-config/src/models/qnaMakerService.ts
+++ b/libraries/botframework-config/src/models/qnaMakerService.ts
@@ -39,7 +39,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
      */
     constructor(source: IQnAService = {} as IQnAService) {
         super(source, ServiceTypes.QnA);
-        
+
         if (!source.hostname) {
             throw TypeError('QnAMakerService requires source parameter to have a hostname.')
         }
@@ -49,7 +49,11 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
         }
     }
 
-    // encrypt keys in service
+    /**
+     * Encrypt properties on this service.
+     * @param secret Secret to use to encrypt.
+     * @param encryptString Function called to encrypt an individual value.
+     */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.endpointKey && this.endpointKey.length > 0) {
             this.endpointKey = encryptString(this.endpointKey, secret);
@@ -60,7 +64,11 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
         }
     }
 
-    // decrypt keys in service
+    /**
+     * Decrypt properties on this service.
+     * @param secret Secret to use to decrypt.
+     * @param decryptString Function called to decrypt an individual value.
+     */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.endpointKey && this.endpointKey.length > 0) {
             this.endpointKey = decryptString(this.endpointKey, secret);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR introduces the change to `jsdoc/require-jsdoc` in the [.eslintrc.json](https://github.com/microsoft/botbuilder-js/blob/master/.eslintrc.json#L215) file from `warn` to `error` and adds all the missing JSDoc documentation for [botframework-config](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botframework-config) based on the errors thrown. Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes

- Updated `jsdoc/require-jsdoc` in `.eslintrc.json` from `warn` to `error`.
- Private methods' documentation that does not exist on botbuilder-dotnet we added the `@private` tag in the JSDoc comment.
- Added JSDoc comments in **11 files**.

## Testing
In the following image there is a sneak peek about the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/62260472/94470471-1ee95200-019e-11eb-883c-f753ac0b3548.png)