### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 3/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
@@ -15,9 +15,8 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return the integer result from dividing two numbers. 
  */
 export class Divide extends MultivariateNumericEvaluator {
-
     /**
-     * Initializes a new instance of the Divide class.
+     * Initializes a new instance of the `Divide` class.
      */
     public constructor() {
         super(ExpressionType.Divide, Divide.func, Divide.verify);

--- a/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
@@ -15,18 +15,28 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return the integer result from dividing two numbers. 
  */
 export class Divide extends MultivariateNumericEvaluator {
+
+    /**
+     * Initializes a new instance of the Divide class.
+     */
     public constructor() {
         super(ExpressionType.Divide, Divide.func, Divide.verify);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): number {
         return Math.floor(Number(args[0]) / Number(args[1]));
     }
 
+    /**
+     * @private
+     */
     private static verify(val: any, expression: Expression, pos: number): string {
         let error: string = FunctionUtils.verifyNumber(val, expression, pos);
         if (!error && (pos > 0 && Number(val) === 0)) {
-            error = `Cannot divide by 0 from ${expression}`;
+            error = `Cannot divide by 0 from ${ expression }`;
         }
 
         return error;

--- a/libraries/adaptive-expressions/src/builtinFunctions/element.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/element.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Support number index for list or string index for object.
  */
 export class Element extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Element class.
+     * Initializes a new instance of the `Element` class.
      */
     public constructor() {
         super(ExpressionType.Element, Element.evaluator, ReturnType.Object, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/element.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/element.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Support number index for list or string index for object.
  */
 export class Element extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Element class.
+     */
     public constructor() {
         super(ExpressionType.Element, Element.evaluator, ReturnType.Object, FunctionUtils.validateBinary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -42,7 +49,7 @@ export class Element extends ExpressionEvaluator {
                 } else if (typeof idxValue === 'string') {
                     ({ value, error } = InternalFunctionUtils.accessProperty(inst, idxValue.toString()));
                 } else {
-                    error = `Could not coerce ${index} to an int or string.`;
+                    error = `Could not coerce ${ index } to an int or string.`;
                 }
 
                 return { value, error };

--- a/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
@@ -18,14 +18,24 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * 4.Input is an object with no property.
  */
 export class Empty extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the Empty class.
+     */
     public constructor() {
         super(ExpressionType.Empty, Empty.func, FunctionUtils.validateUnary, FunctionUtils.verifyContainer);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return Empty.isEmpty(args[0]);
     }
 
+    /**
+     * @private
+     */
     private static isEmpty(instance: any): boolean {
         let result: boolean;
         if (instance === undefined) {

--- a/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
@@ -18,9 +18,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * 4.Input is an object with no property.
  */
 export class Empty extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the Empty class.
+     * Initializes a new instance of the `Empty` class.
      */
     public constructor() {
         super(ExpressionType.Empty, Empty.func, FunctionUtils.validateUnary, FunctionUtils.verifyContainer);

--- a/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
@@ -18,14 +18,24 @@ import { ReturnType } from '../returnType';
  * This function is case-insensitive.
  */
 export class EndsWith extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the EndsWith class.
+     */
     public constructor() {
         super(ExpressionType.EndsWith, EndsWith.evaluator(), ReturnType.Boolean, EndsWith.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): boolean => InternalFunctionUtils.parseStringOrUndefined(args[0]).endsWith(InternalFunctionUtils.parseStringOrUndefined(args[1])), FunctionUtils.verifyStringOrNull);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 2, 2, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * This function is case-insensitive.
  */
 export class EndsWith extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the EndsWith class.
+     * Initializes a new instance of the `EndsWith` class.
      */
     public constructor() {
         super(ExpressionType.EndsWith, EndsWith.evaluator(), ReturnType.Boolean, EndsWith.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
@@ -16,6 +16,10 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if both are equivalent, or return false if they're not equivalent.
  */
 export class Equal extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the Equal class.
+     */
     public constructor() {
         super(ExpressionType.Equal, InternalFunctionUtils.isEqual, FunctionUtils.validateBinary);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
@@ -16,9 +16,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if both are equivalent, or return false if they're not equivalent.
  */
 export class Equal extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the Equal class.
+     * Initializes a new instance of the `Equal` class.
      */
     public constructor() {
         super(ExpressionType.Equal, InternalFunctionUtils.isEqual, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
@@ -14,9 +14,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Evaluates an expression for truthiness.
  */
 export class Exists extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the Exists class.
+     * Initializes a new instance of the `Exists` class.
      */
     public constructor() {
         super(ExpressionType.Exists, Exists.func, FunctionUtils.validateUnary, FunctionUtils.verifyNotNull);

--- a/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
@@ -14,10 +14,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Evaluates an expression for truthiness.
  */
 export class Exists extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the Exists class.
+     */
     public constructor() {
         super(ExpressionType.Exists, Exists.func, FunctionUtils.validateUnary, FunctionUtils.verifyNotNull);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return args[0] !== undefined && args[0] !== null;
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/first.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/first.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the first item from a string or array.
  */
 export class First extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the First class.
+     * Initializes a new instance of the `First` class.
      */
     public constructor() {
         super(ExpressionType.First, First.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/first.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/first.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the first item from a string or array.
  */
 export class First extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the First class.
+     */
     public constructor() {
         super(ExpressionType.First, First.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  *  Flatten an array into non-array values. You can optionally set the maximum depth to flatten to.
  */
 export class Flatten extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Flatten class.
+     */
     public constructor() {
         super(ExpressionType.Flatten, Flatten.evaluator(), ReturnType.Array, Flatten.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): any[] => {
@@ -29,6 +36,9 @@ export class Flatten extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static evalFlatten(arr: any[], dept: number): any[] {
         if (!FunctionUtils.isNumber(dept) || dept < 1) {
             dept = 1;
@@ -49,6 +59,9 @@ export class Flatten extends ExpressionEvaluator {
         return res;
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.Number], ReturnType.Array);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  *  Flatten an array into non-array values. You can optionally set the maximum depth to flatten to.
  */
 export class Flatten extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Flatten class.
+     * Initializes a new instance of the `Flatten` class.
      */
     public constructor() {
         super(ExpressionType.Flatten, Flatten.evaluator(), ReturnType.Array, Flatten.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/float.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/float.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Convert the string version of a floating-point number to a floating-point number.
  */
 export class Float extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Float class.
+     * Initializes a new instance of the `Float` class.
      */
     public constructor() {
         super(ExpressionType.Float, Float.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/float.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/float.ts
@@ -15,17 +15,24 @@ import { ReturnType } from '../returnType';
  * Convert the string version of a floating-point number to a floating-point number.
  */
 export class Float extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Float class.
+     */
     public constructor() {
         super(ExpressionType.Float, Float.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
                 let error: string;
                 const value: number = parseFloat(args[0]);
                 if (!FunctionUtils.isNumber(value)) {
-                    error = `parameter ${args[0]} is not a valid number string.`;
+                    error = `parameter ${ args[0] } is not a valid number string.`;
                 }
 
                 return { value, error };

--- a/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
@@ -13,9 +13,8 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  * Returns the largest integer less than or equal to the specified number.
  */
 export class Floor extends NumberTransformEvaluator {
-
     /**
-     * Initializes a new instance of the Floor class.
+     * Initializes a new instance of the `Floor` class.
      */
     public constructor() {
         super(ExpressionType.Floor, Floor.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
@@ -13,10 +13,17 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  * Returns the largest integer less than or equal to the specified number.
  */
 export class Floor extends NumberTransformEvaluator {
+
+    /**
+     * Initializes a new instance of the Floor class.
+     */
     public constructor() {
         super(ExpressionType.Floor, Floor.func);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): number {
         return Math.floor(args[0]);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
@@ -15,6 +15,10 @@ import { ReturnType } from '../returnType';
  * Operate on each element and return the new collection.
  */
 export class Foreach extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Foreach class.
+     */
     public constructor() {
         super(ExpressionType.Foreach, InternalFunctionUtils.foreach, ReturnType.Array, InternalFunctionUtils.validateForeach);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Operate on each element and return the new collection.
  */
 export class Foreach extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Foreach class.
+     * Initializes a new instance of the `Foreach` class.
      */
     public constructor() {
         super(ExpressionType.Foreach, InternalFunctionUtils.foreach, ReturnType.Array, InternalFunctionUtils.validateForeach);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719548-b202c300-0329-11eb-8502-bea7e8cd09d5.png)
