### PR TITLE
[JSDoc] Add missing documentation for botbuilder-dialogs-adaptive converters/expressions/generators/luis/selectors folders

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
@@ -9,9 +9,17 @@
 import { Converter } from 'botbuilder-dialogs-declarative';
 import { ActivityTemplate, StaticActivityTemplate, TextTemplate } from '../templates';
 
+/**
+ * Activity template converter that implements `Converter`.
+ */
 export class ActivityTemplateConverter implements Converter {
+    /**
+     * Converts a template to one of the foloowing classes `ActivityTemplate` | `StaticActivityTemplate`.
+     * @param value The template to evaluate to create the activity.
+     * @returns A new instance that could be the following classes `ActivityTemplate` | `StaticActivityTemplate`.
+     */
     public convert(value: string): ActivityTemplate | StaticActivityTemplate | TextTemplate {
-        if (typeof value === 'string') { 
+        if (typeof value === 'string') {
             return new ActivityTemplate(value);
         } else {
             return new StaticActivityTemplate(value);

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
@@ -14,7 +14,7 @@ import { ActivityTemplate, StaticActivityTemplate, TextTemplate } from '../templ
  */
 export class ActivityTemplateConverter implements Converter {
     /**
-     * Converts a template to one of the foloowing classes `ActivityTemplate` | `StaticActivityTemplate`.
+     * Converts a template to one of the following classes `ActivityTemplate` | `StaticActivityTemplate`.
      * @param value The template to evaluate to create the activity.
      * @returns A new instance that could be the following classes `ActivityTemplate` | `StaticActivityTemplate`.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
@@ -10,13 +10,25 @@ import { Converter, ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import { Dialog } from 'botbuilder-dialogs';
 import { DialogExpression } from '../expressions';
 
+/**
+ * Dialog expression converter that implements `Converter`.
+ */
 export class DialogExpressionConverter implements Converter {
     private _resourceExplorer: ResourceExplorer;
 
+    /**
+     * Initializes a new instance of the `DialogExpressionConverter` class.
+     * @param resouceExplorer Resource explorer to use for resolving references.
+     */
     public constructor(resouceExplorer: ResourceExplorer) {
         this._resourceExplorer = resouceExplorer;
     }
 
+    /**
+     * Converts an object or string to a `DialogExpression` instance.
+     * @param value An object or string value.
+     * @returns A new `DialogExpression` instance.
+     */
     public convert(value: string | object): DialogExpression {
         if (typeof value == 'string') {
             if (!value.startsWith('=')) {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
@@ -9,7 +9,15 @@
 import { Converter } from 'botbuilder-dialogs-declarative';
 import { ResourceMultiLanguageGenerator } from '../generators';
 
+/**
+ * Language generator converter that implements `Converter`.
+ */
 export class LanguageGeneratorConverter implements Converter {
+    /**
+     * Creates a new `ResourceMultiLanguageGenerator` instance from Resource id value.
+     * @param value Resource id of LG file.
+     * @returns A new `ResourceMultiLanguageGenerator` instance.
+     */
     public convert(value: string|ResourceMultiLanguageGenerator): ResourceMultiLanguageGenerator {
         return typeof value === 'string' ? new ResourceMultiLanguageGenerator(value) : value;
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
@@ -10,13 +10,25 @@ import { Converter, ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import { Recognizer } from '../recognizers';
 import { RecognizerConverter } from './recognizerConverter';
 
+/**
+ * Language generator converter that implements `Converter`.
+ */
 export class MultiLanguageRecognizerConverter implements Converter {
     private _recognizerConverter: RecognizerConverter;
 
+    /**
+     * Initializes a new instance of the `MultiLanguageRecognizerConverter` class.
+     * @param resouceExplorer Resource explorer to use for resolving references.
+     */
     public constructor(resouceExplorer: ResourceExplorer) {
         this._recognizerConverter = new RecognizerConverter(resouceExplorer);
     }
 
+    /**
+     * Converts a recognizers object to an object with `Recognizer` instance for each key.
+     * @param value A recognizers object.
+     * @returns The value object with `Recognizer` instance for each key.
+     */
     public convert(value: object): { [key: string]: Recognizer } {
         const recognizers = {};
         for (const key in value) {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
@@ -9,13 +9,25 @@
 import { Converter, ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import { Recognizer } from '../recognizers';
 
+/**
+ * Recognizer converter that implements `Converter`.
+ */
 export class RecognizerConverter implements Converter {
     private _resourceExplorer: ResourceExplorer;
 
+    /**
+     * Initializes a new instance of the `RecognizerConverter` class.
+     * @param resouceExplorer Resource explorer to use for resolving references.
+     */
     public constructor(resouceExplorer: ResourceExplorer) {
         this._resourceExplorer = resouceExplorer;
     }
 
+    /**
+     * Converts an object or string to a `Recognizer` instance.
+     * @param value An object or string value.
+     * @returns A new `Recognizer` instance.
+     */
     public convert(value: string | object): Recognizer {
         if (typeof value == 'string') {
             const recognizer = this._resourceExplorer.loadType(`${ value }.dialog`) as Recognizer;

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
@@ -9,7 +9,15 @@
 import { Converter } from 'botbuilder-dialogs-declarative';
 import { TextTemplate } from '../templates';
 
+/**
+ * Text template converter that implements `Converter`.
+ */
 export class TextTemplateConverter implements Converter {
+    /**
+     * Converts a string to a `TextTemplate` instance.
+     * @param value The template to evaluate to create text.
+     * @returns A new `TextTemplate` instance.
+     */
     public convert(value: string): TextTemplate {
         return new TextTemplate(value);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
@@ -17,7 +17,7 @@ import { Dialog } from 'botbuilder-dialogs';
 export class DialogExpression extends ExpressionProperty<Dialog> {
     /**
      * Initializes a new instance of the `DialogExpression` class.
-     * @param value A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
+     * @param value Optional. A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
      */
     public constructor(value?: Dialog | string | Expression) {
         super(value);

--- a/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
@@ -11,18 +11,26 @@ import { Dialog } from 'botbuilder-dialogs';
 /**
  * Represents a property which is either a Dialog or a string expression for a dialogId.
  * @remarks
- * String values are always interpreted as a string with interpolation, unless it has '=' prefix 
+ * String values are always interpreted as a string with interpolation, unless it has '=' prefix
  * or not. The result is interpreted as a resource Id or dialogId.
  */
 export class DialogExpression extends ExpressionProperty<Dialog> {
+    /**
+     * Initializes a new instance of the `DialogExpression` class.
+     * @param value A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
+     */
     public constructor(value?: Dialog | string | Expression) {
         super(value);
     }
 
+    /**
+     * Sets the raw value of the expression property.
+     * @param value A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
+     */
     public setValue(value: Dialog | string | Expression): void {
         if (typeof value == 'string' && !value.startsWith('=')) {
             // Resource Id's will be resolved to actual dialog value
-            // if it's not a = then we want to convert to a constant string expressions to represent a 
+            // if it's not a = then we want to convert to a constant string expressions to represent a
             // external dialog id resolved by dc.FindDialog()
             value = `='${ value }'`;
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Class which manages cache of all LG resources from a ResourceExplorer. 
+ * Class which manages cache of all LG resources from a ResourceExplorer.
  * This class automatically updates the cache when resource change events occure.
  */
 import { Resource, ResourceExplorer, FileResource, ResourceChangeEvent } from 'botbuilder-dialogs-declarative';
@@ -64,6 +64,12 @@ export class LanguageGeneratorManager {
      */
     public languageGenerators: Map<string, LanguageGenerator> = new Map<string, LanguageGenerator>();
 
+    /**
+     * Returns the resolver to resolve LG import id to template text based on language and a template resource loader delegate.
+     * @param locale Locale to identify language.
+     * @param resourceMapping Template resource loader delegate.
+     * @returns The delegate to resolve the resource.
+     */
     public static resourceExplorerResolver(locale: string, resourceMapping: Map<string, Resource[]>): ImportResolverDelegate {
         return (lgResource: LGResource, id: string): LGResource => {
             const fallbackLocale = LanguageResourceLoader.fallbackLocale(locale, Array.from(resourceMapping.keys()));
@@ -81,6 +87,9 @@ export class LanguageGeneratorManager {
         };
     }
 
+    /**
+     * @private
+     */
     private getTemplateEngineLanguageGenerator(resource: Resource): TemplateEngineLanguageGenerator {
         return new TemplateEngineLanguageGenerator(resource, this._multiLanguageResources);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
@@ -12,6 +12,9 @@ import { LanguageGenerator } from '../languageGenerator';
 import { LanguageGeneratorManager } from './languageGeneratorManager';
 import { languageGeneratorManagerKey } from '../languageGeneratorExtensions';
 
+/**
+ * Multi language resource generator that extends `MultiLanguageGeneratorBase` class.
+ */
 export class ResourceMultiLanguageGenerator extends MultiLanguageGeneratorBase {
     /**
      * Initializes a new instance of the ResourceMultiLanguageGenerator class.

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
@@ -15,7 +15,7 @@ import { LanguageResourceLoader } from '../languageResourceLoader';
 import { LanguageGeneratorManager } from './languageGeneratorManager';
 
 /**
- * LanguageGenerator implementation which uses LGFile. 
+ * LanguageGenerator implementation which uses LGFile.
  */
 export class TemplateEngineLanguageGenerator implements LanguageGenerator{
     private readonly DEFAULTLABEL: string  = 'Unknown';
@@ -24,6 +24,11 @@ export class TemplateEngineLanguageGenerator implements LanguageGenerator{
 
     public id: string = '';
 
+    /**
+     * Initializes a new instance of the `TemplateEngineLanguageGenerator` class.
+     * @param arg1 An LG `Templates` or a `Resource`.
+     * @param arg2 A `Map` object with a `Resource` array for each key.
+     */
     public constructor(arg1?: Templates | Resource, arg2?: Map<string,Resource[]>) {
         if (arguments.length === 0) {
             this.lg = new Templates();
@@ -38,7 +43,14 @@ export class TemplateEngineLanguageGenerator implements LanguageGenerator{
             this.lg = Templates.parseResource(lgResource, importResolver);
         }
     }
-    
+
+    /**
+     * Method to generate text from given template and data.
+     * @param dialogContext Context for the current turn of conversation.
+     * @param template Template to evaluate.
+     * @param data Data to bind to.
+     * @returns A Promise string with the evaluated result.
+     */
     public generate(dialogContext: DialogContext, template: string, data: object): Promise<string> {
         try {
             // BUGBUG: I'm casting objects to <any> to work around a bug in the activity factory.

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
@@ -26,8 +26,8 @@ export class TemplateEngineLanguageGenerator implements LanguageGenerator{
 
     /**
      * Initializes a new instance of the `TemplateEngineLanguageGenerator` class.
-     * @param arg1 An LG `Templates` or a `Resource`.
-     * @param arg2 A `Map` object with a `Resource` array for each key.
+     * @param arg1 Optional. An LG `Templates` or a `Resource`.
+     * @param arg2 Optional. A `Map` object with a `Resource` array for each key.
      */
     public constructor(arg1?: Templates | Resource, arg2?: Map<string,Resource[]>) {
         if (arguments.length === 0) {

--- a/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
@@ -11,6 +11,9 @@ import { LuisPredictionOptions, LuisRecognizerOptionsV3, LuisRecognizer, LuisApp
 import { DialogContext } from 'botbuilder-dialogs';
 import { Activity, RecognizerResult } from 'botbuilder-core';
 
+/**
+ * Class that represents an adaptive LUIS recognizer.
+ */
 export class LuisAdaptiveRecognizer extends Recognizer {
     /**
      * LUIS application ID.
@@ -51,12 +54,19 @@ export class LuisAdaptiveRecognizer extends Recognizer {
      */
     public predictionOptions: LuisPredictionOptions;
 
+    /**
+     * To recognize intents and entities in a users utterance.
+     * @param dialogContext Dialog Context.
+     * @param activity Activity.
+     * @param telemetryProperties Additional properties to be logged to telemetry with event.
+     * @param telemetryMetrics Additional metrics to be logged to telemetry with event.
+     */
     public async recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }) {
-        // Validate passed in activity matches turn activity 
+        // Validate passed in activity matches turn activity
         const context = dialogContext.context;
-        const utteranceMatches: boolean = !activity || 
+        const utteranceMatches: boolean = !activity ||
             (context.activity.type === activity.type &&  context.activity.text === activity.text);
-        
+
         if (!utteranceMatches) {
             throw new Error(`TurnContext is different than text`);
         }
@@ -103,7 +113,7 @@ export class LuisAdaptiveRecognizer extends Recognizer {
     protected  fillRecognizerResultTelemetryProperties(recognizerResult: RecognizerResult, telemetryProperties: { [key: string]: string }, dialogContext: DialogContext): { [key: string]: string } {
         const logPersonalInfo = this.logPersonalInformation.tryGetValue(dialogContext.state);
         const applicationId = this.applicationId.tryGetValue(dialogContext.state);
-        
+
         const topLuisIntent: string = LuisRecognizer.topIntent(recognizerResult);
         const intentScore: number = (recognizerResult.intents[topLuisIntent] && recognizerResult.intents[topLuisIntent].score) || 0;
 

--- a/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
@@ -58,8 +58,8 @@ export class LuisAdaptiveRecognizer extends Recognizer {
      * To recognize intents and entities in a users utterance.
      * @param dialogContext Dialog Context.
      * @param activity Activity.
-     * @param telemetryProperties Additional properties to be logged to telemetry with event.
-     * @param telemetryMetrics Additional metrics to be logged to telemetry with event.
+     * @param telemetryProperties Optional. Additional properties to be logged to telemetry with event.
+     * @param telemetryMetrics Optional. Additional metrics to be logged to telemetry with event.
      */
     public async recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }) {
         // Validate passed in activity matches turn activity

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
@@ -38,11 +38,21 @@ export class ConditionalSelector implements TriggerSelector {
      */
     public parser: ExpressionParserInterface = new ExpressionParser()
 
+    /**
+     * Initialize the selector with the set of rules.
+     * @param conditionals Possible rules to match.
+     * @param evaluate True if rules should be evaluated on select.
+     */
     public initialize(conditionals: OnCondition[], evaluate: boolean): void {
         this._conditionals = conditionals;
         this._evaluate = evaluate;
     }
 
+    /**
+     * Select the best rule to execute.
+     * @param actionContext Dialog context for evaluation.
+     * @returns A Promise with a number array.
+     */
     public select(actionContext: ActionContext): Promise<number[]> {
         let selector: TriggerSelector;
         if (this.condition && this.condition.getValue(actionContext.state)) {

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
@@ -22,11 +22,21 @@ export class FirstSelector implements TriggerSelector {
      */
     public parser: ExpressionParserInterface = new ExpressionParser()
 
+    /**
+     * Initialize the selector with the set of rules.
+     * @param conditionals Possible rules to match.
+     * @param evaluate True if rules should be evaluated on select.
+     */
     public initialize(conditionals: OnCondition[], evaluate: boolean) {
         this._conditionals = conditionals;
         this._evaluate = evaluate;
     }
 
+    /**
+     * Select the best rule to execute.
+     * @param actionContext Dialog context for evaluation.
+     * @returns A Promise with a number array.
+     */
     public select(actionContext: ActionContext): Promise<number[]> {
         let selection = -1;
         if (this._evaluate) {

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
@@ -25,7 +25,7 @@ export class FirstSelector implements TriggerSelector {
     /**
      * Initialize the selector with the set of rules.
      * @param conditionals Possible rules to match.
-     * @param evaluate True if rules should be evaluated on select.
+     * @param evaluate A boolean representing if rules should be evaluated on select.
      */
     public initialize(conditionals: OnCondition[], evaluate: boolean) {
         this._conditionals = conditionals;

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
@@ -25,7 +25,7 @@ export class RandomSelector implements TriggerSelector {
     /**
      * Initialize the selector with the set of rules.
      * @param conditionals Possible rules to match.
-     * @param evaluate True if rules should be evaluated on select.
+     * @param evaluate A boolean representing if rules should be evaluated on select.
      */
     public initialize(conditionals: OnCondition[], evaluate: boolean): void {
         this._conditionals = conditionals;

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
@@ -22,11 +22,21 @@ export class RandomSelector implements TriggerSelector {
      */
     public parser: ExpressionParserInterface = new ExpressionParser()
 
+    /**
+     * Initialize the selector with the set of rules.
+     * @param conditionals Possible rules to match.
+     * @param evaluate True if rules should be evaluated on select.
+     */
     public initialize(conditionals: OnCondition[], evaluate: boolean): void {
         this._conditionals = conditionals;
         this._evaluate = evaluate;
     }
 
+    /**
+     * Select the best rule to execute.
+     * @param actionContext Dialog context for evaluation.
+     * @returns A Promise with a number array.
+     */
     public select(actionContext: ActionContext): Promise<number[]> {
         const candidates = [];
         for (let i = 0; i < this._conditionals.length; i++) {

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
@@ -22,11 +22,21 @@ export class TrueSelector implements TriggerSelector {
      */
     public parser: ExpressionParserInterface = new ExpressionParser()
 
+    /**
+     * Initialize the selector with the set of rules.
+     * @param conditionals Possible rules to match.
+     * @param evaluate True if rules should be evaluated on select.
+     */
     public initialize(conditionals: OnCondition[], evaluate: boolean): void {
         this._conditionals = conditionals;
         this._evaluate = evaluate;
     }
 
+    /**
+     * Select the best rule to execute.
+     * @param actionContext Dialog context for evaluation.
+     * @returns A Promise with a number array.
+     */
     public select(actionContext: ActionContext): Promise<number[]> {
         const candidates = [];
 


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds all the missing JSDoc documentation for [botbuilder-dialogs-adaptive](https://github.com/microsoft/botbuilder-js/tree/master/libraries/botbuilder-dialogs-adaptive) based on the errors thrown. Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes

- Ported documentation from botbuilder-dotnet.
- Added documentation for the files inside `converters`, `expressions`, `generators`, `luis` and `selectors` folders.
- Added `@private` for private methods.
- Added JSDoc comments in **15 files**.

## Testing
In the following image there is a sneak peek about the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/62260472/94729966-e336bf80-0338-11eb-815d-d4271eae5219.png)