### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 6/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
@@ -18,14 +18,24 @@ import { ReturnType } from '../returnType';
  * Check JSON or a JSON string for nodes or values that match a path expression, and return the matching nodes.
  */
 export class JPath extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the JPath class.
+     */
     public constructor() {
         super(ExpressionType.JPath, JPath.evaluator(), ReturnType.Object, JPath.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((args: any[][]): any => JPath.evalJPath(args[0], args[1].toString()));
     }
 
+    /**
+     * @private
+     */
     private static evalJPath(jsonEntity: object | string, path: string): ValueWithError {
         let result: any;
         let error: string;
@@ -35,7 +45,7 @@ export class JPath extends ExpressionEvaluator {
             try {
                 json = JSON.parse(jsonEntity);
             } catch (e) {
-                error = `${jsonEntity} is not a valid json string`;
+                error = `${ jsonEntity } is not a valid json string`;
             }
         } else if (typeof jsonEntity === 'object') {
             json = jsonEntity;
@@ -47,7 +57,7 @@ export class JPath extends ExpressionEvaluator {
             try {
                 evaled = jsPath.apply(path, json);
             } catch (e) {
-                error = `${path} is not a valid path + ${e}`;
+                error = `${ path } is not a valid path + ${ e }`;
             }
         }
 
@@ -56,6 +66,9 @@ export class JPath extends ExpressionEvaluator {
         return { value: result, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expr: Expression): void {
         FunctionUtils.validateOrder(expr, undefined, ReturnType.Object, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * Check JSON or a JSON string for nodes or values that match a path expression, and return the matching nodes.
  */
 export class JPath extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the JPath class.
+     * Initializes a new instance of the `JPath` class.
      */
     public constructor() {
         super(ExpressionType.JPath, JPath.evaluator(), ReturnType.Object, JPath.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/join.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/join.ts
@@ -18,10 +18,17 @@ import { ReturnType } from '../returnType';
  * Return a string that has all the items from an array, with each character separated by a delimiter.
  */
 export class Join extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Join class.
+     */
     public constructor() {
         super(ExpressionType.Join, Join.evaluator, ReturnType.String, Join.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -29,7 +36,7 @@ export class Join extends ExpressionEvaluator {
         ({ args, error } = FunctionUtils.evaluateChildren(expression, state, options));
         if (!error) {
             if (!Array.isArray(args[0])) {
-                error = `${expression.children[0]} evaluates to ${args[0]} which is not a list.`;
+                error = `${ expression.children[0] } evaluates to ${ args[0] } which is not a list.`;
             } else {
                 if (args.length === 2) {
                     value = args[0].join(args[1]);
@@ -47,6 +54,9 @@ export class Join extends ExpressionEvaluator {
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String], ReturnType.Array, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/json.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/json.ts
@@ -16,14 +16,24 @@ import { ReturnType } from '../returnType';
  * Return the JavaScript Object Notation (JSON) type value or object of a string or XML.
  */
 export class Json extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Json class.
+     */
     public constructor() {
         super(ExpressionType.Json, Json.evaluator(), ReturnType.Object, Json.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): any => JSON.parse(args[0].trim()));
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, undefined, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/json.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/json.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the JavaScript Object Notation (JSON) type value or object of a string or XML.
  */
 export class Json extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Json class.
+     * Initializes a new instance of the `Json` class.
      */
     public constructor() {
         super(ExpressionType.Json, Json.evaluator(), ReturnType.Object, Json.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the string version of a value.
  */
 export class JsonStringify extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the JsonStringify class.
+     */
     public constructor() {
         super(ExpressionType.JsonStringify, JsonStringify.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): string => {
             return JSON.stringify(args[0]);

--- a/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return the string version of a value.
  */
 export class JsonStringify extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the JsonStringify class.
+     * Initializes a new instance of the `JsonStringify` class.
      */
     public constructor() {
         super(ExpressionType.JsonStringify, JsonStringify.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/last.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/last.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the last item from a collection.
  */
 export class Last extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Last class.
+     * Initializes a new instance of the `Last` class.
      */
     public constructor() {
         super(ExpressionType.Last, Last.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/last.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/last.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the last item from a collection.
  */
 export class Last extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Last class.
+     */
     public constructor() {
         super(ExpressionType.Last, Last.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * The zero-based index position of value if that value is found, or -1 if it is not.
  */
 export class LastIndexOf extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the LastIndexOf class.
+     */
     public constructor() {
         super(ExpressionType.LastIndexOf, LastIndexOf.evaluator, ReturnType.Number, LastIndexOf.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value = -1;
         let error: string;
@@ -36,18 +43,21 @@ export class LastIndexOf extends ExpressionEvaluator {
                     const searchValue = InternalFunctionUtils.parseStringOrUndefined(args[1]);
                     value = str.lastIndexOf(searchValue, str.length - 1);
                 } else {
-                    error = `Can only look for indexof string in ${expression}`;
+                    error = `Can only look for indexof string in ${ expression }`;
                 }
             } else if (Array.isArray(args[0])) {
                 value = args[0].lastIndexOf(args[1]);
             } else {
-                error = `${expression} works only on string or list.`;
+                error = `${ expression } works only on string or list.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [], ReturnType.String | ReturnType.Array, ReturnType.Object);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * The zero-based index position of value if that value is found, or -1 if it is not.
  */
 export class LastIndexOf extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the LastIndexOf class.
+     * Initializes a new instance of the `LastIndexOf` class.
      */
     public constructor() {
         super(ExpressionType.LastIndexOf, LastIndexOf.evaluator, ReturnType.Number, LastIndexOf.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/length.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/length.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the length of a string.
  */
 export class Length extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Length class.
+     * Initializes a new instance of the `Length` class.
      */
     public constructor() {
         super(ExpressionType.Length, Length.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/length.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/length.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the length of a string.
  */
 export class Length extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Length class.
+     */
     public constructor() {
         super(ExpressionType.Length, Length.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): number => (InternalFunctionUtils.parseStringOrUndefined(args[0])).length, FunctionUtils.verifyStringOrNull);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is less, or return false if the first value is more.
  */
 export class LessThan extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the LessThan class.
+     */
     public constructor() {
         super(ExpressionType.LessThan, LessThan.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return args[0] < args[1];
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
@@ -15,9 +15,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is less, or return false if the first value is more.
  */
 export class LessThan extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the LessThan class.
+     * Initializes a new instance of the `LessThan` class.
      */
     public constructor() {
         super(ExpressionType.LessThan, LessThan.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is less than or equal, or return false if the first value is more.
  */
 export class LessThanOrEqual extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the LessThanOrEqual class.
+     */
     public constructor() {
         super(ExpressionType.LessThanOrEqual, LessThanOrEqual.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return args[0] <= args[1];
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
@@ -15,9 +15,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the first value is less than or equal, or return false if the first value is more.
  */
 export class LessThanOrEqual extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the LessThanOrEqual class.
+     * Initializes a new instance of the `LessThanOrEqual` class.
      */
     public constructor() {
         super(ExpressionType.LessThanOrEqual, LessThanOrEqual.func, FunctionUtils.validateBinaryNumberOrString, FunctionUtils.verifyNumberOrString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/max.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/max.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  *  Return the highest value from an array. The array is inclusive at both ends.
  */
 export class Max extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Max class.
+     */
     public constructor() {
         super(ExpressionType.Max, Max.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): number => {
             let result = Number.NEGATIVE_INFINITY;

--- a/libraries/adaptive-expressions/src/builtinFunctions/max.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/max.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  *  Return the highest value from an array. The array is inclusive at both ends.
  */
 export class Max extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Max class.
+     * Initializes a new instance of the `Max` class.
      */
     public constructor() {
         super(ExpressionType.Max, Max.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Merge two JSON objects into one JSON object.
  */
 export class Merge extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Merge class.
+     * Initializes a new instance of the `Merge` class.
      */
     public constructor() {
         super(ExpressionType.Merge, Merge.evaluator(), ReturnType.Object, Merge.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Merge two JSON objects into one JSON object.
  */
 export class Merge extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Merge class.
+     */
     public constructor() {
         super(ExpressionType.Merge, Merge.evaluator(), ReturnType.Object, Merge.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applySequenceWithError(
             (args: any[]): any => {
@@ -29,13 +36,16 @@ export class Merge extends ExpressionEvaluator {
                     Object.assign(args[0], args[1]);
                     value = args[0];
                 } else {
-                    error = `The argumets ${args[0]} and ${args[1]} must be JSON objects.`;
+                    error = `The argumets ${ args[0] } and ${ args[1] } must be JSON objects.`;
                 }
 
                 return { value, error };
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 2, Number.MAX_SAFE_INTEGER);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/min.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/min.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the lowest value from a set of numbers in an array.
  */
 export class Min extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Min class.
+     */
     public constructor() {
         super(ExpressionType.Min, Min.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): number => {
             let result = Number.POSITIVE_INFINITY;

--- a/libraries/adaptive-expressions/src/builtinFunctions/min.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/min.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return the lowest value from a set of numbers in an array.
  */
 export class Min extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Min class.
+     * Initializes a new instance of the `Min` class.
      */
     public constructor() {
         super(ExpressionType.Min, Min.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the remainder from dividing two numbers. 
  */
 export class Mod extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Mod class.
+     */
     public constructor() {
         super(ExpressionType.Mod, Mod.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return the remainder from dividing two numbers. 
  */
 export class Mod extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Mod class.
+     * Initializes a new instance of the `Mod` class.
      */
     public constructor() {
         super(ExpressionType.Mod, Mod.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/month.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/month.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the month of the specified timestamp.
  */
 export class Month extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Month class.
+     * Initializes a new instance of the `Month` class.
      */
     public constructor() {
         super(ExpressionType.Month, Month.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/month.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/month.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the month of the specified timestamp.
  */
 export class Month extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Month class.
+     */
     public constructor() {
         super(ExpressionType.Month, Month.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): number => timestamp.getUTCMonth() + 1),

--- a/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
@@ -13,9 +13,8 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return the product from multiplying any number of numbers.
  */
 export class Multiply extends MultivariateNumericEvaluator {
-
     /**
-     * Initializes a new instance of the Multiply class.
+     * Initializes a new instance of the `Multiply` class.
      */
     public constructor() {
         super(ExpressionType.Multiply, Multiply.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
@@ -13,10 +13,17 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return the product from multiplying any number of numbers.
  */
 export class Multiply extends MultivariateNumericEvaluator {
+
+    /**
+     * Initializes a new instance of the Multiply class.
+     */
     public constructor() {
         super(ExpressionType.Multiply, Multiply.func);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): number {
         return Number(args[0]) * Number(args[1]);
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719715-e4142500-0329-11eb-9443-d8c0377ff92d.png)
