### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/builtinFuntions files 10/10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
@@ -16,14 +16,24 @@ import { ReturnType } from '../returnType';
  * Remove all duplicates from an array.
  */
 export class Unique extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Unique class.
+     */
     public constructor() {
         super(ExpressionType.Unique, Unique.evaluator(), ReturnType.Array, Unique.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): any[] => [... new Set(args[0])]);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [], ReturnType.Array);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Remove all duplicates from an array.
  */
 export class Unique extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Unique class.
+     * Initializes a new instance of the `Unique` class.
      */
     public constructor() {
         super(ExpressionType.Unique, Unique.evaluator(), ReturnType.Array, Unique.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the binary version of a uniform resource identifier (URI) component.
  */
 export class UriComponent extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriComponent class.
+     */
     public constructor() {
         super(ExpressionType.UriComponent, UriComponent.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: Readonly<any>): string => encodeURIComponent(args[0]), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return the binary version of a uniform resource identifier (URI) component.
  */
 export class UriComponent extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriComponent class.
+     * Initializes a new instance of the `UriComponent` class.
      */
     public constructor() {
         super(ExpressionType.UriComponent, UriComponent.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
@@ -15,9 +15,8 @@ import { ReturnType } from '../returnType';
  * Return the string version of a uniform resource identifier (URI) encoded string, effectively decoding the URI-encoded string.
  */
 export class UriComponentToString extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriComponentToString class.
+     * Initializes a new instance of the `UriComponentToString` class.
      */
     public constructor() {
         super(ExpressionType.UriComponentToString, UriComponentToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
@@ -15,10 +15,17 @@ import { ReturnType } from '../returnType';
  * Return the string version of a uniform resource identifier (URI) encoded string, effectively decoding the URI-encoded string.
  */
 export class UriComponentToString extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriComponentToString class.
+     */
     public constructor() {
         super(ExpressionType.UriComponentToString, UriComponentToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply((args: any[]): string => decodeURIComponent(args[0]), FunctionUtils.verifyString);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the host value of a unified resource identifier (URI).
  */
 export class UriHost extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriHost class.
+     * Initializes a new instance of the `UriHost` class.
      */
     public constructor() {
         super(ExpressionType.UriHost, UriHost.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the host value of a unified resource identifier (URI).
  */
 export class UriHost extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriHost class.
+     */
     public constructor() {
         super(ExpressionType.UriHost, UriHost.evaluator, ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriHost extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriHost.evalUriHost(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriHost(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the path value of a unified resource identifier (URI).
  */
 export class UriPath extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriPath class.
+     */
     public constructor() {
         super(ExpressionType.UriPath, UriPath.evaluator, ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriPath extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriPath.evalUriPath(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriPath(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the path value of a unified resource identifier (URI).
  */
 export class UriPath extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriPath class.
+     * Initializes a new instance of the `UriPath` class.
      */
     public constructor() {
         super(ExpressionType.UriPath, UriPath.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the path and query value of a unified resource identifier (URI).
  */
 export class UriPathAndQuery extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriPathAndQuery class.
+     */
     public constructor() {
         super(ExpressionType.UriPathAndQuery, UriPathAndQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriPathAndQuery extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriPathAndQuery.evalUriPathAndQuery(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriPathAndQuery(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the path and query value of a unified resource identifier (URI).
  */
 export class UriPathAndQuery extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriPathAndQuery class.
+     * Initializes a new instance of the `UriPathAndQuery` class.
      */
     public constructor() {
         super(ExpressionType.UriPathAndQuery, UriPathAndQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the port value of a unified resource identifier (URI).
  */
 export class UriPort extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriPort class.
+     * Initializes a new instance of the `UriPort` class.
      */
     public constructor() {
         super(ExpressionType.UriPort, UriPort.evaluator, ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the port value of a unified resource identifier (URI).
  */
 export class UriPort extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriPort class.
+     */
     public constructor() {
         super(ExpressionType.UriPort, UriPort.evaluator, ReturnType.Number, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriPort extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriPort.evalUriPort(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriPort(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the query value of a unified resource identifier (URI).
  */
 export class UriQuery extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriQuery class.
+     * Initializes a new instance of the `UriQuery` class.
      */
     public constructor() {
         super(ExpressionType.UriQuery, UriQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the query value of a unified resource identifier (URI).
  */
 export class UriQuery extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriQuery class.
+     */
     public constructor() {
         super(ExpressionType.UriQuery, UriQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriQuery extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriQuery.evalUriQuery(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriQuery(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
@@ -19,10 +19,17 @@ import { ReturnType } from '../returnType';
  * Return the scheme value of a unified resource identifier (URI).
  */
 export class UriScheme extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UriScheme class.
+     */
     public constructor() {
         super(ExpressionType.UriScheme, UriScheme.evaluator, ReturnType.String, FunctionUtils.validateUnary);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expr: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let value: any;
         let error: string;
@@ -32,13 +39,16 @@ export class UriScheme extends ExpressionEvaluator {
             if (typeof (args[0]) === 'string') {
                 ({ value, error } = UriScheme.evalUriScheme(args[0]));
             } else {
-                error = `${expr} should contain a URI string.`;
+                error = `${ expr } should contain a URI string.`;
             }
         }
 
         return { value, error };
     }
 
+    /**
+     * @private
+     */
     private static evalUriScheme(uri: string): ValueWithError {
         let result: string;
         let error: string;

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
@@ -19,9 +19,8 @@ import { ReturnType } from '../returnType';
  * Return the scheme value of a unified resource identifier (URI).
  */
 export class UriScheme extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UriScheme class.
+     * Initializes a new instance of the `UriScheme` class.
      */
     public constructor() {
         super(ExpressionType.UriScheme, UriScheme.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
@@ -18,9 +18,8 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp.
  */
 export class UtcNow extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the UtcNow class.
+     * Initializes a new instance of the `UtcNow` class.
      */
     public constructor() {
         super(ExpressionType.UtcNow, UtcNow.evaluator(), ReturnType.String, UtcNow.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
@@ -18,16 +18,26 @@ import { ReturnType } from '../returnType';
  * Return the current timestamp.
  */
 export class UtcNow extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the UtcNow class.
+     */
     public constructor() {
         super(ExpressionType.UtcNow, UtcNow.evaluator(), ReturnType.String, UtcNow.validator);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.apply(
             (args: any[]): string => args.length === 1 ? moment(new Date()).utc().format(args[0]) : new Date().toISOString(),
             FunctionUtils.verifyString);
     }
 
+    /**
+     * @private
+     */
     private static validator(expression: Expression): void {
         FunctionUtils.validateOrder(expression, [ReturnType.String]);
     }

--- a/libraries/adaptive-expressions/src/builtinFunctions/where.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/where.ts
@@ -22,9 +22,8 @@ import { ReturnType } from '../returnType';
  * Filter on each element and return the new collection of filtered elements which match a specific condition.
  */
 export class Where extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Where class.
+     * Initializes a new instance of the `Where` class.
      */
     public constructor() {
         super(ExpressionType.Where, Where.evaluator, ReturnType.Array, InternalFunctionUtils.validateForeach);

--- a/libraries/adaptive-expressions/src/builtinFunctions/where.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/where.ts
@@ -22,10 +22,17 @@ import { ReturnType } from '../returnType';
  * Filter on each element and return the new collection of filtered elements which match a specific condition.
  */
 export class Where extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Where class.
+     */
     public constructor() {
         super(ExpressionType.Where, Where.evaluator, ReturnType.Array, InternalFunctionUtils.validateForeach);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
         let result: any;
         let error: string;
@@ -43,7 +50,7 @@ export class Where extends ExpressionEvaluator {
             } else if (typeof instance === 'object') {
                 Object.keys(instance).forEach((u): number => arr.push({ key: u, value: instance[u] }));
             } else {
-                error = `${expression.children[0]} is not a collection or structure object to run foreach`;
+                error = `${ expression.children[0] } is not a collection or structure object to run foreach`;
             }
 
             if (!error) {

--- a/libraries/adaptive-expressions/src/builtinFunctions/year.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/year.ts
@@ -16,10 +16,17 @@ import { ReturnType } from '../returnType';
  * Return the year of the specified timestamp.
  */
 export class Year extends ExpressionEvaluator {
+
+    /**
+     * Initializes a new instance of the Year class.
+     */
     public constructor() {
         super(ExpressionType.Year, Year.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);
     }
 
+    /**
+     * @private
+     */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError(
             (args: any[]): any => InternalFunctionUtils.parseTimestamp(args[0], (timestamp: Date): number => timestamp.getUTCFullYear()),

--- a/libraries/adaptive-expressions/src/builtinFunctions/year.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/year.ts
@@ -16,9 +16,8 @@ import { ReturnType } from '../returnType';
  * Return the year of the specified timestamp.
  */
 export class Year extends ExpressionEvaluator {
-
     /**
-     * Initializes a new instance of the Year class.
+     * Initializes a new instance of the `Year` class.
      */
     public constructor() {
         super(ExpressionType.Year, Year.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/builtinFunctions/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/builtinFunctions) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.
- Added `@private` attribute to private methods.
- Fixes linter spacing warnings.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94719910-2d647480-032a-11eb-962b-eb58c53e6397.png)
