### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 4/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Format reference: https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
  */
 export class FormatDateTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the FormatDateTime class.
+     */
     public constructor() {
         super(ExpressionType.FormatDateTime, FormatDateTime.evaluator(), ReturnType.String, FormatDateTime.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -44,6 +51,9 @@ export class FormatDateTime extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Format reference: https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
  */
 export class FormatDateTime extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the FormatDateTime class.
+     * Initializes a new instance of the `FormatDateTime` class.
      */
     public constructor() {
         super(ExpressionType.FormatDateTime, FormatDateTime.evaluator(), ReturnType.String, FormatDateTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
@@ -18,20 +18,27 @@ import { ReturnType } from '../returnType';
  * Return a timestamp in the specified format from UNIX time (also know as Epoch time, POSIX time, UNIX Epoch time).
  */
 export class FormatEpoch extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the FormatEpoch class.
+     */
     public constructor() {
         super(ExpressionType.FormatEpoch, FormatEpoch.evaluator(), ReturnType.String, FormatEpoch.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
                 let error: string;
                 let arg: any = args[0];
                 if (typeof arg !== 'number') {
-                    error = `formatEpoch first argument ${arg} must be a number`
+                    error = `formatEpoch first argument ${ arg } must be a number`;
                 } else {
                     // Convert to ms
-                    arg = arg * 1000
+                    arg = arg * 1000;
                 }
 
                 let value: any;
@@ -44,6 +51,9 @@ export class FormatEpoch extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Number);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * Return a timestamp in the specified format from UNIX time (also know as Epoch time, POSIX time, UNIX Epoch time).
  */
 export class FormatEpoch extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the FormatEpoch class.
+     * Initializes a new instance of the `FormatEpoch` class.
      */
     public constructor() {
         super(ExpressionType.FormatEpoch, FormatEpoch.evaluator(), ReturnType.String, FormatEpoch.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Format number into required decimal numbers.
  */
 export class FormatNumber extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the FormatNumber class.
+     * Initializes a new instance of the `FormatNumber` class.
      */
     public constructor() {
         super(ExpressionType.FormatNumber, FormatNumber.evaluator(), ReturnType.String, FormatNumber.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Format number into required decimal numbers.
  */
 export class FormatNumber extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the FormatNumber class.
+     */
     public constructor() {
         super(ExpressionType.FormatNumber, FormatNumber.evaluator(), ReturnType.String, FormatNumber.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -29,11 +36,11 @@ export class FormatNumber extends ExpressionEvaluator {
                 let precision = args[1];
                 let locale = args.length > 2 ? args[2] : 'en-us';
                 if (typeof number !== 'number') {
-                    error = `formatNumber first argument ${number} must be a number`;
+                    error = `formatNumber first argument ${ number } must be a number`;
                 } else if (typeof precision !== 'number') {
-                    error = `formatNumber second argument ${precision} must be a number`;
+                    error = `formatNumber second argument ${ precision } must be a number`;
                 } else if (locale && typeof locale !== 'string') {
-                    error = `formatNubmer third argument ${locale} is not a valid locale`;
+                    error = `formatNubmer third argument ${ locale } is not a valid locale`;
                 } else {
                     // NOTE: Nodes toLocaleString and Intl do not work to localize unless a special version of node is used.
                     // TODO: In R10 we should try another package.  Numeral and d3-format have the basics, but no locale specific.  
@@ -45,6 +52,9 @@ export class FormatNumber extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expr: Expression): void {
         FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.Number, ReturnType.Number);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Return a timestamp in the specified format from ticks.
  */
 export class FormatTicks extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the FormatTicks class.
+     */
     public constructor() {
         super(ExpressionType.FormatTicks, FormatTicks.evaluator(), ReturnType.String, FormatTicks.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
@@ -36,7 +43,7 @@ export class FormatTicks extends ExpressionEvaluator {
                     arg = bigInt(arg);
                 }
                 if (!bigInt.isInstance(arg)) {
-                    error = `formatTicks first argument ${arg} is not a number, numeric string or bigInt`;
+                    error = `formatTicks first argument ${ arg } is not a number, numeric string or bigInt`;
                 } else {
                     // Convert to ms
                     arg = ((arg.subtract(InternalFunctionUtils.UnixMilliSecondToTicksConstant)).divide(InternalFunctionUtils.MillisecondToTickConstant)).toJSNumber();
@@ -52,6 +59,9 @@ export class FormatTicks extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Number);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Return a timestamp in the specified format from ticks.
  */
 export class FormatTicks extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the FormatTicks class.
+     * Initializes a new instance of the `FormatTicks` class.
      */
     public constructor() {
         super(ExpressionType.FormatTicks, FormatTicks.evaluator(), ReturnType.String, FormatTicks.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
@@ -21,9 +21,8 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp plus the specified time units.
  */
 export class GetFutureTime extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetFutureTime class.
+     * Initializes a new instance of the `GetFutureTime` class.
      */
     public constructor() {
         super(ExpressionType.GetFutureTime, GetFutureTime.evaluator, ReturnType.String, GetFutureTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
@@ -21,10 +21,17 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp plus the specified time units.
  */
 export class GetFutureTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetFutureTime class.
+     */
     public constructor() {
         super(ExpressionType.GetFutureTime, GetFutureTime.evaluator, ReturnType.String, GetFutureTime.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: any;
@@ -35,7 +42,7 @@ export class GetFutureTime extends ExpressionEvaluator {
                 const format: string = (args.length === 3 ? FunctionUtils.timestampFormatter(args[2]) : FunctionUtils.DefaultDateTimeFormat);
                 const { duration, tsStr } = InternalFunctionUtils.timeUnitTransformer(args[0], args[1]);
                 if (tsStr === undefined) {
-                    error = `${args[2]} is not a valid time unit.`;
+                    error = `${ args[2] } is not a valid time unit.`;
                 } else {
                     const dur: any = duration;
                     ({ value, error } = InternalFunctionUtils.parseTimestamp(new Date().toISOString(), (dt: Date): string => {
@@ -43,7 +50,7 @@ export class GetFutureTime extends ExpressionEvaluator {
                     }));
                 }
             } else {
-                error = `${expression} should contain a time interval integer, a string unit of time and an optional output format string.`;
+                error = `${ expression } should contain a time interval integer, a string unit of time and an optional output format string.`;
             }
         }
 
@@ -51,6 +58,9 @@ export class GetFutureTime extends ExpressionEvaluator {
     }
 
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Number, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
@@ -23,9 +23,8 @@ import {TimexProperty} from '@microsoft/recognizers-text-data-types-timex-expres
  * Return the next viable date of a timex expression based on the current date and user's timezone.
  */
 export class GetNextViableDate extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetNextViableDate class.
+     * Initializes a new instance of the `GetNextViableDate` class.
      */
     public constructor(){
         super(ExpressionType.GetNextViableDate, GetNextViableDate.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
@@ -23,10 +23,17 @@ import {TimexProperty} from '@microsoft/recognizers-text-data-types-timex-expres
  * Return the next viable date of a timex expression based on the current date and user's timezone.
  */
 export class GetNextViableDate extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetNextViableDate class.
+     */
     public constructor(){
         super(ExpressionType.GetNextViableDate, GetNextViableDate.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): {value: any; error: string} {
         let parsed: TimexProperty;
         let value: string;
@@ -44,7 +51,7 @@ export class GetNextViableDate extends ExpressionEvaluator {
 
         if (parsed && !error) {
             if (parsed.year || !parsed.month || !parsed.dayOfMonth) {
-                error = `${args[0]} must be a timex string which only contains month and day-of-month, for example: 'XXXX-10-31'.`;
+                error = `${ args[0] } must be a timex string which only contains month and day-of-month, for example: 'XXXX-10-31'.`;
             }
         }
 
@@ -52,7 +59,7 @@ export class GetNextViableDate extends ExpressionEvaluator {
             if (args.length === 2 && typeof args[1] === 'string') {
                 const timeZone: string = TimeZoneConverter .windowsToIana(args[1]);
                 if (!TimeZoneConverter.verifyTimeZoneStr(timeZone)) {
-                    error = `${args[1]} is not a valid timezone`;
+                    error = `${ args[1] } is not a valid timezone`;
                 }
 
                 if (!error) {
@@ -88,6 +95,9 @@ export class GetNextViableDate extends ExpressionEvaluator {
         return {value, error};
     }
 
+    /**
+     * @private
+     */
     private static leapYear(year: number): boolean
     {
         return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
@@ -22,10 +22,17 @@ import {TimexProperty, Time} from '@microsoft/recognizers-text-data-types-timex-
  * Return the next viable time of a timex expression based on the current time and user's timezone.
  */
 export class GetNextViableTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetNextViableTime class.
+     */
     public constructor(){
         super(ExpressionType.GetNextViableTime, GetNextViableTime.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): {value: any; error: string} {
         let parsed: TimexProperty;
         let value: string;
@@ -40,7 +47,7 @@ export class GetNextViableTime extends ExpressionEvaluator {
         ({args, error} = FunctionUtils.evaluateChildren(expr, state, options));
         if(!error)  {
             if (!formatRegex.test(args[0] as string)) {
-                error = `${args[0]}  must be a timex string which only contains minutes and seconds, for example: 'TXX:15:28'`;
+                error = `${ args[0] }  must be a timex string which only contains minutes and seconds, for example: 'TXX:15:28'`;
             }
         }
 
@@ -48,7 +55,7 @@ export class GetNextViableTime extends ExpressionEvaluator {
             if (args.length === 2 && typeof args[1] === 'string') {
                 const timeZone: string = TimeZoneConverter .windowsToIana(args[1]);
                 if (!TimeZoneConverter.verifyTimeZoneStr(timeZone)) {
-                    error = `${args[1]} is not a valid timezone`;
+                    error = `${ args[1] } is not a valid timezone`;
                 }
 
                 if (!error) {

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
@@ -22,9 +22,8 @@ import {TimexProperty, Time} from '@microsoft/recognizers-text-data-types-timex-
  * Return the next viable time of a timex expression based on the current time and user's timezone.
  */
 export class GetNextViableTime extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetNextViableTime class.
+     * Initializes a new instance of the `GetNextViableTime` class.
      */
     public constructor(){
         super(ExpressionType.GetNextViableTime, GetNextViableTime.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
@@ -21,10 +21,17 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp minus the specified time units.
  */
 export class GetPastTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetPastTime class.
+     */
     public constructor() {
         super(ExpressionType.GetPastTime, GetPastTime.evaluator, ReturnType.String, GetPastTime.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: any;
@@ -35,7 +42,7 @@ export class GetPastTime extends ExpressionEvaluator {
                 const format: string = (args.length === 3 ? FunctionUtils.timestampFormatter(args[2]) : FunctionUtils.DefaultDateTimeFormat);
                 const { duration, tsStr } = InternalFunctionUtils.timeUnitTransformer(args[0], args[1]);
                 if (tsStr === undefined) {
-                    error = `${args[2]} is not a valid time unit.`;
+                    error = `${ args[2] } is not a valid time unit.`;
                 } else {
                     const dur: any = duration;
                     ({ value, error } = InternalFunctionUtils.parseTimestamp(new Date().toISOString(), (dt: Date): string => {
@@ -43,14 +50,16 @@ export class GetPastTime extends ExpressionEvaluator {
                     }));
                 }
             } else {
-                error = `${expression} should contain a time interval integer, a string unit of time and an optional output format string.`;
+                error = `${ expression } should contain a time interval integer, a string unit of time and an optional output format string.`;
             }
         }
 
         return { value, error };
     }
 
-
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Number, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
@@ -21,9 +21,8 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp minus the specified time units.
  */
 export class GetPastTime extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetPastTime class.
+     * Initializes a new instance of the `GetPastTime` class.
      */
     public constructor() {
         super(ExpressionType.GetPastTime, GetPastTime.evaluator, ReturnType.String, GetPastTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
@@ -23,10 +23,17 @@ import {TimexProperty} from '@microsoft/recognizers-text-data-types-timex-expres
  * Return the previous viable date of a timex expression based on the current date and user's timezone.
  */
 export class GetPreviousViableDate extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetPreviousViableDate class.
+     */
     public constructor(){
         super(ExpressionType.GetPreviousViableDate, GetPreviousViableDate.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): {value: any; error: string} {
         let parsed: TimexProperty;
         let value: string;
@@ -44,7 +51,7 @@ export class GetPreviousViableDate extends ExpressionEvaluator {
 
         if (parsed && !error) {
             if (parsed.year || !parsed.month || !parsed.dayOfMonth) {
-                error = `${args[0]} must be a timex string which only contains month and day-of-month, for example: 'XXXX-10-31'.`;
+                error = `${ args[0] } must be a timex string which only contains month and day-of-month, for example: 'XXXX-10-31'.`;
             }
         }
 
@@ -52,7 +59,7 @@ export class GetPreviousViableDate extends ExpressionEvaluator {
             if (args.length === 2 && typeof args[1] === 'string') {
                 const timeZone: string = TimeZoneConverter .windowsToIana(args[1]);
                 if (!TimeZoneConverter.verifyTimeZoneStr(timeZone)) {
-                    error = `${args[1]} is not a valid timezone`;
+                    error = `${ args[1] } is not a valid timezone`;
                 }
 
                 if (!error) {
@@ -88,6 +95,9 @@ export class GetPreviousViableDate extends ExpressionEvaluator {
         return {value, error};
     }
 
+    /**
+     * @private
+     */
     private static leapYear(year: number): boolean
     {
         return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
@@ -23,9 +23,8 @@ import {TimexProperty} from '@microsoft/recognizers-text-data-types-timex-expres
  * Return the previous viable date of a timex expression based on the current date and user's timezone.
  */
 export class GetPreviousViableDate extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetPreviousViableDate class.
+     * Initializes a new instance of the `GetPreviousViableDate` class.
      */
     public constructor(){
         super(ExpressionType.GetPreviousViableDate, GetPreviousViableDate.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
@@ -22,9 +22,8 @@ import {TimexProperty, Time} from '@microsoft/recognizers-text-data-types-timex-
  * Return the previous viable time of a timex expression based on the current time and user's timezone.
  */
 export class GetPreviousViableTime extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetPreviousViableTime class.
+     * Initializes a new instance of the `GetPreviousViableTime` class.
      */
     public constructor(){
         super(ExpressionType.GetPreviousViableTime, GetPreviousViableTime.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
@@ -22,10 +22,17 @@ import {TimexProperty, Time} from '@microsoft/recognizers-text-data-types-timex-
  * Return the previous viable time of a timex expression based on the current time and user's timezone.
  */
 export class GetPreviousViableTime extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetPreviousViableTime class.
+     */
     public constructor(){
         super(ExpressionType.GetPreviousViableTime, GetPreviousViableTime.evaluator, ReturnType.String, FunctionUtils.validateUnaryOrBinaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): {value: any; error: string} {
         let parsed: TimexProperty;
         let value: string;
@@ -40,7 +47,7 @@ export class GetPreviousViableTime extends ExpressionEvaluator {
         ({args, error} = FunctionUtils.evaluateChildren(expr, state, options));
         if(!error)  {
             if (!formatRegex.test(args[0] as string)) {
-                error = `${args[0]}  must be a timex string which only contains minutes and seconds, for example: 'TXX:15:28'`;
+                error = `${ args[0] }  must be a timex string which only contains minutes and seconds, for example: 'TXX:15:28'`;
             }
         }
 
@@ -48,7 +55,7 @@ export class GetPreviousViableTime extends ExpressionEvaluator {
             if (args.length === 2 && typeof args[1] === 'string') {
                 const timeZone: string = TimeZoneConverter .windowsToIana(args[1]);
                 if (!TimeZoneConverter.verifyTimeZoneStr(timeZone)) {
-                    error = `${args[1]} is not a valid timezone`;
+                    error = `${ args[1] } is not a valid timezone`;
                 }
 
                 if (!error) {

--- a/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Retrieve the value of the specified property from the JSON object.
  */
 export class GetProperty extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetProperty class.
+     * Initializes a new instance of the `GetProperty` class.
      */
     public constructor() {
         super(ExpressionType.GetProperty, GetProperty.evaluator, ReturnType.Object, GetProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Retrieve the value of the specified property from the JSON object.
  */
 export class GetProperty extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetProperty class.
+     */
     public constructor() {
         super(ExpressionType.GetProperty, GetProperty.evaluator, ReturnType.Object, GetProperty.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -38,7 +45,7 @@ export class GetProperty extends ExpressionEvaluator {
                 if (typeof firstItem === 'string') {
                     value = InternalFunctionUtils.wrapGetValue(state, firstItem, options);
                 } else {
-                    error = `"Single parameter ${children[0]} is not a string."`;
+                    error = `"Single parameter ${ children[0] } is not a string."`;
                 }
             } else {
                 // get the peoperty value from the instance
@@ -53,6 +60,9 @@ export class GetProperty extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Object);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * Returns time of day for a given timestamp.
  */
 export class GetTimeOfDay extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GetTimeOfDay class.
+     * Initializes a new instance of the `GetTimeOfDay` class.
      */
     public constructor() {
         super(ExpressionType.GetTimeOfDay, GetTimeOfDay.evaluator(), ReturnType.String, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
@@ -18,10 +18,17 @@ import { ReturnType } from '../returnType';
  * Returns time of day for a given timestamp.
  */
 export class GetTimeOfDay extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GetTimeOfDay class.
+     */
     public constructor() {
         super(ExpressionType.GetTimeOfDay, GetTimeOfDay.evaluator(), ReturnType.String, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is more, or return false if less.
  */
 export class GreaterThan extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the GreaterThan class.
+     */
     public constructor() {
         super(ExpressionType.GreaterThan, GreaterThan.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return args[0] > args[1];
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
@@ -15,9 +15,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is more, or return false if less.
  */
 export class GreaterThan extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the GreaterThan class.
+     * Initializes a new instance of the `GreaterThan` class.
      */
     public constructor() {
         super(ExpressionType.GreaterThan, GreaterThan.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
@@ -15,9 +15,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * or return false if the first value is less.
  */
 export class GreaterThanOrEqual extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the GreaterThanOrEqual class.
+     * Initializes a new instance of the `GreaterThanOrEqual` class.
      */
     public constructor() {
         super(ExpressionType.GreaterThanOrEqual, GreaterThanOrEqual.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * or return false if the first value is less.
  */
 export class GreaterThanOrEqual extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the GreaterThanOrEqual class.
+     */
     public constructor() {
         super(ExpressionType.GreaterThanOrEqual, GreaterThanOrEqual.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return args[0] >= args[1];
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/if.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/if.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class If extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GreaterThan` class.
+     * Initializes a new instance of the `If` class.
      */
     public constructor() {
         super(ExpressionType.If, If.evaluator, ReturnType.Object, If.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/if.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/if.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Check whether an expression is true or false. Based on the result, return a specified value.
  */
 export class If extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GreaterThan class.
+     */
     public constructor() {
         super(ExpressionType.If, If.evaluator, ReturnType.Object, If.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let result: any;
         let error: string;
@@ -38,6 +45,9 @@ export class If extends ExpressionEvaluator {
         return { value: result, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expr: Expression): void {
         FunctionUtils.validateArityAndAnyType(expr, 3, 3);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/if.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/if.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Check whether an expression is true or false. Based on the result, return a specified value.
  */
 export class If extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GreaterThan class.
+     * Initializes a new instance of the `GreaterThan` class.
      */
     public constructor() {
         super(ExpressionType.If, If.evaluator, ReturnType.Object, If.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * 
  */
 export class Ignore extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the GreaterThan class.
+     */
     public constructor() {
         super(ExpressionType.Ignore, Ignore.evaluator, ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         return expression.children[0].tryEvaluate(state, options);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Ignore extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GreaterThan` class.
+     * Initializes a new instance of the `Ignore` class.
      */
     public constructor() {
         super(ExpressionType.Ignore, Ignore.evaluator, ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * 
  */
 export class Ignore extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the GreaterThan class.
+     * Initializes a new instance of the `GreaterThan` class.
      */
     public constructor() {
         super(ExpressionType.Ignore, Ignore.evaluator, ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing and semicolon warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719612-c777ed00-0329-11eb-8936-ee5df8e7ad6a.png)
