### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs-declarative files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -164,7 +164,7 @@
             "files": ["libraries/botbuilder-dialogs-declarative/src/*.ts", "libraries/botbuilder-dialogs-declarative/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder-dialogs-declarative/src/builderRegistration.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/builderRegistration.ts
@@ -7,7 +7,15 @@
  */
 import { TypeBuilder } from './factory/typeBuilder';
 
+/**
+ * Registers a builder to receive notifications on builder events.
+ */
 export class BuilderRegistration {
+    /**
+     * Creates a new instance of the `BuilderRegistration` class.
+     * @param name Name for the builder.
+     * @param builder Type Builder.
+     */
     public constructor(name: string, builder: TypeBuilder) {
         this.name = name;
         this.builder = builder;

--- a/libraries/botbuilder-dialogs-declarative/src/converterRegistration.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/converterRegistration.ts
@@ -7,7 +7,15 @@
  */
 import { Converter } from './converter';
 
+/**
+ * Registers a converter to receive notifications on converter events.
+ */
 export class ConverterRegistration {
+    /**
+     * Creates a new instance of the `ConverterRegistration` class.
+     * @param name Name for the converter.
+     * @param converter Converter.
+     */
     public constructor(name: string, converter: Converter) {
         this.name = name;
         this.converter = converter;

--- a/libraries/botbuilder-dialogs-declarative/src/factory/customTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/factory/customTypeBuilder.ts
@@ -8,10 +8,21 @@
 
 import { TypeBuilder } from './typeBuilder';
 
+/**
+ * Declarative custom type builder.
+ */
 export class CustomTypeBuilder implements TypeBuilder {
 
+    /**
+     * Creates a new instance of the `CustomTypeBuilder` class.
+     * @param factory Factory for the custom type.
+     */
     constructor(private factory: (config: object) => object) {}
 
+    /**
+     * Builds a custom type.
+     * @param config Configuration object for the type.
+     */
     public build(config: object): object {
         return this.factory(config);
     }

--- a/libraries/botbuilder-dialogs-declarative/src/factory/defaultTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/factory/defaultTypeBuilder.ts
@@ -8,10 +8,21 @@
 
 import { TypeBuilder } from './typeBuilder';
 
+/**
+ * Declarative default type builder.
+ */
 export class DefaultTypeBuilder implements TypeBuilder {
 
+    /**
+     * Creates a new instance of the `DefaultTypeBuilder` class.
+     * @param factory Factory for the default type.
+     */
     constructor(private factory: new () => any) {}
 
+    /**
+     * Builds a default type.
+     * @param config Configuration object for the type.
+     */
     public build(config: object) : object {
         return new this.factory();
     }

--- a/libraries/botbuilder-dialogs-declarative/src/factory/typeFactory.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/factory/typeFactory.ts
@@ -9,7 +9,7 @@
 import { TypeBuilder } from './typeBuilder';
 
 /**
- * Declarative type factory
+ * Declarative type factory.
  */
 export class TypeFactory {
 
@@ -36,6 +36,11 @@ export class TypeFactory {
         this.registrations[name] = builder;
     }
 
+    /**
+     * Builds a type in the factory.
+     * @param name Name of the type to build.
+     * @param config Configuration object for the type.
+     */
     public build(name: string, config: object): object {
 
         if (!name) {

--- a/libraries/botbuilder-dialogs-declarative/src/pathUtil.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/pathUtil.ts
@@ -10,7 +10,7 @@ import { join } from 'path';
 import { readdirSync, lstatSync } from 'fs';
 
 /**
- * A utilities class of file path operations.
+ * An utility class for file path operations.
  */
 export class PathUtil {
     /**

--- a/libraries/botbuilder-dialogs-declarative/src/pathUtil.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/pathUtil.ts
@@ -9,6 +9,9 @@
 import { join } from 'path';
 import { readdirSync, lstatSync } from 'fs';
 
+/**
+ * A utilities class of file path operations.
+ */
 export class PathUtil {
     /**
      * Check if a path is a directory

--- a/libraries/botbuilder-dialogs-declarative/src/resources/folderResourceProvider.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/folderResourceProvider.ts
@@ -103,6 +103,9 @@ export class FolderResourceProvider extends ResourceProvider {
         return resources;
     }
 
+    /**
+     * @private
+     */
     private onResourceAdded(path: string): void {
         const ext = extname(path.toLowerCase()).replace(/^\./, '');
         if (this.resourceExplorer.resourceTypes.has(ext)) {
@@ -114,6 +117,9 @@ export class FolderResourceProvider extends ResourceProvider {
         }
     }
 
+    /**
+     * @private
+     */
     private onResourceChanged(path: string): void {
         const ext = extname(path.toLowerCase()).replace(/^\./, '');
         if (this.resourceExplorer.resourceTypes.has(ext)) {
@@ -123,6 +129,9 @@ export class FolderResourceProvider extends ResourceProvider {
         }
     }
 
+    /**
+     * @private
+     */
     private onResourceRemoved(path: string): void {
         const ext = extname(path.toLowerCase()).replace(/^\./, '');
         if (this.resourceExplorer.resourceTypes.has(ext)) {

--- a/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
@@ -210,6 +210,12 @@ export class ResourceExplorer {
         return result;
     }
 
+    /**
+     * @protected
+     * Handler for on changed events.
+     * @param event Resource Change Event.
+     * @param resources A collection of resources to pass to the event handler.
+     */
     protected onChanged(event: ResourceChangeEvent, resources: Resource[]): void {
         if (this._eventEmitter) {
             this._eventEmitter.emit(event, resources);

--- a/libraries/botbuilder-dialogs-declarative/src/resources/resourceProvider.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/resourceProvider.ts
@@ -85,6 +85,12 @@ export abstract class ResourceProvider {
      */
     public abstract refresh(): void;
 
+    /**
+     * @protected
+     * Actions to perform when the current object is changed.
+     * @param event Resource Change Event.
+     * @param resources A collection of changed resources.
+     */
     protected onChanged(event: ResourceChangeEvent, resources: Resource[]): void {
         if (this._eventEmitter) {
             this._eventEmitter.emit(event, resources);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder-dialogs-declarative](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-dialogs-declarative) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Updated jsdoc/require-jsdoc in .eslintrc.json from warn to error.
- Added JSDoc comments in all public methods and classes.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94608492-dbf9ae00-0273-11eb-9e53-3410a8df715a.png)
