### PR TITLE
Add missing documentation for teams-scenarios files

### DIFF
--- a/libraries/teams-scenarios/conversationUpdate/src/conversationUpdateBot.ts
+++ b/libraries/teams-scenarios/conversationUpdate/src/conversationUpdateBot.ts
@@ -11,8 +11,16 @@ import {
     TurnContext,
 } from 'botbuilder';
 
-
+/**
+ * This bot must be added to a team. You might need to create your own team so you can modify the channel information.
+ * From the UI you can click the 3 dots on the team level, or the channel level to add, rename, or delete the channel/team.
+ * You can go to the "manage team" option at the team level to add/remove people.
+ */
 export class ConversationUpdateBot  extends TeamsActivityHandler {
+
+    /**
+     * Initializes a new instance of the `ConversationUpdateBot` class.
+     */
     constructor() {
         super();
 

--- a/libraries/teams-scenarios/fileUpload/src/fileUploadBot.ts
+++ b/libraries/teams-scenarios/fileUpload/src/fileUploadBot.ts
@@ -11,7 +11,14 @@ import {
     FileConsentCardResponse
 } from 'botbuilder';
 
+/**
+ * You can install this bot at any scope. You can @mention the bot and it will present you with the file prompt.
+ * You can accept and the file will be uploaded, or you can decline and it won't.
+ */
 export class FileUploadBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `FileUploadBot` class.
+     */
     constructor() {
         super();
 
@@ -35,6 +42,9 @@ export class FileUploadBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         try {
             await this.sendFile(fileConsentCardResponse);
@@ -45,13 +55,19 @@ export class FileUploadBot extends TeamsActivityHandler {
         }
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         let reply = this.createReply(context.activity);
         reply.textFormat = "xml";
         reply.text = `Declined. We won't upload file <b>${fileConsentCardResponse.context["filename"]}</b>.`;
         await context.sendActivity(reply);
-    } 
-    
+    }
+
+    /**
+     * @private
+     */
     private createReply(activity, text = null, locale = null) : Activity {
         return {
             type: 'message',
@@ -66,23 +82,29 @@ export class FileUploadBot extends TeamsActivityHandler {
         } as Activity;
     }
 
+    /**
+     * @private
+     */
     private async sendFile(fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         const request = require("request");
-        const fs = require('fs');     
+        const fs = require('fs');
         let context = fileConsentCardResponse.context;
         let path = require('path');
         let filePath = path.join('files', context["filename"]);
         let stats = fs.statSync(filePath);
-        let fileSizeInBytes = stats['size']; 
+        let fileSizeInBytes = stats['size'];
         fs.createReadStream(filePath).pipe(request.put(fileConsentCardResponse.uploadInfo.uploadUrl));
     }
 
+    /**
+     * @private
+     */
     private async sendFileCard(context: TurnContext): Promise<void> {
         let filename = "teams-logo.png";
-        let fs = require('fs'); 
+        let fs = require('fs');
         let path = require('path');
         let stats = fs.statSync(path.join('files', filename));
-        let fileSizeInBytes = stats['size'];    
+        let fileSizeInBytes = stats['size'];
 
         let fileContext = {
             filename: filename
@@ -104,6 +126,9 @@ export class FileUploadBot extends TeamsActivityHandler {
         await context.sendActivity(replyActivity);
     }
 
+    /**
+     * @private
+     */
     private async fileUploadCompleted(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         let fileUploadInfoName = fileConsentCardResponse.uploadInfo.name;
         let downloadCard = <FileInfoCard>{
@@ -124,6 +149,9 @@ export class FileUploadBot extends TeamsActivityHandler {
         await context.sendActivity(reply);
     }
 
+    /**
+     * @private
+     */
     private async fileUploadFailed(context: TurnContext, error: string): Promise<void> {
         let reply = this.createReply(context.activity, `<b>File upload failed.</b> Error: <pre>${error}</pre>`);
         reply.textFormat = 'xml';

--- a/libraries/teams-scenarios/link-unfurling/src/linkUnfurling.ts
+++ b/libraries/teams-scenarios/link-unfurling/src/linkUnfurling.ts
@@ -3,14 +3,20 @@
 
 import {
     AppBasedLinkQuery,
-    CardFactory, 
+    CardFactory,
     MessagingExtensionResponse,
     MessagingExtensionResult,
     TeamsActivityHandler,
-    TurnContext } 
+    TurnContext }
 from 'botbuilder';
 
+/**
+ * Teams handler class to do link unfurling.
+ */
 export class LinkUnfurlingBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `LinkUnfurlingBot` class.
+     */
     constructor() {
         super();
 
@@ -22,11 +28,14 @@ export class LinkUnfurlingBot extends TeamsActivityHandler {
         });
     }
 
-     // "Link Unfurling"
-    // This handler is used for the processing of "composeExtension/queryLink" activities from Teams.
-    // https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/messaging-extensions/search-extensions#receive-requests-from-links-inserted-into-the-compose-message-box
-    // By specifying domains under the messageHandlers section in the manifest, the bot can receive
-    // events when a user enters in a domain in the compose box.   
+    /**
+     * @protected
+     * "Link Unfurling"
+     * This handler is used for the processing of "composeExtension/queryLink" activities from Teams.
+     * https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/messaging-extensions/search-extensions#receive-requests-from-links-inserted-into-the-compose-message-box
+     * By specifying domains under the messageHandlers section in the manifest, the bot can receive
+     * events when a user enters in a domain in the compose box.
+     */
     protected async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
         const attachment = CardFactory.thumbnailCard('Thumbnail Card', query.url, ["https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"]);
 
@@ -39,7 +48,7 @@ export class LinkUnfurlingBot extends TeamsActivityHandler {
         const response: MessagingExtensionResponse = {
             composeExtension: result,
         }
-        
+
         return response;
     }
 }

--- a/libraries/teams-scenarios/mentionsBot/src/mentionsBot.ts
+++ b/libraries/teams-scenarios/mentionsBot/src/mentionsBot.ts
@@ -7,10 +7,13 @@ import {
     TeamsActivityHandler,
 } from 'botbuilder';
 
+/**
+ * You can @mention the bot from any scope and it will reply with the mention.
+ */
 export class MentionsBot  extends TeamsActivityHandler {
-    /*
-     * You can @mention the bot from any scope and it will reply with the mention.
-     */    
+    /**
+     * Initializes a new instance of the `MentionsBot` class.
+     */
     constructor() {
         super();
 

--- a/libraries/teams-scenarios/messageReaction/src/activityLog.ts
+++ b/libraries/teams-scenarios/messageReaction/src/activityLog.ts
@@ -10,13 +10,25 @@ import{
 } from 'botframework-schema'
 
 
+/**
+ * `Activity`'s class with a Storage provider.
+ */
 export class ActivityLog  {
-    private readonly _storage: Storage;   
+    private readonly _storage: Storage;
 
+    /**
+     * Initializes a new instance of the `ActivityLog` class.
+     * @param storage A storage provider that stores and retrieves plain old JSON objects.
+     */
     public constructor(storage: Storage) {
         this._storage = storage;
     }
-    
+
+    /**
+     * Saves an `Activity` with its associated id into the storage.
+     * @param activityId `Activity`'s Id.
+     * @param activity The `Activity` object.
+     */
     public async append(activityId: string, activity: Partial<Activity>): Promise<void> {
         if (activityId == null)
         {
@@ -36,6 +48,11 @@ export class ActivityLog  {
         return;
     }
 
+    /**
+     * Retrieves an `Activity` from the storage by a given Id.
+     * @param activityId `Activity`'s Id.
+     * @returns The `Activity`'s object retrieved from storage.
+     */
     public async find(activityId: string): Promise<Activity>
     {
         if (activityId == null)

--- a/libraries/teams-scenarios/messageReaction/src/messageReactionBot.ts
+++ b/libraries/teams-scenarios/messageReaction/src/messageReactionBot.ts
@@ -12,11 +12,15 @@ import {
     ActivityLog
 } from './activityLog';
 
+/**
+ * From the UI you need to @mention the bot, then add a message reaction to the message the bot sent.
+ */
 export class MessageReactionBot extends ActivityHandler {
     _log: ActivityLog;
 
-    /*
-     * From the UI you need to @mention the bot, then add a message reaction to the message the bot sent.
+    /**
+     * Initializes a new instance of the `MessageReactionBot` class.
+     * @param activityLog The `ActivityLog`.
      */
     constructor(activityLog: ActivityLog) {
         super();
@@ -32,6 +36,9 @@ export class MessageReactionBot extends ActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
         for (var i = 0, len = reactionsAdded.length; i < len; i++) {
             var activity = await this._log.find(context.activity.replyToId);
@@ -47,6 +54,9 @@ export class MessageReactionBot extends ActivityHandler {
         return;
     }
 
+    /**
+     * @protected
+     */
     protected async onReactionsRemovedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
         for (var i = 0, len = reactionsAdded.length; i < len; i++) {
             // The ReplyToId property of the inbound MessageReaction Activity will correspond to a Message Activity that was previously sent from this bot.
@@ -63,6 +73,11 @@ export class MessageReactionBot extends ActivityHandler {
         return;
     }
 
+    /**
+     * Sends an activity reply.
+     * @param context The `TurnContext`.
+     * @param text The `Activity`'s text.
+     */
     async sendMessageAndLogActivityId(context: TurnContext, text: string): Promise<void> {
         var replyActivity = MessageFactory.text(text);
         var resourceResponse = await context.sendActivity(replyActivity);

--- a/libraries/teams-scenarios/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
+++ b/libraries/teams-scenarios/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
@@ -19,17 +19,22 @@ import {
     IUserTokenProvider,
 } from 'botbuilder-core';
 
-/*
-* This Bot requires an Azure Bot Service OAuth connection name in appsettings.json
-* see: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication
-*
-* Clicking this bot's Task Menu will retrieve the login dialog, if the user is not already signed in.
-*/
+/**
+ * This Bot requires an Azure Bot Service OAuth connection name in appsettings.json
+ * see: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication
+ *
+ * Clicking this bot's Task Menu will retrieve the login dialog, if the user is not already signed in.
+ */
 export class MessagingExtensionAuthBot extends TeamsActivityHandler {
     connectionName: string;
+
+    /**
+     * Initializes a new instance of the `MessagingExtensionAuthBot` class.
+     * @param authConnectionName The Auth connection name.
+     */
     constructor(authConnectionName: string) {
         super();
-        
+
         this.connectionName = authConnectionName;
 
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
@@ -47,7 +52,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
 
                 await adapter.signOutUser(context, this.connectionName);
                 await context.sendActivity(`Signed Out: ${context.activity.from.name}`);
-                
+
                 return;
             }
 
@@ -69,6 +74,9 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const adapter: IUserTokenProvider = context.adapter as BotFrameworkAdapter;
         const userToken = await adapter.getUserToken(context, this.connectionName);
@@ -79,14 +87,14 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
             // Retrieve the OAuth Sign in Link to use in the MessagingExtensionResult Suggested Actions
             const signInLink = await adapter.getSignInLink(context, this.connectionName);
 
-            const response : MessagingExtensionActionResponse = { 
-                composeExtension: { 
-                    type: 'auth', 
-                    suggestedActions: { 
-                        actions: [{ 
-                            type: 'openUrl', 
-                            value: signInLink, 
-                            title: 'Bot Service OAuth' 
+            const response : MessagingExtensionActionResponse = {
+                composeExtension: {
+                    type: 'auth',
+                    suggestedActions: {
+                        actions: [{
+                            type: 'openUrl',
+                            value: signInLink,
+                            title: 'Bot Service OAuth'
                         }]
                     }
                 }
@@ -100,13 +108,16 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
             value: this.CreateSignedInTaskModuleTaskInfo(),
         };
 
-        const response : MessagingExtensionActionResponse = { 
-            task: continueResponse 
-        }; 
+        const response : MessagingExtensionActionResponse = {
+            task: continueResponse
+        };
 
         return response;
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         var data = context.activity.value;
         if (data && data.state)
@@ -118,10 +129,10 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
                 type: 'continue',
                 value: this.CreateSignedInTaskModuleTaskInfo(tokenResponse.token),
             };
-    
-            const response : MessagingExtensionActionResponse = { 
-                task: continueResponse 
-            }; 
+
+            const response : MessagingExtensionActionResponse = {
+                task: continueResponse
+            };
 
             return response;
         }
@@ -132,6 +143,9 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         }
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         if (action.data != null && action.data.key && action.data.key == "signout")
         {
@@ -143,8 +157,11 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         return null;
     }
 
+    /**
+     * @private
+     */
     private CreateSignedInTaskModuleTaskInfo(token?: string): TaskModuleTaskInfo {
-        const attachment = this.GetTaskModuleAdaptiveCard(); 
+        const attachment = this.GetTaskModuleAdaptiveCard();
         let width = 350;
         let height = 160;
         if(token){
@@ -172,7 +189,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
             width = 500;
             height = 300;
         }
-        return { 
+        return {
             card: attachment,
             height: height,
             width: width,
@@ -180,6 +197,9 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @private
+     */
     private GetTaskModuleAdaptiveCard(): Attachment {
         return CardFactory.adaptiveCard({
             version: '1.0.0',

--- a/libraries/teams-scenarios/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
+++ b/libraries/teams-scenarios/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
@@ -14,7 +14,16 @@ import {
     ActionTypes,
 } from 'botframework-schema'
 
+/**
+ * After uploading the manifest you can click the dots in the extension menu at the bottom, or search for the
+ * exntesion in the command bar. From the extension window or the command bar you can click on the 3 dots on the specific extension to trigger
+ * the OnMessageActivityAsync function. If you click on the "Settings" tab you will fire the OnTeamsMessagingExtensionConfigurationSettingAsync
+ * function.
+ */
 export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `MessagingExtensionConfigBot` class.
+     */
     constructor() {
         super();
 
@@ -38,12 +47,15 @@ export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery){
         return <MessagingExtensionActionResponse>
         {
             composeExtension: <MessagingExtensionResult> {
                 type: 'config',
-                suggestedActions: <MessagingExtensionSuggestedAction> { 
+                suggestedActions: <MessagingExtensionSuggestedAction> {
                     actions: [
                         {
                             type: ActionTypes.OpenUrl,
@@ -55,6 +67,9 @@ export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
         }
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings){
         // This event is fired when the settings page is submitted
         await context.sendActivity(`onTeamsMessagingExtensionSettings event fired with ${ JSON.stringify(settings) }`);

--- a/libraries/teams-scenarios/notificationOnly/src/notificationOnlyBot.ts
+++ b/libraries/teams-scenarios/notificationOnly/src/notificationOnlyBot.ts
@@ -9,12 +9,15 @@ import {
     TurnContext,
 } from 'botbuilder';
 
+/**
+ * This bot needs to be installed in a team or group chat that you are an admin of. You can add/remove someone from that team and
+ * the bot will send that person a 1:1 message saying what happened. Also, yes, this scenario isn't the most up to date with the updated
+ * APIs for membersAdded/removed. Also you should NOT be able to @mention this bot.
+ */
 export class NotificationOnlyBot extends TeamsActivityHandler {
-    /*
-     * This bot needs to be installed in a team or group chat that you are an admin of. You can add/remove someone from that team and
-     * the bot will send that person a 1:1 message saying what happened. Also, yes, this scenario isn't the most up to date with the updated
-     * APIs for membersAdded/removed. Also you should NOT be able to @mention this bot.
-     */    
+    /**
+     * Initializes a new instance of the `NotificationOnlyBot` class.
+     */
     constructor() {
         super();
 
@@ -46,7 +49,7 @@ export class NotificationOnlyBot extends TeamsActivityHandler {
         this.onMembersAdded(async (context: TurnContext, next: () => Promise<void>): Promise<void> => {
             for (const member of context.activity.membersAdded) {
                 var replyActivity = MessageFactory.text(`${member.id} was added to the team.`);
-                
+
                 replyActivity = TurnContext.applyConversationReference(replyActivity, TurnContext.getConversationReference(context.activity));
                 const channelId = context.activity.conversation.id.split(';')[0];
                 replyActivity.conversation.id = channelId;
@@ -58,7 +61,7 @@ export class NotificationOnlyBot extends TeamsActivityHandler {
         this.onMembersRemoved(async (context: TurnContext, next: () => Promise<void>): Promise<void> => {
             for (const member of context.activity.membersRemoved) {
                 var replyActivity = MessageFactory.text(`${member.id} was removed from the team.`);
-                
+
                 replyActivity = TurnContext.applyConversationReference(replyActivity, TurnContext.getConversationReference(context.activity));
                 const channelId = context.activity.conversation.id.split(';')[0];
                 replyActivity.conversation.id = channelId;

--- a/libraries/teams-scenarios/office365Card/src/office365CardsBot.ts
+++ b/libraries/teams-scenarios/office365Card/src/office365CardsBot.ts
@@ -23,6 +23,9 @@ import {
  * You can install this bot in any scope. From the UI just @mention the bot.
  */
 export class Office365CardsBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `Office365CardsBot` class.
+     */
     constructor() {
         super();
 
@@ -46,10 +49,16 @@ export class Office365CardsBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
         await context.sendActivity(MessageFactory.text(`O365ConnectorCardActionQuery event value: ${JSON.stringify(query)}`));
     }
 
+    /**
+     * @private
+     */
     private async sendO365CardAttachment(context: TurnContext): Promise<void> {
         const card = CardFactory.o365ConnectorCard(<O365ConnectorCard>{
             "title": "card title",

--- a/libraries/teams-scenarios/replyToChannel/src/replyToChannelBot.ts
+++ b/libraries/teams-scenarios/replyToChannel/src/replyToChannelBot.ts
@@ -16,9 +16,15 @@ import {
 } from 'botbuilder';
 import { basename } from 'path';
 
+/**
+ * Reply to channel bot handlers.
+ */
 export class ReplyToChannelBot extends TeamsActivityHandler {
     botId: string;
-    
+
+    /**
+     * Initializes a new instance of the `ReplyToChannelBot` class.
+     */
     constructor() {
         super();
 
@@ -43,16 +49,18 @@ export class ReplyToChannelBot extends TeamsActivityHandler {
         });
     }
 
-    
+    /**
+     * @private
+     */
     private async teamsCreateConversation(context: TurnContext, teamsChannelId: string, message: Partial<Activity>): Promise<[ConversationReference, string]> {
         if (!teamsChannelId) {
             throw new Error('Missing valid teamsChannelId argument');
         }
-    
+
         if (!message) {
             throw new Error('Missing valid message argument');
         }
-    
+
         const conversationParameters = <ConversationParameters>{
             isGroup: true,
             channelData: <TeamsChannelData>{
@@ -60,14 +68,14 @@ export class ReplyToChannelBot extends TeamsActivityHandler {
                     id: teamsChannelId
                 }
             },
-    
+
             activity: message,
         };
 
-        const adapter = <BotFrameworkAdapter>context.adapter;    
+        const adapter = <BotFrameworkAdapter>context.adapter;
         const connectorClient = adapter.createConnectorClient(context.activity.serviceUrl);
 
-        // This call does NOT send the outbound Activity is not being sent through the middleware stack.    
+        // This call does NOT send the outbound Activity is not being sent through the middleware stack.
         const conversationResourceResponse: ConversationResourceResponse = await connectorClient.conversations.createConversation(conversationParameters);
         const conversationReference = <ConversationReference>TurnContext.getConversationReference(context.activity);
         conversationReference.conversation.id = conversationResourceResponse.id;

--- a/libraries/teams-scenarios/roster/src/rosterBot.ts
+++ b/libraries/teams-scenarios/roster/src/rosterBot.ts
@@ -9,11 +9,14 @@ import {
     TurnContext
 } from 'botbuilder';
 
-//
-// You need to install this bot in a team. You can @mention the bot "show members", "show channels", or "show details" to get the
-// members of the team, the channels of the team, or metadata about the team respectively.
-//
+/**
+ * You need to install this bot in a team. You can @mention the bot "show members", "show channels", or "show details" to get the
+ * members of the team, the channels of the team, or metadata about the team respectively.
+ */
 export class RosterBot extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `RosterBot` class.
+     */
     constructor() {
         super();
 
@@ -62,6 +65,9 @@ export class RosterBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @private
+     */
     private async showMembers(context: TurnContext): Promise<void> {
         let options = {"continuationToken": null, "pageSize": 2};
         let teamsChannelAccounts = await (await TeamsInfo.getPagedMembers(context, 5)).members;
@@ -72,6 +78,9 @@ export class RosterBot extends TeamsActivityHandler {
         await this.sendInBatches(context, messages);
     }
 
+    /**
+     * @private
+     */
     private async showChannels(context: TurnContext): Promise<void> {
         let channels = await TeamsInfo.getTeamChannels(context);
         await context.sendActivity(MessageFactory.text(`Total of ${channels.length} channels are currently in team`));
@@ -81,16 +90,25 @@ export class RosterBot extends TeamsActivityHandler {
         await this.sendInBatches(context, messages);
     }
 
+    /**
+     * @private
+     */
     private async showMember(context: TurnContext): Promise<void> {
         let member = await TeamsInfo.getMember(context, context.activity.from.id);
         await context.sendActivity(MessageFactory.text("You are: " + member.name));
     }
 
+    /**
+     * @private
+     */
     private async showDetails(context: TurnContext): Promise<void> {
         let teamDetails = await TeamsInfo.getTeamDetails(context);
         await context.sendActivity(MessageFactory.text(`The team name is ${teamDetails.name}. The team ID is ${teamDetails.id}. The AAD GroupID is ${teamDetails.aadGroupId}.`));
     }
 
+    /**
+     * @private
+     */
     private async sendInBatches(context: TurnContext, messages: string[]): Promise<void> {
         let batch: string[] = [];
         messages.forEach(async (msg: string) => {

--- a/libraries/teams-scenarios/roster/src/teamsTenantFilteringMiddleware.ts
+++ b/libraries/teams-scenarios/roster/src/teamsTenantFilteringMiddleware.ts
@@ -10,9 +10,9 @@ import {
     TeamsChannelData,
 } from 'botbuilder-core';
 
-//
-// Teams specific middleware for filtering messages by Tenant Id.
-//
+/**
+ * Teams specific middleware for filtering messages by Tenant Id.
+ */
 export class TeamsTenantFilteringMiddleware implements Middleware {
     // tslint:disable:variable-name
     private readonly _tenantSet = new Set();
@@ -20,7 +20,7 @@ export class TeamsTenantFilteringMiddleware implements Middleware {
 
     /**
      * Initializes a new instance of the TeamsTenantFilteringMiddleware class.
-     * * @param allowedTenants either a single Tenant Id or array of Tenant Ids.
+     * * @param allowedTenants Either a single Tenant Id or array of Tenant Ids.
      */
     constructor(allowedTenants: string | string[]) {
         if(Array.isArray(allowedTenants)){

--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
@@ -15,15 +15,16 @@ import {
     TurnContext
 } from 'botbuilder';
 
+/**
+ * For this example, we're using UserState to store the user's preferences for the type of Rich Card they receive.
+ * Users can specify the type of card they receive by configuring the Messaging Extension.
+ * To store their configuration, we will use the userState passed in via the constructor.
+ */
 export class TeamsSearchExtensionBot extends TeamsActivityHandler {
-
-    // For this example, we're using UserState to store the user's preferences for the type of Rich Card they receive.
-    // Users can specify the type of card they receive by configuring the Messaging Extension.
-    // To store their configuration, we will use the userState passed in via the constructor.
-
     /**
+     * Initializes a new instance of the `TeamsSearchExtensionBot` class.
      * We need to change the key for the user state because the bot might not be in the conversation, which means they get a 403 error.
-     * @param userState 
+     * @param userState User's bot state for persistance.
      */
     constructor(public userState: BotState) {
         super();
@@ -48,11 +49,14 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse>{
         const searchQuery = query.parameters[0].value;
         const composeExtension = this.createMessagingExtensionResult([
-            this.createSearchResultAttachment(searchQuery), 
-            this.createDummySearchResultAttachment(searchQuery), 
+            this.createSearchResultAttachment(searchQuery),
+            this.createDummySearchResultAttachment(searchQuery),
             this.createSelectItemsResultAttachment(searchQuery)
         ]);
 
@@ -61,6 +65,9 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsMessagingExtensionSelectItem(context: TurnContext, query: any): Promise<MessagingExtensionResponse> {
         const searchQuery = query.query;
         const bfLogo = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU";
@@ -71,6 +78,9 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @private
+     */
     private createMessagingExtensionResult(attachments: Attachment[]) : MessagingExtensionResult {
         return <MessagingExtensionResult> {
             type: "result",
@@ -79,6 +89,9 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @private
+     */
     private createSearchResultAttachment(searchQuery: string) : MessagingExtensionAttachment {
         const cardText = `You said \"${searchQuery}\"`;
         const bfLogo = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU";
@@ -100,6 +113,9 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @private
+     */
     private createDummySearchResultAttachment(searchQuery: string) : MessagingExtensionAttachment {
         const cardText = "https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-overview";
         const bfLogo = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU";
@@ -121,6 +137,9 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
+    /**
+     * @private
+     */
     private createSelectItemsResultAttachment(searchQuery: string): MessagingExtensionAttachment {
         const bfLogo = 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU';
         const cardText = `You said: "${searchQuery}"`;

--- a/libraries/teams-scenarios/taskModule/src/taskModuleBot.ts
+++ b/libraries/teams-scenarios/taskModule/src/taskModuleBot.ts
@@ -16,7 +16,14 @@ import {
     TurnContext,
 } from 'botbuilder-core';
 
+/**
+ * This bot can be installed at any scope. If you @mention the bot you will get the task module. You can interact with the task module to
+ * hit the other functions.
+ */
 export class TaskModuleBot  extends TeamsActivityHandler {
+    /**
+     * Initializes a new instance of the `TaskModuleBot` class.
+     */
     constructor() {
         super();
 
@@ -29,43 +36,55 @@ export class TaskModuleBot  extends TeamsActivityHandler {
         });
     }
 
+    /**
+     * @protected
+     */
     protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         var reply = MessageFactory.text("handleTeamsTaskModuleFetch TaskModuleRequest" + JSON.stringify(taskModuleRequest));
         await context.sendActivity(reply);
 
         return {
-            task: { 
-                type: "continue", 
+            task: {
+                type: "continue",
                 value: {
                     card: this.getTaskModuleAdaptiveCard(),
                     height: 200,
                     width: 400,
                     title: "Adaptive Card: Inputs",
-                } as TaskModuleTaskInfo, 
+                } as TaskModuleTaskInfo,
             } as TaskModuleContinueResponse
         } as TaskModuleResponse;
     }
-    
+
+    /**
+     * @protected
+     */
     protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         var reply = MessageFactory.text("handleTeamsTaskModuleSubmit Value: " + JSON.stringify(taskModuleRequest));
         await context.sendActivity(reply);
 
         return {
-            task: { 
-                type: "message", 
-                value: "Hello", 
+            task: {
+                type: "message",
+                value: "Hello",
             } as TaskModuleMessageResponse
         } as TaskModuleResponse;
     }
 
+    /**
+     * @private
+     */
     private getTaskModuleHeroCard() : Attachment {
-        return CardFactory.heroCard("Task Module Invocation from Hero Card", 
+        return CardFactory.heroCard("Task Module Invocation from Hero Card",
             "This is a hero card with a Task Module Action button.  Click the button to show an Adaptive Card within a Task Module.",
             null, // No images
             [{type: "invoke", title:"Adaptive Card", value: {type:"task/fetch", data:"adaptivecard"} }]
             );
     }
 
+    /**
+     * @private
+     */
     private getTaskModuleAdaptiveCard(): Attachment {
         return CardFactory.adaptiveCard({
             version: '1.0.0',


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds `jsdoc/require-jsdoc` to include `teams-scenarios` in the `.eslintrc.json` file and adds all the missing JSDoc documentation for [teams-scenarios](https://github.com/microsoft/botbuilder-js/tree/master/libraries/teams-scenarios) based on the errors thrown. Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

> **Note:** We divided the work for this library into two PRs to ease the review. PR# 160 contains the rest of the teams-scenarios fixes.

## Specific Changes

- Private methods' documentation that does not exist on botbuilder-dotnet we added the `@private` tag in the JSDoc comment.
- Protected methods' documentation that does not exist on botbuilder-dotnet we added the `@protected` tag in the JSDoc comment.
- Added JSDoc comments in **15 files**.

Folders included:
- conversationUpdate
- fileUpload
- link-unfurling
- mentionsBot
- messageReaction
- messagingExtensionAuth
- messagingExtensionConfig
- notificationOnly
- office365Card
- replyToChannel
- roster
- searchBasedMessagingExtension
- taskModule

## Testing
In the following image there is a sneak peek about the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/62260472/94612570-a952b400-0279-11eb-9bf9-c317eeea8ba7.png)