### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs-adaptive/root

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
@@ -12,14 +12,14 @@ import { ActionChangeList } from './actionChangeList';
 import { ActionChangeType } from './actionChangeType';
 
 /**
- * Extends the `DialogContext` with additional methods for manipulating the
- * executing sequence of actions for an `AdaptiveDialog`.
+ * Extends the [DialogContext](xref:botbuilder-dialogs.DialogContext) with additional methods for manipulating the
+ * executing sequence of actions for an [AdaptiveDialog](xref:botbuilder-dialogs-adaptive.AdaptiveDialog).
  */
 export class ActionContext extends DialogContext {
     private readonly _changeKey: symbol;
 
     /**
-     * Initializes a new instance of the `ActionContext` class
+     * Initializes a new instance of the [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) class
      * @param dialogs The dialog set to create the action context for.
      * @param parentDialogContext Parent dialog context.
      * @param state Current dialog state.

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -188,7 +188,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the dialog is started and pushed onto the dialog stack.
-     * @param dc The `DialogContext` for the current turn of conversation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional, initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
      */
@@ -252,7 +252,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when the dialog is _continued_, where it is the active dialog and the
      * user replies with a new activity.
-     * @param dc The `DialogContext` for the current turn of conversation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      */
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
@@ -293,8 +293,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @protected
      * Called before an event is bubbled to its parent.
-     * @param dc The `DialogContext` for the current turn of conversation.
-     * @param event The `DialogEvent` being raised.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param event The [DialogEvent](xref:botbuilder-dialogs.DialogEvent) being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      */
     protected async onPreBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean> {
@@ -307,8 +307,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @protected
      * Called after an event was bubbled to all parents and wasn't handled.
-     * @param dc The `DialogContext` for the current turn of conversation.
-     * @param event The `DialogEvent` being raised.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param event The [DialogEvent](xref:botbuilder-dialogs.DialogEvent) being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      */
     protected async onPostBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean> {
@@ -361,9 +361,9 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-     * Creates a child `DialogContext` for the given context.
-     * @param dc The `DialogContext` for the current turn of conversation.
-     * @returns The child `DialogContext` or null if no `AdaptiveDialogState.actions` are found for the given context.
+     * Creates a child [DialogContext](xref:botbuilder-dialogs.DialogContext) for the given context.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @returns The child [DialogContext](xref:botbuilder-dialogs.DialogContext) or null if no [AdaptiveDialogState.actions](xref:botbuilder-dialogs-adaptive.AdaptiveDialogState.actions) are found for the given context.
      */
     public createChildContext(dc: DialogContext): DialogContext {
         const activeDialogState = dc.activeDialog.state;
@@ -381,8 +381,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-     * Gets `Dialog` enumerated dependencies.
-     * @returns `Dialog`'s enumerated dependencies.
+     * Gets [Dialog](xref:botbuilder-dialogs.Dialog) enumerated dependencies.
+     * @returns [Dialog](xref:botbuilder-dialogs.Dialog)'s enumerated dependencies.
      */
     public getDependencies(): Dialog[] {
         this.ensureDependenciesInstalled();
@@ -396,8 +396,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @protected
      * Event processing implementation.
-     * @param actionContext The `ActionContext` for the current turn of conversation.
-     * @param dialogEvent The `DialogEvent` being raised.
+     * @param actionContext The [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) for the current turn of conversation.
+     * @param dialogEvent The [DialogEvent](xref:botbuilder-dialogs.DialogEvent) being raised.
      * @param preBubble A flag indicator for preBubble processing.
      * @returns A Promise representation of a boolean indicator or the result.
      */
@@ -549,9 +549,9 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @protected
      * Recognizes intent for current activity given the class recognizer set, if set is null no intent will be recognized.
-     * @param actionContext The `ActionContext` for the current turn of conversation.
-     * @param activity `Activity` to recognize.
-     * @returns A Promise representing a `RecognizerResult`.
+     * @param actionContext The [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) for the current turn of conversation.
+     * @param activity [Activity](xref:botbuilder-schema.Activity) to recognize.
+     * @returns A Promise representing a [RecognizerResult](xref:botbuilder.RecognizerResult).
      */
     protected async onRecognize(actionContext: ActionContext, activity: Activity): Promise<RecognizerResult> {
         const { text } = activity;
@@ -614,9 +614,9 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * @protected
-     * Waits for pending actions to complete and moves on to `OnEndOfActions`.
-     * @param dc The `DialogContext` for the current turn of conversation.
-     * @returns A Promise representation of `DialogTurnResult`.
+     * Waits for pending actions to complete and moves on to [OnEndOfActions](xref:botbuilder-dialogs-adaptive.OnEndOfActions).
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @returns A Promise representation of [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult).
      */
     protected async continueActions(dc: DialogContext): Promise<DialogTurnResult> {
         // Apply any queued up changes
@@ -682,8 +682,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * @protected
-     * `onSetScopedServices` provides the ability to set scoped services for the current dialogContext.
-     * @param dialogContext The `DialogContext` for the current turn of conversation.
+     * Provides the ability to set scoped services for the current [DialogContext](xref:botbuilder-dialogs.DialogContext).
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      */
     protected onSetScopedServices(dialogContext: DialogContext): void {
         if (this.generator) {
@@ -693,8 +693,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * @protected
-     * Removes the most current action from the given `ActionContext` if there are any.
-     * @param actionContext The `ActionContext` for the current turn of conversation.
+     * Removes the most current action from the given [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) if there are any.
+     * @param actionContext The [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) for the current turn of conversation.
      * @returns A Promise representing a boolean indicator for the result.
      */
     protected async endCurrentAction(actionContext: ActionContext): Promise<boolean> {
@@ -708,8 +708,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @protected
      * Awaits for completed actions to finish processing entity assignments and finishes the turn.
-     * @param actionContext The `ActionContext` for the current turn of conversation.
-     * @returns A Promise representation of `DialogTurnResult`.
+     * @param actionContext The [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) for the current turn of conversation.
+     * @returns A Promise representation of [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult).
      */
     protected async onEndOfActions(actionContext: ActionContext): Promise<DialogTurnResult> {
         // Is the current dialog still on the stack?

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialogComponentRegistration.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialogComponentRegistration.ts
@@ -28,15 +28,15 @@ import { LuisAdaptiveRecognizer } from './luis';
 import { LanguagePolicyConverter } from './languagePolicy';
 
 /**
- * `ComponentRegistration` implementation for adaptive components.
+ * [ComponentRegistration](xref:botbuilder-dialogs-declarative.ComponentRegistration) implementation for adaptive components.
  */
 export class AdaptiveDialogComponentRegistration implements ComponentRegistration {
     private _resourceExplorer: ResourceExplorer;
     private _builderRegistrations: BuilderRegistration[] = [];
 
     /**
-     * Initializes a new instance of the `AdaptiveComponentRegistration` class.
-     * @param resourceExplorer `ResourceExplorer` to get all schema resources.
+     * Initializes a new instance of the [AdaptiveComponentRegistration](xref:botbuilder-dialogs-adaptive.AdaptiveComponentRegistration) class.
+     * @param resourceExplorer [ResourceExplorer](xref:botbuilder-dialogs-declarative.ResourceExplorer) to get all schema resources.
      */
     public constructor(resourceExplorer: ResourceExplorer) {
         this._resourceExplorer = resourceExplorer;
@@ -68,7 +68,7 @@ export class AdaptiveDialogComponentRegistration implements ComponentRegistratio
 
     /**
      * Gets all the builder registrations instances.
-     * @returns An array of `BuilderRegistration`.
+     * @returns An array of [BuilderRegistration](xref:botbuilder-dialogs-declarative.BuilderRegistration).
      */
     public getTypeBuilders(): BuilderRegistration[] {
         return this._builderRegistrations;

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveTypeBuilder.ts
@@ -31,6 +31,7 @@ export class AdaptiveTypeBuilder implements TypeBuilder {
     /**
      * Builds an adaptive type.
      * @param config Configuration object for the type.
+     * @returns A new factory object for the adaptive type.
      */
     public build(config: object): object {
         const obj = new this._factory();

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveTypeBuilder.ts
@@ -17,7 +17,7 @@ export class AdaptiveTypeBuilder implements TypeBuilder {
     private _resourceExplorer: ResourceExplorer;
 
     /**
-     * Creates a new instance of the `AdaptiveTypeBuilder` class.
+     * Creates a new instance of the [AdaptiveTypeBuilder](xref:botbuilder-dialogs-adaptive.AdaptiveTypeBuilder) class.
      * @param factory Factory for the adaptive type.
      * @param resourceExplorer Resource explorer.
      * @param converters Key value pair with converters.

--- a/libraries/botbuilder-dialogs-adaptive/src/customDialogTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/customDialogTypeBuilder.ts
@@ -16,6 +16,7 @@ export class CustomDialogTypeBuilder extends AdaptiveTypeBuilder {
     /**
      * Builds a custom adaptive type.
      * @param config Configuration object for the type.
+     * @returns A new factory object for the custom adaptive type.
      */
     public build(config: object): object {
         const kind = config['$kind'];

--- a/libraries/botbuilder-dialogs-adaptive/src/languagePolicy.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languagePolicy.ts
@@ -13,7 +13,7 @@ import { Converter } from 'botbuilder-dialogs-declarative';
  */
 export class LanguagePolicy extends Map<string, string[]> {
     /**
-     * Initializes a new instance of the `LanguagePolicy` class.
+     * Initializes a new instance of the [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) class.
      * @param defaultLanguages Default languages to use.
      */
     public constructor(...defaultLanguages: string[]) {
@@ -86,7 +86,7 @@ export class LanguagePolicy extends Map<string, string[]> {
     /**
      * Walk through all of the cultures and create a dictionary map with most specific to least specific.
      * @param defaultLanguages Default languages to use.
-     * @returns A `Map` object with a string array for each key.
+     * @returns A Map object with a string array for each key.
      * @example Example output "en-us" will generate fallback rule like this:
      * "en-us" -> "en" -> ""
      * "en" -> ""
@@ -128,9 +128,9 @@ export class LanguagePolicy extends Map<string, string[]> {
  */
 export class LanguagePolicyConverter implements Converter {
     /**
-     * Converts an object to a `LanguagePolicy` instance.
+     * Converts an object to a [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) instance.
      * @param value Object.
-     * @returns A new `LanguagePolicy` instance.
+     * @returns A new [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) instance.
      */
     public convert(value: object): LanguagePolicy {
         const policy = new LanguagePolicy();


### PR DESCRIPTION
PR 2852 in MS, #172 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.