### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 1/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Used to access the variable value corresponding to the path.
  */
 export class Accessor extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Accessor class.
+     */
     public constructor() {
         super(ExpressionType.Accessor, Accessor.evaluator, ReturnType.Object, Accessor.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let path: string;
         let left: any;
@@ -48,6 +55,9 @@ export class Accessor extends ExpressionEvaluator {
         }
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         const children: any[] = expression.children;
         if (children.length === 0

--- a/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
@@ -63,14 +63,14 @@ export class Accessor extends ExpressionEvaluator {
         if (children.length === 0
             || children[0].type !== ExpressionType.Constant
             || children[0].returnType !== ReturnType.String) {
-            throw new Error(`${expression} must have a string as first argument.`);
+            throw new Error(`${ expression } must have a string as first argument.`);
         }
 
         if (children.length > 2) {
-            throw new Error(`${expression} has more than 2 children.`);
+            throw new Error(`${ expression } has more than 2 children.`);
         }
         if (children.length === 2 && (children[1].returnType & ReturnType.Object) === 0) {
-            throw new Error(`${expression} must have an object as its second argument.`);
+            throw new Error(`${ expression } must have an object as its second argument.`);
         }
     }
 }

--- a/libraries/adaptive-expressions/src/builtinFunctions/add.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/add.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the result from adding two or more numbers (pure number case) or concatting two or more strings (other case).
  */
 export class Add extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Add class.
+     */
     public constructor() {
         super(ExpressionType.Add, Add.evaluator(), ReturnType.String | ReturnType.Number, Add.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applySequenceWithError(
             (args: any[]): any => {
@@ -48,6 +55,9 @@ export class Add extends ExpressionEvaluator {
             }, FunctionUtils.verifyNumberOrStringOrNull);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 2, Number.MAX_SAFE_INTEGER, ReturnType.String | ReturnType.Number);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
@@ -15,6 +15,10 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  * Add a number of days to a timestamp.
  */
 export class AddDays extends TimeTransformEvaluator {
+
+    /**
+     * Initializes a new instance of the AddDays class.
+     */
     public constructor() {
         super(ExpressionType.AddDays, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'd').toDate());
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
@@ -15,6 +15,10 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  * Add a number of hours to a timestamp.
  */
 export class AddHours extends TimeTransformEvaluator {
+
+    /**
+     * Initializes a new instance of the AddHours class.
+     */
     public constructor() {
         super(ExpressionType.AddHours, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'h').toDate());
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
@@ -15,6 +15,10 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  * Add a number of minutes to a timestamp.
  */
 export class AddMinutes extends TimeTransformEvaluator {
+
+    /**
+     * Initializes a new instance of the AddMinutes class.
+     */
     public constructor() {
         super(ExpressionType.AddMinutes, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'minutes').toDate());
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
@@ -16,14 +16,24 @@ import { ReturnType } from '../returnType';
  * Return the ordinal number of the input number.
  */
 export class AddOrdinal extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the AddOrdinal class.
+     */
     public constructor() {
         super(ExpressionType.AddOrdinal, AddOrdinal.evaluator(), ReturnType.String, AddOrdinal.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): string => AddOrdinal.evalAddOrdinal(args[0]), FunctionUtils.verifyInteger);
     }
 
+    /**
+     * @private
+     */
     private static evalAddOrdinal(num: number): string {
         let hasResult = false;
         let ordinalResult: string = num.toString();
@@ -60,6 +70,9 @@ export class AddOrdinal extends ExpressionEvaluator {
         return ordinalResult;
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 1, 1, ReturnType.Number);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
@@ -17,10 +17,17 @@ import { ReturnType } from '../returnType';
  * If the object already exists at runtime the function throws an error.
  */
 export class AddProperty extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the AddProperty class.
+     */
     public constructor() {
         super(ExpressionType.AddProperty, AddProperty.evaluator(), ReturnType.Object, AddProperty.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -37,6 +44,9 @@ export class AddProperty extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, undefined, ReturnType.Object, ReturnType.String, ReturnType.Object);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
@@ -35,7 +35,7 @@ export class AddProperty extends ExpressionEvaluator {
                 const temp: any = args[0];
                 const prop = String(args[1]);
                 if (prop in temp) {
-                    error = `${prop} already exists`;
+                    error = `${ prop } already exists`;
                 } else {
                     temp[String(args[1])] = args[2];
                 }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
@@ -15,6 +15,10 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  * Add a number of seconds to a timestamp.
  */
 export class AddSeconds extends TimeTransformEvaluator {
+
+    /**
+     * Initializes a new instance of the AddSeconds class.
+     */
     public constructor() {
         super(ExpressionType.AddSeconds, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'seconds').toDate());
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
@@ -21,10 +21,17 @@ import { ReturnType } from '../returnType';
  * Add a number of time units to a timestamp.
  */
 export class AddToTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the AddToTime class.
+     */
     public constructor() {
         super(ExpressionType.AddToTime, AddToTime.evaluator, ReturnType.String, AddToTime.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -42,6 +49,9 @@ export class AddToTime extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalAddToTime(timeStamp: string, interval: number, timeUnit: string, format?: string): ValueWithError {
         let result: string;
         let error: string;
@@ -102,6 +112,9 @@ export class AddToTime extends ExpressionEvaluator {
         return { value: result, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.String, ReturnType.Number, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
@@ -42,7 +42,7 @@ export class AddToTime extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string' && Number.isInteger(args[1]) && typeof (args[2]) === 'string') {
                 ({ value, error } = AddToTime.evalAddToTime(args[0], args[1], args[2], format));
             } else {
-                error = `${expression} should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.`;
+                error = `${ expression } should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.`;
             }
         }
 
@@ -98,7 +98,7 @@ export class AddToTime extends ExpressionEvaluator {
                 }
 
                 default: {
-                    error = `${timeUnit} is not valid time unit`;
+                    error = `${ timeUnit } is not valid time unit`;
                     break;
                 }
             }

--- a/libraries/adaptive-expressions/src/builtinFunctions/and.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/and.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return true if all expressions are true or return false if at least one expression is false.
  */
 export class And extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the And class.
+     */
     public constructor() {
         super(ExpressionType.And, And.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let result = true;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/average.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/average.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the average of a numeric array.
  */
 export class Average extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Average class.
+     */
     public constructor() {
         super(ExpressionType.Average, Average.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): number => args[0].reduce((x: number, y: number): number => x + y) / args[0].length,

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the base64-encoded version of a string or byte array.
  */
 export class Base64 extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Base64 class.
+     */
     public constructor() {
         super(ExpressionType.Base64, Base64.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: Readonly<any>): string | Uint8Array => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
@@ -18,10 +18,17 @@ import atob = require('atob-lite');
  * Return the binary array of a base64-encoded string.
  */
 export class Base64ToBinary extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Base64ToBinary class.
+     */
     public constructor() {
         super(ExpressionType.Base64ToBinary, Base64ToBinary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: Readonly<any>): Uint8Array => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the string version of a base64-encoded string, effectively decoding the base64 string.
  */
 export class Base64ToString extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Base64ToString class.
+     */
     public constructor() {
         super(ExpressionType.Base64ToString, Base64ToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: Readonly<any>): string => Buffer.from(args[0], 'base64').toString(), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the binary version of a string.
  */
 export class Binary extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Binary class.
+     */
     public constructor() {
         super(ExpressionType.Binary, Binary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): Uint8Array => InternalFunctionUtils.toBinary(args[0]), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return the Boolean version of a value.
  */
 export class Bool extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the Bool class.
+     */
     public constructor() {
         super(ExpressionType.Bool, Bool.func, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return InternalFunctionUtils.isLogicTrue(args[0]);
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719157-2c7f1300-0329-11eb-8f0c-0b674cc65c40.png)
