### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botframework streaming

### DIFF
--- a/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
+++ b/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
@@ -29,8 +29,8 @@ export class PayloadAssembler {
     private readonly _utf: string = 'utf8';
 
     /**
-     * Initializes a new instance of the `PayloadAssembler` class.
-     * @param streamManager The `StreamManager` managing the stream being assembled.
+     * Initializes a new instance of the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) class.
+     * @param streamManager The [StreamManager](xref:botframework-streaming.StreamManager) managing the stream being assembled.
      * @param params Parameters for a streaming assembler.
      */
     public constructor(streamManager: StreamManager, params: IAssemblerParams) {
@@ -53,7 +53,7 @@ export class PayloadAssembler {
 
     /**
      * Retrieves the assembler's payload as a stream.
-     * @returns A `SubscribableStream` of the assembler's payload.
+     * @returns A [SubscribableStream](xref:botframework-streaming.SubscribableStream) of the assembler's payload.
      */
     public getPayloadStream(): SubscribableStream {
         if (!this.stream) {
@@ -89,7 +89,7 @@ export class PayloadAssembler {
     }
 
     /**
-     * Creates a new `SubscribableStream` instance.
+     * Creates a new [SubscribableStream](xref:botframework-streaming.SubscribableStream) instance.
      * @returns The new stream ready for consumption.
      */
     private createPayloadStream(): SubscribableStream {

--- a/libraries/botframework-streaming/src/contentStream.ts
+++ b/libraries/botframework-streaming/src/contentStream.ts
@@ -18,9 +18,9 @@ export class ContentStream {
     private stream: SubscribableStream;
 
     /**
-     * Initializes a new instance of the `ContentStream` class.
+     * Initializes a new instance of the [ContentStream](xref:botframework-streaming.ContentStream) class.
      * @param id The ID assigned to this instance.
-     * @param assembler The `PayloadAssembler` assigned to this instance.
+     * @param assembler The [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) assigned to this instance.
      */
     public constructor(id: string, assembler: PayloadAssembler) {
         if (!assembler) {
@@ -31,21 +31,21 @@ export class ContentStream {
     }
 
     /**
-     * Gets the name of the type of the object contained within this `ContentStream`.
+     * Gets the name of the type of the object contained within this [ContentStream](xref:botframework-streaming.ContentStream).
      */
     public get contentType(): string {
         return this.assembler.payloadType;
     }
 
     /**
-     * Gets the length of this `ContentStream`.
+     * Gets the length of this [ContentStream](xref:botframework-streaming.ContentStream).
      */
     public get length(): number {
         return this.assembler.contentLength;
     }
 
     /**
-     * Gets the data contained within this `ContentStream`.
+     * Gets the data contained within this [ContentStream](xref:botframework-streaming.ContentStream).
      */
     public getStream(): SubscribableStream {
         if (!this.stream) {
@@ -63,8 +63,8 @@ export class ContentStream {
     }
 
     /**
-     * Gets the `SubscribableStream` content as a string.
-     * @returns A string Promise with `SubscribableStream` content.
+     * Gets the [SubscribableStream](xref:botframework-streaming.SubscribableStream) content as a string.
+     * @returns A string Promise with [SubscribableStream](xref:botframework-streaming.SubscribableStream) content.
      */
     public async readAsString(): Promise<string> {
         const { bufferArray } = await this.readAll();
@@ -72,7 +72,7 @@ export class ContentStream {
     }
 
     /**
-     * Gets the `SubscribableStream` content as a typed JSON object.
+     * Gets the [SubscribableStream](xref:botframework-streaming.SubscribableStream) content as a typed JSON object.
      * @returns A typed object Promise with `SubscribableStream` content.
      */
     public async readAsJson<T>(): Promise<T> {

--- a/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
@@ -18,8 +18,8 @@ export class CancelDisassembler {
     private readonly payloadType: PayloadTypes;
 
     /**
-     * Initializes a new instance of the `CancelDisassembler` class.
-     * @param sender The `PayloadSender` that this Cancel request will be sent by.
+     * Initializes a new instance of the [CancelDisassembler](xref:botframework-streaming.CancelDisassembler) class.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) that this Cancel request will be sent by.
      * @param id The ID of the Stream to cancel.
      * @param payloadType The type of the Stream that is being cancelled.
      */
@@ -30,7 +30,7 @@ export class CancelDisassembler {
     }
 
     /**
-     * Initiates the process of disassembling the request and signals the `PayloadSender` to begin sending.
+     * Initiates the process of disassembling the request and signals the [PayloadSender](xref:botframework-streaming.PayloadSender) to begin sending.
      */
     public disassemble(): void {
         const header: IHeader = {payloadType: this.payloadType, payloadLength: 0, id: this.id, end: true};

--- a/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
@@ -20,9 +20,9 @@ export class HttpContentStreamDisassembler extends PayloadDisassembler {
     public payloadType: PayloadTypes = PayloadTypes.stream;
 
     /**
-     * Initializes a new instance of the `HttpContentStreamDisassembler` class.
-     * @param sender The `PayloadSender` to send the disassembled data to.
-     * @param contentStream The `HttpContentStream` to be disassembled.
+     * Initializes a new instance of the [HttpContentStreamDisassembler](xref:botframework-streaming.HttpContentStreamDisassembler) class.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
+     * @param contentStream The [HttpContentStream](xref:botframework-streaming.HttpContentStream) to be disassembled.
      */
     public constructor(sender: PayloadSender, contentStream: HttpContentStream) {
         super(sender, contentStream.id);
@@ -31,7 +31,7 @@ export class HttpContentStreamDisassembler extends PayloadDisassembler {
 
     /**
      * Gets the stream this disassembler is operating on.
-     * @returns An `IStreamWrapper` with a Subscribable Strea.
+     * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Strea.
      */
     public async getStream(): Promise<IStreamWrapper> {
         let stream: SubscribableStream = this.contentStream.content.getStream();

--- a/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
@@ -22,8 +22,8 @@ export abstract class PayloadDisassembler {
     private readonly id: string;
 
     /**
-     * Initializes a new instance of the `PayloadDisassembler` class.
-     * @param sender The `PayloadSender` used to send the disassembled payload chunks.
+     * Initializes a new instance of the [PayloadDisassembler](xref:botframework-streaming.PayloadDisassembler) class.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) used to send the disassembled payload chunks.
      * @param id The ID of this disassembler.
      */
     public constructor(sender: PayloadSender, id: string) {
@@ -32,7 +32,7 @@ export abstract class PayloadDisassembler {
     }
 
     /**
-     * Serializes the item into the `IStreamWrapper` that exposes the stream and length of the result.
+     * Serializes the item into the [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) that exposes the stream and length of the result.
      * @param item The item to be serialized.
      */
     protected static serialize<T>(item: T): IStreamWrapper {
@@ -46,12 +46,12 @@ export abstract class PayloadDisassembler {
 
     /**
      * Gets the stream this disassembler is operating on.
-     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
     public abstract async getStream(): Promise<IStreamWrapper>;
 
     /**
-     * Begins the process of disassembling a payload and sending the resulting chunks to the `PayloadSender` to dispatch over the transport.
+     * Begins the process of disassembling a payload and sending the resulting chunks to the [PayloadSender](xref:botframework-streaming.PayloadSender) to dispatch over the transport.
      */
     public async disassemble(): Promise<void> {
         let { stream, streamLength }: IStreamWrapper = await this.getStream();
@@ -63,7 +63,7 @@ export abstract class PayloadDisassembler {
     }
 
     /**
-     * Begins the process of disassembling a payload and signals the `PayloadSender`.
+     * Begins the process of disassembling a payload and signals the [PayloadSender](xref:botframework-streaming.PayloadSender).
      */
     private async send(): Promise<void> {
         let header: IHeader = {payloadType: this.payloadType, payloadLength: this.streamLength, id: this.id, end: true};

--- a/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
@@ -20,8 +20,8 @@ export class RequestDisassembler extends PayloadDisassembler {
     public payloadType: PayloadTypes = PayloadTypes.request;
 
     /**
-     * Initializes a new instance of the `RequestDisassembler` class.
-     * @param sender The `PayloadSender` to send the disassembled data to.
+     * Initializes a new instance of the [RequestDisassembler](xref:botframework-streaming.RequestDisassembler) class.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
      * @param id The ID of this disassembler.
      * @param request The request to be disassembled.
      */
@@ -32,7 +32,7 @@ export class RequestDisassembler extends PayloadDisassembler {
 
     /**
      * Gets the stream this disassembler is operating on.
-     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
     public async getStream(): Promise<IStreamWrapper> {
         let payload: IRequestPayload = {verb: this.request.verb, path: this.request.path, streams: []};

--- a/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
@@ -20,8 +20,8 @@ export class ResponseDisassembler extends PayloadDisassembler {
     public readonly payloadType: PayloadTypes = PayloadTypes.response;
 
     /**
-     * Initializes a new instance of the `ResponseDisassembler` class.
-     * @param sender The `PayloadSender` to send the disassembled data to.
+     * Initializes a new instance of the [ResponseDisassembler](xref:botframework-streaming.ResponseDisassembler) class.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
      * @param id The ID of this disassembler.
      * @param response The response to be disassembled.
      */
@@ -32,7 +32,7 @@ export class ResponseDisassembler extends PayloadDisassembler {
 
     /**
      * Gets the stream this disassembler is operating on.
-     * @returns An `IStreamWrapper` with a Subscribable Stream.
+     * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
     public async getStream(): Promise<IStreamWrapper> {
         let payload: IResponsePayload = {statusCode: this.response.statusCode, streams: []};

--- a/libraries/botframework-streaming/src/httpContentStream.ts
+++ b/libraries/botframework-streaming/src/httpContentStream.ts
@@ -19,8 +19,8 @@ export class HttpContentStream {
     public description: { id: string; type: string; length: number; };
 
     /**
-     * Initializes a new instance of the `HttpContentStream` class.
-     * @param content The content to assign to the `HttpContentStream`.
+     * Initializes a new instance of the [HttpContentStream](xref:botframework-streaming.HttpContentStream) class.
+     * @param content The [HttpContent](xref:botframework-streaming.HttpContent) to assign to the [HttpContentStream](xref:botframework-streaming.HttpContentStream).
      */
     public constructor(content: HttpContent) {
         this.id = generateGuid();
@@ -30,14 +30,14 @@ export class HttpContentStream {
 }
 
 /**
- * The HttpContent class that contains a SubscribableStream.
+ * The HttpContent class that contains a [SubscribableStream](xref:botframework-streaming.SubscribableStream).
  */
 export class HttpContent {
     public headers: IHttpContentHeaders;
     private readonly stream: SubscribableStream;
 
     /**
-     * Initializes a new instance of the `HttpContent` class.
+     * Initializes a new instance of the [HttpContent](xref:botframework-streaming.HttpContent) class.
      * @param headers The Streaming Http content header definition.
      * @param stream The stream of buffered data.
      */
@@ -47,7 +47,7 @@ export class HttpContent {
     }
 
     /**
-     * Gets the data contained within this `HttpContent`.
+     * Gets the data contained within this [HttpContent](xref:botframework-streaming.HttpContent).
      */
     public getStream(): SubscribableStream {
         return this.stream;

--- a/libraries/botframework-streaming/src/subscribableStream.ts
+++ b/libraries/botframework-streaming/src/subscribableStream.ts
@@ -17,7 +17,7 @@ export class SubscribableStream extends Duplex {
     private _onData: (chunk: any) => void;
 
     /**
-     * Initializes a new instance of the `SubscribableStream` class.
+     * Initializes a new instance of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) class.
      * @param options The `DuplexOptions` to use when constructing this stream.
      */
     public constructor(options?: DuplexOptions) {


### PR DESCRIPTION
PR 2826 in MS, #150 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.