### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 5/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/indexOf.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/indexOf.ts
@@ -20,10 +20,16 @@ import { ReturnType } from '../returnType';
  * The zero-based index position of value if that value is found, or -1 if it is not.
  */
 export class IndexOf extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IndexOf` class.
+     */
     public constructor() {
         super(ExpressionType.IndexOf, IndexOf.evaluator, ReturnType.Number, IndexOf.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value = -1;
         let error: string;
@@ -46,6 +52,9 @@ export class IndexOf extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [], ReturnType.String | ReturnType.Array, ReturnType.Object);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/indicesAndValues.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/indicesAndValues.ts
@@ -19,10 +19,16 @@ import { ReturnType } from '../returnType';
  * For objects, it is the key for the value.
  */
 export class IndicesAndValues extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IndicesAndValues` class.
+     */
     public constructor() {
         super(ExpressionType.IndicesAndValues, IndicesAndValues.evaluator, ReturnType.Array, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: any, options: Options): ValueWithError {
         let result: object = undefined;
         let error: string = undefined;

--- a/libraries/adaptive-expressions/src/builtinFunctions/int.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/int.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return the integer version of a string.
  */
 export class Int extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Int` class.
+     */
     public constructor() {
         super(ExpressionType.Int, Int.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/intersection.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/intersection.ts
@@ -19,10 +19,16 @@ import { ReturnType } from '../returnType';
  * the last item with that name appears in the result.
  */
 export class Intersection extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `Intersection` class.
+     */
     public constructor() {
         super(ExpressionType.Intersection, Intersection.evaluator(), ReturnType.Array, Intersection.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): any => {
@@ -36,6 +42,9 @@ export class Intersection extends ExpressionEvaluator {
             FunctionUtils.verifyList);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 1, Number.MAX_SAFE_INTEGER, ReturnType.Array);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/isArray.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isArray.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given input is an array.
  */
 export class IsArray extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsArray` class.
+     */
     public constructor() {
         super(ExpressionType.IsArray, IsArray.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => Array.isArray(args[0]));

--- a/libraries/adaptive-expressions/src/builtinFunctions/isBoolean.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isBoolean.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given input is a Boolean.
  */
 export class IsBoolean extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsBoolean` class.
+     */
     public constructor() {
         super(ExpressionType.IsBoolean, IsBoolean.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => typeof args[0] === 'boolean');

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
@@ -22,10 +22,16 @@ import { ReturnType } from '../returnType';
  * Valid dates contain the month and dayOfMonth, or contain the dayOfWeek.
  */
 export class IsDate extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsDate` class.
+     */
     public constructor() {
         super(ExpressionType.IsDate, IsDate.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
@@ -21,10 +21,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given TimexProperty or Timex expression refers to a valid date range.
  */
 export class IsDateRange extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsDateRange` class.
+     */
     public constructor() {
         super(ExpressionType.IsDateRange, IsDateRange.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDateTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDateTime.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given input is a UTC ISO format (YYYY-MM-DDTHH:mm:ss.fffZ) timestamp string.
  */
 export class IsDateTime extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsDateTime` class.
+     */
     public constructor() {
         super(ExpressionType.IsDateTime, IsDateTime.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => typeof args[0] === 'string' && InternalFunctionUtils.verifyISOTimestamp(args[0]) === undefined);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
@@ -21,10 +21,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given TimexProperty or Timex expression refers to a valid date. Valid dates contain the year, month and dayOfMonth.
  */
 export class IsDefinite extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsDefinite` class.
+     */
     public constructor() {
         super(ExpressionType.IsDefinite, IsDefinite.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
@@ -21,10 +21,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given TimexProperty or Timex expression refers to a valid duration.
  */
 export class IsDuration extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsDuration` class.
+     */
     public constructor() {
         super(ExpressionType.IsDuration, IsDuration.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isFloat.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isFloat.ts
@@ -16,10 +16,16 @@ import { ReturnType } from '../returnType';
  * Due to the alignment between C# and JavaScript, a number with an non-zero residue of its modulo 1 will be treated as a floating-point number.
  */
 export class IsFloat extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsFloat` class.
+     */
     public constructor() {
         super(ExpressionType.IsFloat, IsFloat.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => FunctionUtils.isNumber(args[0]) && !Number.isInteger(args[0]));

--- a/libraries/adaptive-expressions/src/builtinFunctions/isInteger.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isInteger.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given input is an integer number. Due to the alignment between C# and JavaScript, a number with a zero residue of its modulo 1 will be treated as an integer number.
  */
 export class IsInteger extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsInteger` class.
+     */
     public constructor() {
         super(ExpressionType.IsInteger, IsInteger.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => FunctionUtils.isNumber(args[0]) && Number.isInteger(args[0]));

--- a/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
@@ -18,10 +18,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given string matches a specified regular expression pattern.
  */
 export class IsMatch extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsMatch` class.
+     */
     public constructor() {
         super(ExpressionType.IsMatch, IsMatch.evaluator(), ReturnType.Boolean, IsMatch.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -39,6 +45,9 @@ export class IsMatch extends ExpressionEvaluator {
             }, FunctionUtils.verifyStringOrNull);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 2, 2, ReturnType.String);
 

--- a/libraries/adaptive-expressions/src/builtinFunctions/isObject.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isObject.ts
@@ -17,10 +17,16 @@ import { ReturnType } from '../returnType';
  * complex types, contain properties.
  */
 export class IsObject extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsObject` class.
+     */
     public constructor() {
         super(ExpressionType.IsObject, IsObject.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => typeof args[0] === 'object');

--- a/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
@@ -21,10 +21,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given TimexProperty or Timex expression refers to the present.
  */
 export class IsPresent extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsPresent` class.
+     */
     public constructor() {
         super(ExpressionType.IsPresent, IsPresent.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isString.ts
@@ -15,10 +15,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given input is a string.
  */
 export class IsString extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsString` class.
+     */
     public constructor() {
         super(ExpressionType.IsString, IsString.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): boolean => typeof args[0] === 'string');

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
@@ -22,10 +22,16 @@ import { ReturnType } from '../returnType';
  * Valid time contains hours, minutes and seconds.
  */
 export class IsTime extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsTime` class.
+     */
     public constructor() {
         super(ExpressionType.IsTime, IsTime.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
@@ -21,10 +21,16 @@ import { ReturnType } from '../returnType';
  * Return true if a given `TimexProperty` or Timex string refers to a valid time range Valid time ranges contain partOfDay.
  */
 export class IsTimeRange extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the `IsTimeRange` class.
+     */
     public constructor() {
         super(ExpressionType.IsTimeRange, IsTimeRange.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let parsed: TimexProperty;
         let value = false;


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/44245136/94714994-43bb0200-0323-11eb-95a6-d4d099715afa.png)
