### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 2/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/ceiling.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ceiling.ts
@@ -13,10 +13,16 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  * Returns the smallest integral value that is greater than or equal to the specified number.
  */
 export class Ceiling extends NumberTransformEvaluator {
+    /**
+     * Initializes a new instance of the `Ceiling` class.
+     */
     public constructor() {
         super(ExpressionType.Ceiling, Ceiling.func);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): number {
         return Math.ceil(args[0]);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/coalesce.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/coalesce.ts
@@ -16,14 +16,23 @@ import { ReturnType } from '../returnType';
  * Empty strings, empty arrays, and empty objects are not null.
  */
 export class Coalesce extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Coalesce` class.
+     */
     public constructor() {
         super(ExpressionType.Coalesce, Coalesce.evaluator(), ReturnType.Object, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[][]): any => Coalesce.evalCoalesce(args as any[]));
     }
 
+    /**
+     * @private
+     */
     private static evalCoalesce(objetcList: object[]): any {
         for (const obj of objetcList) {
             if (obj !== null && obj !== undefined) {

--- a/libraries/adaptive-expressions/src/builtinFunctions/comparisonEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/comparisonEvaluator.ts
@@ -19,10 +19,20 @@ import { ReturnType } from '../returnType';
  * A comparison operator returns false if the comparison is false, or there is an error.  This prevents errors from short-circuiting boolean expressions.
  */
 export class ComparisonEvaluator extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `ComparisonEvaluator` class.
+     * @param type Name of the built-in function.
+     * @param func The comparison function, it takes a list of objects and returns a boolean.
+     * @param validator Validator of input arguments.
+     * @param verify Optional. Function to verify each child's result.
+     */
     public constructor(type: string, func: (arg0: any[]) => boolean, validator: ValidateExpressionDelegate, verify?: VerifyExpression) {
         super(type, ComparisonEvaluator.evaluator(func, verify), ReturnType.Boolean, validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(func: (args: any[]) => boolean, verify?: VerifyExpression): EvaluateExpressionDelegate {
         return (expression: Expression, state: MemoryInterface, options: Options): ValueWithError => {
             let result = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/concat.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/concat.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Combine two or more strings, and return the combined string.
  */
 export class Concat extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Concat` class.
+     */
     public constructor() {
         super(ExpressionType.Concat, Concat.evaluator(), ReturnType.String | ReturnType.Array, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applySequence((args: any[]): string => {
             const firstItem = args[0];
@@ -41,6 +47,9 @@ export class Concat extends ExpressionEvaluator {
         });
     }
 
+    /**
+     * @private
+     */
     private static commonStringify(input: any): string {
         if (input === null || input === undefined) {
             return '';

--- a/libraries/adaptive-expressions/src/builtinFunctions/contains.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/contains.ts
@@ -20,10 +20,16 @@ import { ReturnType } from '../returnType';
  * This function is case-sensitive.
  */
 export class Contains extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Contains` class.
+     */
     public constructor() {
         super(ExpressionType.Contains, Contains.evaluator, ReturnType.Boolean, FunctionUtils.validateBinary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let found = false;
         let error: any;

--- a/libraries/adaptive-expressions/src/builtinFunctions/convertFromUTC.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/convertFromUTC.ts
@@ -25,10 +25,16 @@ export class ConvertFromUTC extends ExpressionEvaluator {
 
     private static readonly NoneUtcDefaultDateTimeFormat: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
+    /**
+     * Initializes a new instance of the `ConvertFromUTC` class.
+     */
     public constructor() {
         super(ExpressionType.ConvertFromUTC, ConvertFromUTC.evaluator, ReturnType.String, ConvertFromUTC.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -46,6 +52,9 @@ export class ConvertFromUTC extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalConvertFromUTC(timeStamp: string, destinationTimeZone: string, format?: string): ValueWithError {
         let result: string;
         let error: string;
@@ -66,6 +75,9 @@ export class ConvertFromUTC extends ExpressionEvaluator {
         return { value: result, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.String, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
@@ -22,10 +22,16 @@ import { TimeZoneConverter } from '../timeZoneConverter';
  * Convert a timestamp to Universal Time Coordinated (UTC) from the source time zone.
  */
 export class ConvertToUTC extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `ConvertToUTC` class.
+     */
     public constructor() {
         super(ExpressionType.ConvertToUTC, ConvertToUTC.evaluator, ReturnType.String, ConvertToUTC.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -43,6 +49,9 @@ export class ConvertToUTC extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static verifyTimeStamp(timeStamp: string): string {
         let parsed: any;
         let error: string;
@@ -54,6 +63,9 @@ export class ConvertToUTC extends ExpressionEvaluator {
         return error;
     }
 
+    /**
+     * @private
+     */
     private static evalConvertToUTC(timeStamp: string, sourceTimezone: string, format?: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
@@ -98,7 +98,9 @@ export class ConvertToUTC extends ExpressionEvaluator {
         return { value: result, error };
     }
 
-
+    /**
+     * @private
+     */
     private static validator(expr: Expression): void {
         FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.String, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/count.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/count.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return the number of items in a collection.
  */
 export class Count extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Count` class.
+     */
     public constructor() {
         super(ExpressionType.Count, Count.evaluator(), ReturnType.Number, Count.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): number => {
@@ -36,6 +42,9 @@ export class Count extends ExpressionEvaluator {
             }, FunctionUtils.verifyContainer);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [], ReturnType.String | ReturnType.Array);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/countWord.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/countWord.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return the number of words in a string.
  */
 export class CountWord extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `CountWord` class.
+     */
     public constructor() {
         super(ExpressionType.CountWord, CountWord.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): number => InternalFunctionUtils.parseStringOrUndefined(args[0]).trim().split(/\s+/).length, FunctionUtils.verifyStringOrNull);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/createArray.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/createArray.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return an array from multiple inputs.
  */
 export class CreateArray extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `CreateArray` class.
+     */
     public constructor() {
         super(ExpressionType.CreateArray, CreateArray.evaluator(), ReturnType.Array);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): any[] => Array.from(args));
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUri.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUri.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return a data uniform resource identifier (URI) of a string.
  */
 export class DataUri extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DataUri` class.
+     */
     public constructor() {
         super(ExpressionType.DataUri, DataUri.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): string => 'data:text/plain;charset=utf-8;base64,'.concat(Buffer.from(args[0]).toString('base64')), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUriToBinary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUriToBinary.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return the binary version of a data uniform resource identifier (URI).
  */
 export class DataUriToBinary extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DataUriToBinary` class.
+     */
     public constructor() {
         super(ExpressionType.DataUriToBinary, DataUriToBinary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): Uint8Array => InternalFunctionUtils.toBinary(args[0]), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUriToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUriToString.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return the string version of a data uniform resource identifier (URI).
  */
 export class DataUriToString extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DataUriToString` class.
+     */
     public constructor() {
         super(ExpressionType.DataUriToString, DataUriToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): string => Buffer.from(args[0].slice(args[0].indexOf(',') + 1), 'base64').toString(), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateFunc.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateFunc.ts
@@ -18,10 +18,16 @@ import { ReturnType } from '../returnType';
  * Return the date of a specified timestamp in m/dd/yyyy format.
  */
 export class DateFunc extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DateFunc` class.
+     */
     public constructor() {
         super(ExpressionType.Date, DateFunc.evaluator(), ReturnType.String, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): string => moment(timestamp).utc().format('M/DD/YYYY')),

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
@@ -19,10 +19,16 @@ import { ReturnType } from '../returnType';
  * Uses the date-time library to provide a date readback.
  */
 export class DateReadBack extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DateReadBack` class.
+     */
     public constructor() {
         super(ExpressionType.DateReadBack, DateReadBack.evaluator(), ReturnType.String, DateReadBack.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -42,6 +48,9 @@ export class DateReadBack extends ExpressionEvaluator {
             FunctionUtils.verifyString);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, undefined, ReturnType.String, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class DateTimeDiff extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DataUriToBinary` class.
+     * Initializes a new instance of the `DateTimeDiff` class.
      */
     public constructor() {
         super(ExpressionType.DateTimeDiff, DateTimeDiff.evaluator, ReturnType.Number, DateTimeDiff.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
@@ -19,10 +19,16 @@ import { ReturnType } from '../returnType';
  * Return a number of ticks that the two timestamps differ.
  */
 export class DateTimeDiff extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DataUriToBinary` class.
+     */
     public constructor() {
         super(ExpressionType.DateTimeDiff, DateTimeDiff.evaluator, ReturnType.Number, DateTimeDiff.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let dateTimeStart: any;
@@ -44,6 +50,9 @@ export class DateTimeDiff extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 2, 2, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfMonth.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfMonth.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return the day of the month from a timestamp.
  */
 export class DayOfMonth extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DayOfMonth` class.
+     */
     public constructor() {
         super(ExpressionType.DayOfMonth, DayOfMonth.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): number => timestamp.getUTCDate()),

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfWeek.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfWeek.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return the day of the week from a timestamp.
  */
 export class DayOfWeek extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DayOfWeek` class.
+     */
     public constructor() {
         super(ExpressionType.DayOfWeek, DayOfWeek.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): number => timestamp.getUTCDay()),

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfYear.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfYear.ts
@@ -18,10 +18,16 @@ import { ReturnType } from '../returnType';
  * Return the day of the year from a timestamp.
  */
 export class DayOfYear extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `DayOfYear` class.
+     */
     public constructor() {
         super(ExpressionType.DayOfYear, DayOfYear.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): number => moment(timestamp).utc().dayOfYear()),


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94714654-d14a2200-0322-11eb-89cf-89c6a6f1fbca.png)
