### PR TITLE
Add missing documentation for teams-scenarios root

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -271,6 +271,22 @@
                   "publicOnly": true
               }]
             }
+        },
+        {
+            "files": ["libraries/teams-scenarios/*/src/*.ts", "libraries/teams-scenarios/*/src/**/*.ts"],
+            "plugins": ["jsdoc"],
+            "rules": {
+              "jsdoc/require-jsdoc": ["error", {
+                  "require": {
+                      "FunctionDeclaration": true,
+                      "MethodDefinition": true,
+                      "ClassDeclaration": true,
+                      "ArrowFunctionExpression": false,
+                      "FunctionExpression": false
+                  },
+                  "publicOnly": true
+              }]
+            }
         }
     ],
     "parserOptions": {

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
@@ -23,10 +23,13 @@ import { AdaptiveCardHelper } from './adaptiveCardHelper';
 import { CardResponseHelpers } from './cardResponseHelpers';
 import { SubmitExampleData } from './submitExampleData';
 
+/**
+ * After installing this bot you will need to click on the 3 dots to pull up the extension menu to select the bot. Once you do you do
+ * see the extension pop a task module.
+ */
 export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHandler {
-    /*
-     * After installing this bot you will need to click on the 3 dots to pull up the extension menu to select the bot. Once you do you do
-     * see the extension pop a task module.
+    /**
+     * Initializes a new instance of the `ActionBasedMessagingExtensionFetchTaskBot` class.
      */
     constructor() {
         super();
@@ -39,11 +42,17 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const response = AdaptiveCardHelper.createTaskModuleAdaptiveCardResponse();
         return response;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submittedData = action.data as SubmitExampleData;
         const adaptiveCard = AdaptiveCardHelper.toAdaptiveCardAttachment(submittedData);
@@ -51,6 +60,9 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         return response;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submitData = AdaptiveCardHelper.toSubmitExampleData(action);
         const response = AdaptiveCardHelper.createTaskModuleAdaptiveCardResponse(
@@ -62,6 +74,9 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         return response;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submitData: SubmitExampleData = AdaptiveCardHelper.toSubmitExampleData(action);
         const adaptiveCard: Attachment = AdaptiveCardHelper.toAdaptiveCardAttachment(submitData);
@@ -84,20 +99,26 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         return response;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionCardButtonClicked(context: TurnContext, obj) {
         const reply = MessageFactory.text('handleTeamsMessagingExtensionCardButtonClicked Value: ' + JSON.stringify(context.activity.value));
         await context.sendActivity(reply);
     }
 
+    /**
+     * @protected
+     */
     private async teamsCreateConversation(context: TurnContext, teamsChannelId: string, message: Partial<Activity>): Promise<[ConversationReference, string]> {
         if (!teamsChannelId) {
             throw new Error('Missing valid teamsChannelId argument');
         }
-    
+
         if (!message) {
             throw new Error('Missing valid message argument');
         }
-    
+
         const conversationParameters = <ConversationParameters>{
             isGroup: true,
             channelData: <TeamsChannelData>{
@@ -105,14 +126,14 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
                     id: teamsChannelId
                 }
             },
-    
+
             activity: message,
         };
 
-        const adapter = <BotFrameworkAdapter>context.adapter;    
+        const adapter = <BotFrameworkAdapter>context.adapter;
         const connectorClient = adapter.createConnectorClient(context.activity.serviceUrl);
 
-        // This call does NOT send the outbound Activity is not being sent through the middleware stack.    
+        // This call does NOT send the outbound Activity is not being sent through the middleware stack.
         const conversationResourceResponse: ConversationResourceResponse = await connectorClient.conversations.createConversation(conversationParameters);
         const conversationReference = <ConversationReference>TurnContext.getConversationReference(context.activity);
         conversationReference.conversation.id = conversationResourceResponse.id;

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/adaptiveCardHelper.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/adaptiveCardHelper.ts
@@ -12,7 +12,15 @@ import {
 
 import { SubmitExampleData } from './submitExampleData';
 
+/**
+ * Helper for AdaptiveCard.
+ */
 export class AdaptiveCardHelper {
+    /**
+     * Creates an example data.
+     * @param action Messaging extension action
+     * @returns A `SubmitExampleData` object.
+     */
     public static toSubmitExampleData(action: MessagingExtensionAction): SubmitExampleData {
         const activityPreview = action.botActivityPreview[0];
         const attachmentContent = activityPreview.attachments[0].content;
@@ -29,6 +37,15 @@ export class AdaptiveCardHelper {
         } as SubmitExampleData;
     }
 
+    /**
+     * Creates a `MessagingExtensionActionResponse` with an AdaptiveCard.
+     * @param userText Question text.
+     * @param isMultiSelect Multi select.
+     * @param option1 Option 1.
+     * @param option2 Option 2.
+     * @param option3 Option 3.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static createTaskModuleAdaptiveCardResponse(
         userText: string = null,
         isMultiSelect: boolean = true,
@@ -106,6 +123,11 @@ export class AdaptiveCardHelper {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Creates an AdaptiveCard attachment.
+     * @param data Example data.
+     * @returns An `Attachment` object.
+     */
     public static toAdaptiveCardAttachment(data: SubmitExampleData): Attachment {
         return CardFactory.adaptiveCard({
             actions: [

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/cardResponseHelpers.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/cardResponseHelpers.ts
@@ -13,7 +13,15 @@ import {
     TaskModuleTaskInfo
 } from 'botbuilder';
 
+/**
+ * Helper for an Attachment as CardResponse.
+ */
 export class CardResponseHelpers {
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a task.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toTaskModuleResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
             task: {
@@ -27,8 +35,12 @@ export class CardResponseHelpers {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a compose extension.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toComposeExtensionResultResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
-
         return {
             composeExtension: {
                 attachmentLayout: 'list',
@@ -39,6 +51,12 @@ export class CardResponseHelpers {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object
+     * as a compose extension with type of botMessagePreview.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toMessagingExtensionBotMessagePreviewResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
             composeExtension: {

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/submitExampleData.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/submitExampleData.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+/**
+ * Example data class
+ */
 export class SubmitExampleData {
     public MultiSelect: string;
     public Option1: string;

--- a/libraries/teams-scenarios/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
@@ -14,7 +14,14 @@ import {
     TurnContext
 } from 'botbuilder';
 
+/**
+ * After installing this bot you can click on the 3 dots to pull up the extension menu. You should be able to click on the search extension
+ * and the bot will start. Interact with the cards to execrcise the flows.
+ */
 export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `ActionBasedMessagingExtensionBot` class.
+     */
     constructor() {
         super();
 
@@ -38,6 +45,9 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const data = action.data;
         let body: MessagingExtensionActionResponse;
@@ -80,14 +90,20 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         return body;
     }
 
-    // This method fires when an user uses an Action-based Messaging Extension from the Teams Client.
-    // It should send back the tab or task module for the user to interact with.
+    /**
+     * @protected
+     * This method fires when an user uses an Action-based Messaging Extension from the Teams Client.
+     * It should send back the tab or task module for the user to interact with.
+     */
     protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         return {
             task: this.taskModuleResponse(action, false)
         };
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         let body: MessagingExtensionActionResponse;
         const card = this.getCardFromPreviewMessage(action);
@@ -106,6 +122,9 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         return body;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context, value: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const card = this.getCardFromPreviewMessage(value);
         let body: MessagingExtensionActionResponse;
@@ -128,6 +147,9 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         return body;
     }
 
+    /**
+     * @private
+     */
     private getCardFromPreviewMessage(query: MessagingExtensionAction): Attachment {
         const userEditActivities = query.botActivityPreview;
         return userEditActivities
@@ -136,6 +158,9 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
             && userEditActivities[0].attachments[0];
     }
 
+    /**
+     * @private
+     */
     private taskModuleResponse(query: any, done: boolean): TaskModuleResponseBase {
         if (done) {
             return {
@@ -153,6 +178,9 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         }
     }
 
+    /**
+     * @private
+     */
     private taskModuleResponseCard(data: any, textValue?: string) {
         return CardFactory.adaptiveCard({
             actions: [

--- a/libraries/teams-scenarios/activityUpdateAndDelete/src/activityUpdateAndDeleteBot.ts
+++ b/libraries/teams-scenarios/activityUpdateAndDelete/src/activityUpdateAndDeleteBot.ts
@@ -7,13 +7,17 @@ import {
     TurnContext
 } from 'botbuilder';
 
-/*
+/**
  * From the UI you can just @mention the bot from any channelwith any string EXCEPT for "delete". If you send the bot "delete" it will delete
  * all of the previous bot responses and empty it's internal storage.
  */
 export class ActivityUpdateAndDeleteBot extends ActivityHandler {
     protected activityIds: string[];
 
+    /**
+     * Initializes a new instance of the `ActivityUpdateAndDeleteBot` class.
+     * @param activityIds An array of activity ids.
+     */
     constructor(activityIds: string[]) {
         super();
 
@@ -43,6 +47,9 @@ export class ActivityUpdateAndDeleteBot extends ActivityHandler {
         });
     }
 
+    /**
+     * @private
+     */
     private async sendMessageAndLogActivityId(context: TurnContext, text: string): Promise<void> {
         const resourceResponse = await context.sendActivity({ text });
         await this.activityIds.push(resourceResponse.id);

--- a/libraries/teams-scenarios/adaptiveCards/src/adaptiveCardsBot.ts
+++ b/libraries/teams-scenarios/adaptiveCards/src/adaptiveCardsBot.ts
@@ -19,6 +19,9 @@ import {
  * task module that contains an adpative card. "3" will return an adpative card that contains BF card actions.
  */
 export class AdaptiveCardsBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `AdaptiveCardsBot` class.
+     */
     constructor() {
         super();
 
@@ -67,6 +70,9 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         await context.sendActivity(MessageFactory.text(`handleTeamsTaskModuleFetch TaskModuleRequest: ${JSON.stringify(taskModuleRequest)}`));
 
@@ -97,7 +103,7 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
             "version": "1.0"
         });
         /* tslint:enable:quotemark object-literal-key-quotes */
-        return { 
+        return {
                 task: {
                         type: 'continue',
                         value: {
@@ -110,22 +116,31 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         } as TaskModuleResponse;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         await context.sendActivity(MessageFactory.text(`handleTeamsTaskModuleSubmit value: ${JSON.stringify(taskModuleRequest)}`));
 
-        return { 
-                task: { 
-                    type: 'message', 
-                    value: 'Thanks!' 
+        return {
+                task: {
+                    type: 'message',
+                    value: 'Thanks!'
                 } as TaskModuleMessageResponse
         } as TaskModuleResponse;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
         await context.sendActivity(MessageFactory.text(`handleTeamsCardActionInvoke value: ${JSON.stringify(context.activity.value)}`));
         return { status: 200 } as InvokeResponse;
     }
 
+    /**
+     * @private
+     */
     private async sendAdaptiveCard1(context: TurnContext): Promise<void> {
         /* tslint:disable:quotemark object-literal-key-quotes */
         const card = CardFactory.adaptiveCard({
@@ -187,6 +202,9 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         await context.sendActivity(MessageFactory.attachment(card));
     }
 
+    /**
+     * @private
+     */
     private async sendAdaptiveCard2(context: TurnContext): Promise<void> {
         /* tslint:disable:quotemark object-literal-key-quotes */
         const card = CardFactory.adaptiveCard({
@@ -219,6 +237,9 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         await context.sendActivity(MessageFactory.attachment(card));
     }
 
+    /**
+     * @private
+     */
     private async sendAdaptiveCard3(context: TurnContext): Promise<void> {
         /* tslint:disable:quotemark object-literal-key-quotes */
         const card = CardFactory.adaptiveCard({

--- a/libraries/teams-scenarios/cardBotFramework/src/cardsBot.ts
+++ b/libraries/teams-scenarios/cardBotFramework/src/cardsBot.ts
@@ -11,9 +11,16 @@ import {
     TurnContext
 } from 'botbuilder';
 
+/**
+ * You can install this bot in any scope. From the UI just @mention the bot.
+ */
 export class CardsBot extends TeamsActivityHandler {
     // NOT SUPPORTED ON TEAMS: AnimationCard, AudioCard, VideoCard, OAuthCard
     protected cardTypes: string[];
+
+    /**
+     * Initializes a new instance of the `CardsBot` class.
+     */
     constructor() {
         super();
         /*
@@ -69,6 +76,9 @@ export class CardsBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @private
+     */
     private getHeroCard() {
         return CardFactory.heroCard('BotFramework Hero Card',
             'Build and connect intelligent bots to interact with your users naturally wherever they are,' +
@@ -77,6 +87,9 @@ export class CardsBot extends TeamsActivityHandler {
             [{ type: ActionTypes.OpenUrl, title: 'Get Started', value: 'https://docs.microsoft.com/bot-framework' }]);
     }
 
+    /**
+     * @private
+     */
     private getThumbnailCard() {
         return CardFactory.thumbnailCard('BotFramework Thumbnail Card',
             'Build and connect intelligent bots to interact with your users naturally wherever they are,' +
@@ -85,6 +98,9 @@ export class CardsBot extends TeamsActivityHandler {
             [{ type: ActionTypes.OpenUrl, title: 'Get Started', value: 'https://docs.microsoft.com/bot-framework' }]);
     }
 
+    /**
+     * @private
+     */
     private getReceiptCard() {
         return CardFactory.receiptCard({
             buttons: [
@@ -127,10 +143,16 @@ export class CardsBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @private
+     */
     private getSigninCard() {
         return CardFactory.signinCard('BotFramework Sign-in Card', 'https://login.microsoftonline.com/', 'Sign-in');
     }
 
+    /**
+     * @private
+     */
     private getChoices() {
         const actions = this.cardTypes.map((cardType) => ({ type: ActionTypes.MessageBack, title: cardType, text: cardType })) as CardAction[];
         return CardFactory.heroCard('Task Module Invocation from Hero Card', null, actions);

--- a/libraries/teams-scenarios/integrationBot/src/activityLog.ts
+++ b/libraries/teams-scenarios/integrationBot/src/activityLog.ts
@@ -9,14 +9,25 @@ import{
     Activity
 } from 'botframework-schema'
 
-
+/**
+ * `Activity`'s class with a Storage provider.
+ */
 export class ActivityLog  {
-    private readonly _storage: Storage;   
+    private readonly _storage: Storage;
 
+    /**
+     * Initializes a new instance of the `ActivityLog` class.
+     * @param storage A storage provider that stores and retrieves plain old JSON objects.
+     */
     public constructor(storage: Storage) {
         this._storage = storage;
     }
-    
+
+    /**
+     * Saves an `Activity` with its associated id into the storage.
+     * @param activityId `Activity`'s Id.
+     * @param activity The `Activity` object.
+     */
     public async append(activityId: string, activity: Partial<Activity>): Promise<void> {
         if (activityId == null)
         {
@@ -36,6 +47,11 @@ export class ActivityLog  {
         return;
     }
 
+    /**
+     * Retrieves an `Activity` from the storage by a given Id.
+     * @param activityId `Activity`'s Id.
+     * @returns The `Activity`'s object retrieved from storage.
+     */
     public async find(activityId: string): Promise<Activity>
     {
         if (activityId == null)

--- a/libraries/teams-scenarios/integrationBot/src/adaptiveCardHelper.ts
+++ b/libraries/teams-scenarios/integrationBot/src/adaptiveCardHelper.ts
@@ -12,7 +12,15 @@ import {
 
 import { SubmitExampleData } from './submitExampleData';
 
+/**
+ * Helper for AdaptiveCard.
+ */
 export class AdaptiveCardHelper {
+    /**
+     * Creates an example data.
+     * @param action Messaging extension action
+     * @returns A `SubmitExampleData` object.
+     */
     public static toSubmitExampleData(action: MessagingExtensionAction): SubmitExampleData {
         const activityPreview = action.botActivityPreview[0];
         const attachmentContent = activityPreview.attachments[0].content;
@@ -29,6 +37,15 @@ export class AdaptiveCardHelper {
         } as SubmitExampleData;
     }
 
+    /**
+     * Creates a `MessagingExtensionActionResponse` with an AdaptiveCard.
+     * @param userText Question text.
+     * @param isMultiSelect Multi select.
+     * @param option1 Option 1.
+     * @param option2 Option 2.
+     * @param option3 Option 3.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static createTaskModuleAdaptiveCardResponse(
         userText: string = null,
         isMultiSelect: boolean = true,
@@ -106,6 +123,11 @@ export class AdaptiveCardHelper {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Creates an AdaptiveCard attachment.
+     * @param data Example data.
+     * @returns An `Attachment` object.
+     */
     public static toAdaptiveCardAttachment(data: SubmitExampleData): Attachment {
         return CardFactory.adaptiveCard({
             actions: [

--- a/libraries/teams-scenarios/integrationBot/src/cardResponseHelpers.ts
+++ b/libraries/teams-scenarios/integrationBot/src/cardResponseHelpers.ts
@@ -13,7 +13,15 @@ import {
     TaskModuleTaskInfo
 } from 'botbuilder';
 
+/**
+ * Helper for an Attachment as CardResponse.
+ */
 export class CardResponseHelpers {
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a task.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toTaskModuleResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
             task: {
@@ -27,8 +35,12 @@ export class CardResponseHelpers {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a compose extension.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toComposeExtensionResultResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
-
         return {
             composeExtension: {
                 attachmentLayout: 'list',
@@ -39,6 +51,12 @@ export class CardResponseHelpers {
         } as MessagingExtensionActionResponse;
     }
 
+    /**
+     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object
+     * as a compose extension with type of botMessagePreview.
+     * @param cardAttachment Attachment to be assigned.
+     * @returns A `MessagingExtensionActionResponse` object.
+     */
     public static toMessagingExtensionBotMessagePreviewResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
             composeExtension: {

--- a/libraries/teams-scenarios/integrationBot/src/submitExampleData.ts
+++ b/libraries/teams-scenarios/integrationBot/src/submitExampleData.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+/**
+ * Example data class
+ */
 export class SubmitExampleData {
     public MultiSelect: string;
     public Option1: string;

--- a/libraries/teams-scenarios/integrationBot/src/teamsTenantFilteringMiddleware.ts
+++ b/libraries/teams-scenarios/integrationBot/src/teamsTenantFilteringMiddleware.ts
@@ -10,9 +10,9 @@ import {
     TeamsChannelData,
 } from 'botbuilder-core';
 
-//
-// Teams specific middleware for filtering messages by Tenant Id.
-//
+/**
+ * Teams specific middleware for filtering messages by Tenant Id.
+ */
 export class TeamsTenantFilteringMiddleware implements Middleware {
     // tslint:disable:variable-name
     private readonly _tenantSet = new Set();
@@ -20,7 +20,7 @@ export class TeamsTenantFilteringMiddleware implements Middleware {
 
     /**
      * Initializes a new instance of the TeamsTenantFilteringMiddleware class.
-     * * @param allowedTenants either a single Tenant Id or array of Tenant Ids.
+     * * @param allowedTenants Either a single Tenant Id or array of Tenant Ids.
      */
     constructor(allowedTenants: string | string[]) {
         if(Array.isArray(allowedTenants)){

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-coverage": "nyc mocha \"libraries/@(adaptive*|bot*)/tests/**/*.test.js\" --exit",
     "upload-coverage": "nyc report --reporter=text-lcov | coveralls",
     "build-docs": "lerna run build-docs",
-    "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
+    "eslint": "eslint ./libraries/**/src/*.ts ./libraries/**/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
     "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} ${PreviewPackageVersion} adaptive-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-dialogs-adaptive botbuilder-dialogs-declarative botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot bot-integration-tests && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds `jsdoc/require-jsdoc` to include `teams-scenarios` in the `.eslintrc.json` file and adds all the missing JSDoc documentation for [teams-scenarios](https://github.com/microsoft/botbuilder-js/tree/master/libraries/teams-scenarios) based on the errors thrown. Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes

- Adds `jsdoc/require-jsdoc` in `.eslintrc.json` for teams-scenarios.
- Updates `package.json` eslint script to contemplates teams-scenarios folder.
- Private methods' documentation that does not exist on botbuilder-dotnet we added the `@private` tag in the JSDoc comment.
- Protected methods' documentation that does not exist on botbuilder-dotnet we added the `@protected` tag in the JSDoc comment.
- Added JSDoc comments in **14 files**.

Folders included:
- actionBasedMessagingExtension-fetchTask
- actionBasedMessagingExtension
- activityUpdateAndDelete
- adaptiveCards
- cardBotFramework
- integrationBot

## Testing
In the following image there is a sneak peek about the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/62260472/94612570-a952b400-0279-11eb-9bf9-c317eeea8ba7.png)