### PR TITLE
[JSDoc] Add missing documentation for botbuilder-applicationinsights files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,7 @@
             "files": ["libraries/botbuilder-applicationinsights/src/*.ts", "libraries/botbuilder-applicationinsights/src/**/*.ts"],
             "plugins": ["jsdoc"],
             "rules": {
-              "jsdoc/require-jsdoc": ["warn", {
+              "jsdoc/require-jsdoc": ["error", {
                   "require": {
                       "FunctionDeclaration": true,
                       "MethodDefinition": true,

--- a/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
+++ b/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
@@ -49,7 +49,6 @@ export const ApplicationInsightsWebserverMiddleware: any = (req: any, res: any, 
 };
 
 /**
- * ApplicationInsightsTelemetryClient Class
  * This is a wrapper class around the Application Insights node client.
  * This is primarily designed to be used alongside the WaterfallDialog telemetry collection.
  * It provides a pre-configured App Insights client, and wrappers around

--- a/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
+++ b/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
@@ -48,7 +48,8 @@ export const ApplicationInsightsWebserverMiddleware: any = (req: any, res: any, 
 
 };
 
-/* ApplicationInsightsTelemetryClient Class
+/**
+ * ApplicationInsightsTelemetryClient Class
  * This is a wrapper class around the Application Insights node client.
  * This is primarily designed to be used alongside the WaterfallDialog telemetry collection.
  * It provides a pre-configured App Insights client, and wrappers around
@@ -66,7 +67,10 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
     private client: appInsights.TelemetryClient;
     private config: appInsights.Configuration;
 
-    /* The settings parameter is passed directly into appInsights.setup().
+    /**
+     * Creates a new instance of the `ApplicationInsightsTelemetryClient` class.
+     * @param instrumentationKey The ApplicationInsights instrumentation key.
+     * @remarks The settings parameter is passed directly into appInsights.setup().
      * https://www.npmjs.com/package/applicationinsights#basic-usage
      * This function currently takes an app insights instrumentation key only.
      */
@@ -85,7 +89,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
         this.client.addTelemetryProcessor(addBotIdentifiers);
     }
 
-    /* configuration()
+    /**
      * Provides access to the Application Insights configuration that is running here.
      * Allows developers to adjust the options, for example:
      * `appInsightsClient.configuration.setAutoCollectDependencies(false)`
@@ -94,33 +98,56 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
         return this.config;
     }
 
-    /* defaultClient()
+    /**
      * Provides direct access to the telemetry client object, which might be necessary for some operations.
      */
     get defaultClient(): appInsights.TelemetryClient {
         return this.client;
     }
 
+    /**
+     * Sends information about an external dependency (outgoing call) in the application.
+     * @param telemetry Telemetry Dependency.
+     */
     public trackDependency(telemetry: TelemetryDependency): void {
         this.defaultClient.trackDependency(telemetry as appInsights.Contracts.DependencyTelemetry);
     }
 
+    /**
+     * Logs custom events with extensible named fields.
+     * @param telemetry Telemetry Event.
+     */
     public trackEvent(telemetry: TelemetryEvent): void {
         this.defaultClient.trackEvent(telemetry as appInsights.Contracts.EventTelemetry);
     }
 
+    /**
+     * Logs a system exception.
+     * @param telemetry Telemetry Exception.
+     */
     public trackException(telemetry: TelemetryException): void {
         this.defaultClient.trackException(telemetry as appInsights.Contracts.ExceptionTelemetry);
     }
 
+    /**
+     * Sends a trace message.
+     * @param telemetry Telemetry Trace.
+     */
     public trackTrace(telemetry: TelemetryTrace): void {
         this.defaultClient.trackTrace(telemetry as appInsights.Contracts.TraceTelemetry);
     }
 
+    /**
+     * Logs a dialog entry / as an Application Insights page view.
+     * @param telemetry Telemetry Page View.
+     */
     public trackPageView(telemetry: TelemetryPageView): void {
         this.defaultClient.trackPageView(telemetry as appInsights.Contracts.PageViewTelemetry);
     }
 
+    /**
+     * Flushes the in-memory buffer and any metrics being pre-aggregated.
+     */
     public flush(): void {
         this.defaultClient.flush();
     }

--- a/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
+++ b/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
@@ -137,7 +137,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
     }
 
     /**
-     * Logs a dialog entry / as an Application Insights page view.
+     * Logs a dialog entry as an Application Insights page view.
      * @param telemetry Telemetry Page View.
      */
     public trackPageView(telemetry: TelemetryPageView): void {


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [botbuilder-applicationinsights](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-applicationinsights) library.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Updated jsdoc/require-jsdoc in .eslintrc.json from warn to error.
- Added JSDoc comments in all public methods and classes.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94611090-9e971f80-0277-11eb-8cdd-89a99df284a6.png)
