### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 7/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
@@ -14,9 +14,8 @@ import { ReturnType } from '../returnType';
  * Numeric operators that can have 2 or more args.
  */
 export class MultivariateNumericEvaluator extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the MultivariateNumericEvaluator class.
+     * Initializes a new instance of the `MultivariateNumericEvaluator` class.
      */
     public constructor(type: string, func: (args: any[]) => number, verify?: VerifyExpression) {
         super(type, MultivariateNumericEvaluator.evaluator(func, verify), ReturnType.Number, FunctionUtils.validateTwoOrMoreThanTwoNumbers);

--- a/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
@@ -14,10 +14,17 @@ import { ReturnType } from '../returnType';
  * Numeric operators that can have 2 or more args.
  */
 export class MultivariateNumericEvaluator extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the MultivariateNumericEvaluator class.
+     */
     public constructor(type: string, func: (args: any[]) => number, verify?: VerifyExpression) {
         super(type, MultivariateNumericEvaluator.evaluator(func, verify), ReturnType.Number, FunctionUtils.validateTwoOrMoreThanTwoNumbers);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(func: (args: any[]) => number, verify?: VerifyExpression): EvaluateExpressionDelegate {
         return FunctionUtils.applySequence(func, verify || FunctionUtils.verifyNumber);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return a new Guid string.
  */
 export class NewGuid extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the NewGuid class.
+     * Initializes a new instance of the `NewGuid` class.
      */
     public constructor() {
         super(ExpressionType.NewGuid, NewGuid.evaluator(), ReturnType.String, NewGuid.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
@@ -16,14 +16,24 @@ import { ReturnType } from '../returnType';
  * Return a new Guid string.
  */
 export class NewGuid extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the NewGuid class.
+     */
     public constructor() {
         super(ExpressionType.NewGuid, NewGuid.evaluator(), ReturnType.String, NewGuid.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((): string => NewGuid.evalNewGuid());
     }
 
+    /**
+     * @private
+     */
     private static evalNewGuid(): string {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c: any): string => {
             const r: number = Math.random() * 16 | 0;
@@ -33,6 +43,9 @@ export class NewGuid extends ExpressionEvaluator {
         });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 0, 0);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/not.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/not.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Return true if the expression is false, or return false if true.
  */
 export class Not extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Not class.
+     */
     public constructor() {
         super(ExpressionType.Not, Not.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let result = false;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/not.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/not.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Return true if the expression is false, or return false if true.
  */
 export class Not extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Not class.
+     * Initializes a new instance of the `Not` class.
      */
     public constructor() {
         super(ExpressionType.Not, Not.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
@@ -15,9 +15,8 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the two items are not equal.
  */
 export class NotEqual extends ComparisonEvaluator {
-
     /**
-     * Initializes a new instance of the NotEqual class.
+     * Initializes a new instance of the `NotEqual` class.
      */
     public constructor() {
         super(ExpressionType.NotEqual, NotEqual.func, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
@@ -15,10 +15,17 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  * Return true if the two items are not equal.
  */
 export class NotEqual extends ComparisonEvaluator {
+
+    /**
+     * Initializes a new instance of the NotEqual class.
+     */
     public constructor() {
         super(ExpressionType.NotEqual, NotEqual.func, FunctionUtils.validateBinary);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): boolean {
         return !InternalFunctionUtils.isEqual(args);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
@@ -14,10 +14,17 @@ import { ReturnType } from '../returnType';
  * Evaluator that transforms a number to another number.
  */
 export class NumberTransformEvaluator extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the NumberTransformEvaluator class.
+     */
     public constructor(type: string, func: (args: any[]) => number) {
         super(type, NumberTransformEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateUnaryNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(func: (args: any[]) => number): EvaluateExpressionDelegate {
         return FunctionUtils.apply(func, FunctionUtils.verifyNumber);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
@@ -14,9 +14,8 @@ import { ReturnType } from '../returnType';
  * Evaluator that transforms a number to another number.
  */
 export class NumberTransformEvaluator extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the NumberTransformEvaluator class.
+     * Initializes a new instance of the `NumberTransformEvaluator` class.
      */
     public constructor(type: string, func: (args: any[]) => number) {
         super(type, NumberTransformEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateUnaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
@@ -14,10 +14,17 @@ import { ReturnType } from '../returnType';
  * Numeric operators that can have 1 or more args.
  */
 export class NumericEvaluator extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the NumericEvaluator class.
+     */
     public constructor(type: string, func: (args: any[]) => any) {
         super(type, NumericEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(func: (args: any[]) => any): EvaluateExpressionDelegate {
         return FunctionUtils.applySequence(func, FunctionUtils.verifyNumber);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
@@ -14,9 +14,8 @@ import { ReturnType } from '../returnType';
  * Numeric operators that can have 1 or more args.
  */
 export class NumericEvaluator extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the NumericEvaluator class.
+     * Initializes a new instance of the `NumericEvaluator` class.
      */
     public constructor(type: string, func: (args: any[]) => any) {
         super(type, NumericEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * For the MostSpecificSelector, this is a short hand so that instead of having to do A &amp; B || A you can do A &amp; optional(B) to mean the same thing.
  */
 export class Optional extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Optional class.
+     * Initializes a new instance of the `Optional` class.
      */
     public constructor() {
         super(ExpressionType.Optional, Optional.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);

--- a/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * For the MostSpecificSelector, this is a short hand so that instead of having to do A &amp; B || A you can do A &amp; optional(B) to mean the same thing.
  */
 export class Optional extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Optional class.
+     */
     public constructor() {
         super(ExpressionType.Optional, Optional.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return undefined;
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/or.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/or.ts
@@ -20,9 +20,8 @@ import { ReturnType } from '../returnType';
  * Return true if at least one expression is true, or return false if all are false.
  */
 export class Or extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Or class.
+     * Initializes a new instance of the `Or` class.
      */
     public constructor() {
         super(ExpressionType.Or, Or.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/or.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/or.ts
@@ -20,10 +20,17 @@ import { ReturnType } from '../returnType';
  * Return true if at least one expression is true, or return false if all are false.
  */
 export class Or extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Or class.
+     */
     public constructor() {
         super(ExpressionType.Or, Or.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let result = false;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/power.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/power.ts
@@ -14,9 +14,8 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return exponentiation of one number to another.
  */
 export class Power extends MultivariateNumericEvaluator {
-
     /**
-     * Initializes a new instance of the Power class.
+     * Initializes a new instance of the `Power` class.
      */
     public constructor() {
         super(ExpressionType.Power, Power.func, FunctionUtils.verifyNumberOrNumericList);

--- a/libraries/adaptive-expressions/src/builtinFunctions/power.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/power.ts
@@ -14,10 +14,17 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  * Return exponentiation of one number to another.
  */
 export class Power extends MultivariateNumericEvaluator {
+
+    /**
+     * Initializes a new instance of the Power class.
+     */
     public constructor() {
         super(ExpressionType.Power, Power.func, FunctionUtils.verifyNumberOrNumericList);
     }
 
+    /**
+     * @private
+     */
     private static func(args: any[]): number {
         return Math.pow(args[0], args[1]);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
@@ -15,16 +15,23 @@ import { ReturnType } from '../returnType';
  * Return a random integer from a specified range, which is inclusive only at the starting end.
  */
 export class Rand extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Rand class.
+     */
     public constructor() {
         super(ExpressionType.Rand, Rand.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
                 let error: string;
                 if (args[0] > args[1]) {
-                    error = `Min value ${args[0]} cannot be greater than max value ${args[1]}.`;
+                    error = `Min value ${ args[0] } cannot be greater than max value ${ args[1] }.`;
                 }
 
                 const value: any = Math.floor(Math.random() * (Number(args[1]) - Number(args[0])) + Number(args[0]));

--- a/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return a random integer from a specified range, which is inclusive only at the starting end.
  */
 export class Rand extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Rand class.
+     * Initializes a new instance of the `Rand` class.
      */
     public constructor() {
         super(ExpressionType.Rand, Rand.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/range.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/range.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return an integer array that starts from a specified integer with the given length.
  */
 export class Range extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Range class.
+     */
     public constructor() {
         super(ExpressionType.Range, Range.evaluator(), ReturnType.Array, FunctionUtils.validateBinaryNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {

--- a/libraries/adaptive-expressions/src/builtinFunctions/range.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/range.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return an integer array that starts from a specified integer with the given length.
  */
 export class Range extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Range class.
+     * Initializes a new instance of the `Range` class.
      */
     public constructor() {
         super(ExpressionType.Range, Range.evaluator(), ReturnType.Array, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Remove a property from an object and return the updated object.
  */
 export class RemoveProperty extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the RemoveProperty class.
+     * Initializes a new instance of the `RemoveProperty` class.
      */
     public constructor() {
         super(ExpressionType.RemoveProperty, RemoveProperty.evaluator(), ReturnType.Object, RemoveProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Remove a property from an object and return the updated object.
  */
 export class RemoveProperty extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the RemoveProperty class.
+     */
     public constructor() {
         super(ExpressionType.RemoveProperty, RemoveProperty.evaluator(), ReturnType.Object, RemoveProperty.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): any => {
@@ -30,6 +37,9 @@ export class RemoveProperty extends ExpressionEvaluator {
             });
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, undefined, ReturnType.Object, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * This function is case-sensitive.
  */
 export class Replace extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Replace class.
+     * Initializes a new instance of the `Replace` class.
      */
     public constructor() {
         super(ExpressionType.Replace, Replace.evaluator(), ReturnType.String, Replace.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
@@ -18,17 +18,24 @@ import { ReturnType } from '../returnType';
  * This function is case-sensitive.
  */
 export class Replace extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Replace class.
+     */
     public constructor() {
         super(ExpressionType.Replace, Replace.evaluator(), ReturnType.String, Replace.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((
             args: any[]): any => {
             let error = undefined;
             let result = undefined;
             if (InternalFunctionUtils.parseStringOrUndefined(args[1]).length === 0) {
-                error = `${args[1]} should be a string with length at least 1`;
+                error = `${ args[1] } should be a string with length at least 1`;
             }
 
             if (!error) {
@@ -39,6 +46,9 @@ export class Replace extends ExpressionEvaluator {
         }, FunctionUtils.verifyStringOrNull);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 3, 3, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
@@ -18,17 +18,24 @@ import { ReturnType } from '../returnType';
  * This function is case-insensitive.
  */
 export class ReplaceIgnoreCase extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the ReplaceIgnoreCase class.
+     */
     public constructor() {
         super(ExpressionType.ReplaceIgnoreCase, ReplaceIgnoreCase.evaluator(), ReturnType.String, ReplaceIgnoreCase.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((
             args: any[]): any => {
             let error = undefined;
             let result = undefined;
             if (InternalFunctionUtils.parseStringOrUndefined(args[1]).length === 0) {
-                error = `${args[1]} should be a string with length at least 1`;
+                error = `${ args[1] } should be a string with length at least 1`;
             }
 
             if (!error) {
@@ -39,6 +46,9 @@ export class ReplaceIgnoreCase extends ExpressionEvaluator {
         }, FunctionUtils.verifyStringOrNull);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateArityAndAnyType(expression, 3, 3, ReturnType.String);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * This function is case-insensitive.
  */
 export class ReplaceIgnoreCase extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the ReplaceIgnoreCase class.
+     * Initializes a new instance of the `ReplaceIgnoreCase` class.
      */
     public constructor() {
         super(ExpressionType.ReplaceIgnoreCase, ReplaceIgnoreCase.evaluator(), ReturnType.String, ReplaceIgnoreCase.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/round.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/round.ts
@@ -15,23 +15,30 @@ import { ReturnType } from '../returnType';
  * Rounds a number value to the nearest integer.
  */
 export class Round extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Round class.
+     */
     public constructor() {
         super(ExpressionType.Round, Round.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryOrBinaryNumber);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => {
                 let result: any;
                 let error: string;
                 if (args.length === 2 && !Number.isInteger(args[1])) {
-                    error = `The second parameter ${args[1]} must be an integer.`;
+                    error = `The second parameter ${ args[1] } must be an integer.`;
                 }
 
                 if (!error) {
                     const digits = args.length === 2 ? args[1] as number : 0;
                     if (digits < 0 || digits > 15) {
-                        error = `The second parameter ${args[1]} must be an integer between 0 and 15;`;
+                        error = `The second parameter ${ args[1] } must be an integer between 0 and 15;`;
                     } else {
                         result = Round.roundToPrecision(args[0], digits);
                     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/round.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/round.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Rounds a number value to the nearest integer.
  */
 export class Round extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Round class.
+     * Initializes a new instance of the `Round` class.
      */
     public constructor() {
         super(ExpressionType.Round, Round.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryOrBinaryNumber);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719813-073ed480-032a-11eb-8633-37bcf4152c65.png)
