### PR TITLE
[JSDoc] Add missing documentation for botbuilder-core files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -100,7 +100,7 @@
             "files": ["libraries/botbuilder-core/src/*.ts", "libraries/botbuilder-core/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder-core/src/activityFactory.ts
+++ b/libraries/botbuilder-core/src/activityFactory.ts
@@ -95,6 +95,11 @@ export class ActivityFactory {
         return activity;
     }
 
+    /**
+     * Builds an Activity with a given message.
+     * @param messageValue Message value on which to base the activity.
+     * @returns Activity with the given message.
+     */
     private static buildActivity(messageValue: any): Partial<Activity> {
         let activity: Partial<Activity> = { type: ActivityTypes.Message };
         for (const key of Object.keys(messageValue)) {
@@ -121,6 +126,9 @@ export class ActivityFactory {
         return activity;
     }
 
+    /**
+     * @private
+     */
     private static getSuggestions(suggestionsValue: any): SuggestedActions {
         const actions: any[] = this.normalizedToList(suggestionsValue);
 
@@ -132,15 +140,24 @@ export class ActivityFactory {
         return suggestedActions;
     }
 
+    /**
+     * @private
+     */
     private static getButtons(buttonsValue: any): CardAction[] {
         const actions: any[] = this.normalizedToList(buttonsValue);
         return this.getCardActions(actions);
     }
 
+    /**
+     * @private
+     */
     private static getCardActions(actions: any[]): CardAction[] {
         return actions.map((u: any): CardAction => this.getCardAction(u));
     }
 
+    /**
+     * @private
+     */
     private static getCardAction(action: any): CardAction
     {
         let cardAction: CardAction;
@@ -168,6 +185,9 @@ export class ActivityFactory {
         return cardAction;
     }
 
+    /**
+     * @private
+     */
     private static getAttachments(input: any): Attachment[] {
         const attachments: Attachment[] = [];
         const attachmentsJsonList: any[] = this.normalizedToList(input);
@@ -181,6 +201,9 @@ export class ActivityFactory {
         return attachments;
     }
 
+    /**
+     * @private
+     */
     private static getAttachment(input: any): Attachment {
         let attachment: Attachment = {
             contentType: ''
@@ -199,6 +222,9 @@ export class ActivityFactory {
         return attachment;
     }
 
+    /**
+     * @private
+     */
     private static getNormalAttachment(input: any): Attachment {
         const attachment: Attachment = {contentType:''};
 
@@ -226,6 +252,9 @@ export class ActivityFactory {
         return attachment;
     }
 
+    /**
+     * @private
+     */
     private static getCardAttachment(type: string, input: any): Attachment {
         const card: any = {};
 
@@ -290,6 +319,9 @@ export class ActivityFactory {
         return attachment;
     }
 
+    /**
+     * @private
+     */
     private static realProperty(property: string, builtinProperties: string[]): string {
         const properties = builtinProperties.map((u: string): string => u.toLowerCase());
         if (properties.includes(property.toLowerCase()))
@@ -300,6 +332,9 @@ export class ActivityFactory {
         }
     }
 
+    /**
+     * @private
+     */
     private static normalizedToList(item: any): any[] {
         if (item === undefined) {
             return [];
@@ -310,6 +345,9 @@ export class ActivityFactory {
         }
     }
 
+    /**
+     * @private
+     */
     private static getStructureType(input: any): string {
         let result = '';
 
@@ -325,6 +363,9 @@ export class ActivityFactory {
         return result.trim().toLowerCase();
     }
 
+    /**
+     * @private
+     */
     private static normalizedToMediaOrImage(item: any): object {
         if (!item) {
             return {};
@@ -333,6 +374,9 @@ export class ActivityFactory {
         } else return item;
     }
 
+    /**
+     * @private
+     */
     private static getValidBooleanValue(boolValue: any): boolean{
         if (typeof boolValue === 'boolean') {
             return boolValue;

--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -447,9 +447,8 @@ export class ActivityHandler extends ActivityHandlerBase {
         await this.handle(context, 'Message', this.defaultNextEvent(context));
     }
 
-    /*
+    /**
      * Provides default behavior for invoke activities.
-     * 
      * @param context The context object for the current turn.
      * 
      * @remarks
@@ -482,7 +481,7 @@ export class ActivityHandler extends ActivityHandlerBase {
         }
     }
 
-    /*
+    /**
      * Handle _signin invoke activity type_.
      * 
      * @param context The context object for the current turn.
@@ -494,7 +493,7 @@ export class ActivityHandler extends ActivityHandlerBase {
         throw new Error('NotImplemented');
     }
 
-    /*
+    /**
      * Handle _healthCheck invoke activity type_.
      * 
      * @param context The context object for the current turn.
@@ -866,6 +865,11 @@ export class ActivityHandler extends ActivityHandlerBase {
         return returnValue;
     }
 
+    /**
+     * An InvokeResponse factory that initializes the body to the parameter passed and status equal to OK.
+     * @param body JSON serialized content from a POST response.
+     * @returns A new InvokeResponse object.
+     */
     protected static createInvokeResponse(body?: any): InvokeResponse {
         return { status: 200, body };
     }

--- a/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
+++ b/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
@@ -58,6 +58,11 @@ export class AutoSaveStateMiddleware implements Middleware {
         BotStateSet.prototype.add.apply(this.botStateSet, botStates);
     }
 
+    /**
+     * Called by the adapter (for example, a `BotFrameworkAdapter`) at runtime in order to process an inbound `Activity`.
+     * @param context The context object for this turn.
+     * @param next {function} The next delegate function.
+     */
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         await next();
         await this.botStateSet.saveAllChanges(context, false);
@@ -72,5 +77,4 @@ export class AutoSaveStateMiddleware implements Middleware {
 
         return this;
     }
-
 }

--- a/libraries/botbuilder-core/src/botAdapter.ts
+++ b/libraries/botbuilder-core/src/botAdapter.ts
@@ -98,7 +98,7 @@ export abstract class BotAdapter {
         ) => Promise<void>): Promise<void>;
 
     /**
-     * Gets or sets an error handler that can catch exceptions in the middleware or application.
+     * Gets an error handler that can catch exceptions in the middleware or application.
      * 
      * @remarks
      * The error handler is called with these parameters:
@@ -112,6 +112,17 @@ export abstract class BotAdapter {
         return this.turnError;
     }
 
+    /**
+     * Sets an error handler that can catch exceptions in the middleware or application.
+     * 
+     * @remarks
+     * The error handler is called with these parameters:
+     * 
+     * | Name | Type | Description |
+     * | :--- | :--- | :--- |
+     * | `context` | [TurnContext](xref:botbuilder-core.TurnContext) | The context object for the turn. |
+     * | `error` | `Error` | The Node.js error thrown. |
+     */
     public set onTurnError(value: (context: TurnContext, error: Error) => Promise<void>) {
         this.turnError = value;
     }

--- a/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
+++ b/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
@@ -89,6 +89,10 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
      */
     constructor(protected readonly state: BotState, public readonly name: string) { }
 
+    /**
+     * Deletes the persisted property from its backing storage object.
+     * @param context Context object for this turn.
+     */
     public async delete(context: TurnContext): Promise<void> {
         const obj: any = await this.state.load(context);
         if (obj.hasOwnProperty(this.name)) {
@@ -98,6 +102,12 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     public async get(context: TurnContext): Promise<T|undefined>;
     public async get(context: TurnContext, defaultValue: T): Promise<T>;
+    /**
+     * Reads a persisted property from its backing storage object.
+     * @param context Context object for this turn.
+     * @param defaultValue Optional. Default value for the property.
+     * @returns A JSON representation of the cached state.
+     */
     public async get(context: TurnContext, defaultValue?: T): Promise<T> {
         const obj: any = await this.state.load(context);
         if (!obj.hasOwnProperty(this.name) && defaultValue !== undefined) {
@@ -109,6 +119,11 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
         return obj[this.name];
     }
 
+    /**
+     * Assigns a new value to the properties backing storage object.
+     * @param context Context object for this turn.
+     * @param value Value to set on the property.
+     */
     public async set(context: TurnContext, value: T): Promise<void> {
         const obj: any = await this.state.load(context);
         obj[this.name] = value;

--- a/libraries/botbuilder-core/src/botTelemetryClient.ts
+++ b/libraries/botbuilder-core/src/botTelemetryClient.ts
@@ -67,37 +67,75 @@ export interface TelemetryPageView {
     metrics?: {[key: string]: number };
 }
 
+/**
+ * A null bot telemetry client that implements `IBotTelemetryClient`.
+ */
 export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelemetryClient {
 
+    /**
+     * Creates a new instance of the `NullTelemetryClient` class.
+     * @param settings Optional. Settings for the telemetry client.
+     */
     constructor(settings?: any) {
         // noop
     }
-    
+
+    /**
+     * Logs an Application Insights page view.
+     * @param telemetry Telemetry Page View.
+     */
     trackPageView(telemetry: TelemetryPageView) {
         // noop
     }
 
+    /**
+     * Sends information about an external dependency (outgoing call) in the application.
+     * @param telemetry Telemetry Dependency.
+     */
     trackDependency(telemetry: TelemetryDependency) {
         // noop
     }
 
-    trackEvent(telemetry: TelemetryEvent)  {
+    /**
+     * Logs custom events with extensible named fields.
+     * @param telemetry Telemetry Event.
+     */
+    trackEvent(telemetry: TelemetryEvent) {
         // noop
     }
 
+    /**
+     * Logs a system exception.
+     * @param telemetry Telemetry Exception to log.
+     */
     trackException(telemetry: TelemetryException)  {
         // noop
     }
 
+    /**
+     * Sends a trace message.
+     * @param telemetry Telemetry Trace.
+     */
     trackTrace(telemetry: TelemetryTrace) {
         // noop
     }
 
+    /**
+     * Flushes the in-memory buffer and any metrics being pre-aggregated.
+     */
     flush()  {
         // noop
     }
 }
 
+/**
+ * Logs a DialogView using the TrackPageView method on the BotTelemetryClient if BotPageViewTelemetryClient has been implemented.
+ * Alternatively logs the information out via TrackTrace.
+ * @param telemetryClient TelemetryClient that implements BotTelemetryClient.
+ * @param dialogName Name of the dialog to log the entry / start for.
+ * @param properties Named string values you can use to search and classify events.
+ * @param metrics Measurements associated with this event.
+ */
 export function telemetryTrackDialogView(telemetryClient: BotTelemetryClient, dialogName: string, properties?: {[key: string]: any}, metrics?: {[key: string]: number }): void {
     if (!clientSupportsTrackDialogView(telemetryClient)) {
         throw new TypeError('"telemetryClient" parameter does not have methods trackPageView() or trackTrace()');

--- a/libraries/botbuilder-core/src/browserStorage.ts
+++ b/libraries/botbuilder-core/src/browserStorage.ts
@@ -21,7 +21,9 @@ import { MemoryStorage } from './memoryStorage';
  * ```
  */
 export class BrowserLocalStorage extends MemoryStorage {
-    // Creates a new BrowserLocalStorage instance.
+    /**
+     * Creates a new BrowserLocalStorage instance.
+     */
     public constructor() {
         super(localStorage as any);
     }
@@ -43,7 +45,9 @@ export class BrowserLocalStorage extends MemoryStorage {
  * ```
  */
 export class BrowserSessionStorage extends MemoryStorage {
-    // Creates a new BrowserSessionStorage instance.
+    /**
+     * Creates a new BrowserSessionStorage instance.
+     */
     public constructor() {
         super(sessionStorage as any);
     }

--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -156,6 +156,15 @@ export class CardFactory {
         buttons?: (CardAction | string)[],
         other?: Partial<HeroCard>
     ): Attachment;
+    /**
+     * Returns an attachment for a hero card.
+     *
+     * @param title The card title.
+     * @param text Optional. The card text.
+     * @param images Optional. Images to include on the card.
+     * @param buttons Optional. Buttons to include on the card.
+     * @param other Optional. Any additional properties to include on the card.
+     */
     public static heroCard(
         title: string,
         text?: any,
@@ -276,6 +285,15 @@ export class CardFactory {
         buttons?: (CardAction | string)[],
         other?: Partial<ThumbnailCard>
     ): Attachment;
+    /**
+     * Returns an attachment for a thumbnail card.
+     *
+     * @param title The card title.
+     * @param text Optional. The card text.
+     * @param images Optional. Images to include on the card.
+     * @param buttons Optional. Buttons to include on the card.
+     * @param other Optional. Any additional properties to include on the card.
+     */
     public static thumbnailCard(
         title: string,
         text?: any,

--- a/libraries/botbuilder-core/src/memoryStorage.ts
+++ b/libraries/botbuilder-core/src/memoryStorage.ts
@@ -37,6 +37,11 @@ export class MemoryStorage  implements Storage {
         this.etag = 1;
     }
 
+    /**
+     * Reads storage items from storage.
+     * @param keys Keys of the `StoreItem` objects to read.
+     * @returns The read items.
+     */
     public read(keys: string[]): Promise<StoreItems> {
         return new Promise<StoreItems>((resolve: any, reject: any): void => {
             if (!keys) { throw new ReferenceError(`Keys are required when reading.`); }
@@ -51,6 +56,10 @@ export class MemoryStorage  implements Storage {
         });
     }
 
+    /**
+     * Writes storage items to storage.
+     * @param changes The items to write, indexed by key.
+     */
     public write(changes: StoreItems): Promise<void> {
         const that: MemoryStorage = this;
         function saveItem(key: string, item: any): void {
@@ -79,6 +88,10 @@ export class MemoryStorage  implements Storage {
         });
     }
 
+    /**
+     * Deletes storage items from storage.
+     * @param keys Keys of the objects to delete.
+     */
     public delete(keys: string[]): Promise<void> {
         return new Promise<void>((resolve: any, reject: any): void => {
             keys.forEach((key: string) => this.memory[key] = <any>undefined);

--- a/libraries/botbuilder-core/src/middlewareSet.ts
+++ b/libraries/botbuilder-core/src/middlewareSet.ts
@@ -77,6 +77,11 @@ export class MiddlewareSet implements Middleware {
         MiddlewareSet.prototype.use.apply(this, middleware);
     }
 
+    /**
+     * Processes an incoming activity.
+     * @param context Context object for this turn.
+     * @param next Delegate to call to continue the bot middleware pipeline.
+     */
     public onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         return this.run(context, next);
     }

--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -73,6 +73,9 @@ export class ShowTypingMiddleware implements Middleware {
         if (timeout) clearTimeout(timeout);
     }
 
+    /**
+     * @private
+     */
     private async sendTypingActivity(context: TurnContext) {
         // Sending the Activity directly via the Adapter avoids other middleware and avoids setting the
         // responded flag. However this also requires that the conversation reference details are explicitly added.

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -22,6 +22,10 @@ import { TurnContext } from './turnContext';
  * This will remove the <at> nodes, leaving just the name.
  */
 export class SkypeMentionNormalizeMiddleware implements Middleware {
+    /**
+     * Performs the normalization of Skype mention Entities.
+     * @param activity Activity containing the mentions to normalize.
+     */
     public static normalizeSkypeMentionText(activity: Activity): void {
         if (activity.channelId === 'skype' && activity.type === 'message'){
             activity.entities.map((element): void => {
@@ -37,6 +41,11 @@ export class SkypeMentionNormalizeMiddleware implements Middleware {
         }
     }
 
+    /**
+     * Middleware implementation which corrects Entity.Mention.Text to a value RemoveMentionText can work with.
+     * @param turnContext Context for the current turn of conversation.
+     * @param next Delegate to call to continue the bot middleware pipeline.
+     */
     public async onTurn(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {
         SkypeMentionNormalizeMiddleware.normalizeSkypeMentionText(turnContext.activity);
         await next();

--- a/libraries/botbuilder-core/src/stringUtils.ts
+++ b/libraries/botbuilder-core/src/stringUtils.ts
@@ -6,6 +6,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Helper class containing string utility methods.
+ */
 export class StringUtils {
     /**
      * Truncate string with ...

--- a/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
+++ b/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
@@ -327,6 +327,9 @@ export class TelemetryLoggerMiddleware implements Middleware {
         return properties;
     }
 
+    /**
+     * @private
+     */
     private populateAdditionalChannelProperties(activity: Activity, properties?: {[key: string]: string}): void {
         if (activity) {
             switch (activity.channelId) {

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -445,9 +445,16 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
         return undefined;
     }
 
-    
     private exchangeableTokens : {[key: string]: ExchangeableToken} = {};
 
+    /**
+     * Adds a fake exchangeable token so it can be exchanged later.
+     * @param connectionName Name of the auth connection to use.
+     * @param channelId Channel ID.
+     * @param userId User ID.
+     * @param exchangeableItem Exchangeable token or resource URI.
+     * @param token Token to store.
+     */
     public addExchangeableToken(connectionName: string, channelId: string, userId: string, exchangeableItem: string, token: string) {
         const key: ExchangeableToken = new ExchangeableToken();
         key.ChannelId = channelId;
@@ -458,6 +465,13 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
         this.exchangeableTokens[key.toKey()] = key;
     }
 
+    /**
+     * Gets a sign-in resource.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     * @param userId User ID
+     * @param finalRedirect Final redirect URL.
+     */
     public async getSignInResource(context: TurnContext, connectionName: string, userId?: string, finalRedirect?: string): Promise<SignInUrlResponse> {
         return {
             signInLink: `https://botframeworktestadapter.com/oauthsignin/${connectionName}/${context.activity.channelId}/${userId}`,
@@ -470,7 +484,14 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
         }
     }
 
-
+    /**
+     * Performs a token exchange operation such as for single sign-on.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     * @param userId User id associated with the token.
+     * @param tokenExchangeRequest Exchange request details, either a token to exchange or a uri to exchange.
+     * @returns If the promise completes, the exchanged token is returned.
+     */
     public async exchangeToken(context: TurnContext, connectionName: string, userId: string, tokenExchangeRequest: TokenExchangeRequest): Promise<TokenResponse> {
         const exchangeableValue: string = tokenExchangeRequest.token ? tokenExchangeRequest.token : tokenExchangeRequest.uri;
         const key = new ExchangeableToken();

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -744,6 +744,9 @@ export class TurnContext {
         return this._turnState;
     }
 
+    /**
+     * @private
+     */
     private emit<T>(
         handlers: ((context: TurnContext, arg: T, next: () => Promise<any>) => Promise<any>)[],
         arg: T,

--- a/libraries/botbuilder-core/src/turnContextStateCollection.ts
+++ b/libraries/botbuilder-core/src/turnContextStateCollection.ts
@@ -5,6 +5,11 @@
 
 const TURN_STATE_SCOPE_CACHE = Symbol('turnStateScopeCache');
 
+/**
+ * Values persisted for the lifetime of the turn as part of the `TurnContext`.
+ * @remarks Typical values stored here are objects which are needed for the lifetime of a turn, such
+ * as `Storage`, `BotState`, `ConversationState`, `LanguageGenerator`, `ResourceExplorer`, etc.
+ */
 export class TurnContextStateCollection extends Map<any, any> {
     /**
      * Push a value by key to the turn's context.


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder-core](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-core) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Updated jsdoc/require-jsdoc in .eslintrc.json from warn to error.
- Added JSDoc comments in all public methods and classes.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94579222-f1a8ac80-024e-11eb-8bc5-2b0b95d013f1.png)
