### PR TITLE
[internal] Apply xref links for botframework-connector

### DIFF
--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -37,7 +37,7 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
     protected authenticationContext: adal.AuthenticationContext;
 
     /**
-     * Initializes a new instance of the `AppCredentials` class.
+     * Initializes a new instance of the [AppCredentials](xref:botframework-connector.AppCredentials) class.
      * @param appId The App ID.
      * @param channelAuthTenant Optional. The oauth token tenant.
      * @param oAuthScope The scope for the token.

--- a/libraries/botframework-connector/src/auth/authenticationError.ts
+++ b/libraries/botframework-connector/src/auth/authenticationError.ts
@@ -11,7 +11,7 @@ export type StatusCode = number;
  */
 export class AuthenticationError extends Error implements IStatusCodeError {
     /**
-     * Initializes a new instance of the `AuthenticationError` class.
+     * Initializes a new instance of the [AuthenticationError](xref:botframework-connector.AuthenticationError) class.
      * @param message The Error message.
      * @param statusCode The `StatusCode` number to use.
      */

--- a/libraries/botframework-connector/src/auth/authenticationError.ts
+++ b/libraries/botframework-connector/src/auth/authenticationError.ts
@@ -13,7 +13,7 @@ export class AuthenticationError extends Error implements IStatusCodeError {
     /**
      * Initializes a new instance of the `AuthenticationError` class.
      * @param message The Error message.
-     * @param statusCode The `StatusCode` to use.
+     * @param statusCode The `StatusCode` number to use.
      */
     constructor(
         message: string,
@@ -23,7 +23,7 @@ export class AuthenticationError extends Error implements IStatusCodeError {
     }
 
     /**
-     * Corroborates that the error is of type IStatusCodeError.
+     * Corroborates that the error is of type [IStatusCodeError](xref:botbuilder.IStatusCodeError).
      * @param err The error to validate.
      */
     public static isStatusCodeError(err: any): err is IStatusCodeError {

--- a/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
@@ -17,7 +17,7 @@ export class CertificateAppCredentials extends AppCredentials {
     public certificatePrivateKey: string;
 
     /**
-     * Initializes a new instance of the `CertificateAppCredentials` class.
+     * Initializes a new instance of the [CertificateAppCredentials](xref:botframework-connector.CertificateAppCredentials) class.
      * @param appId Microsoft application Id related to the certificate.
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.

--- a/libraries/botframework-connector/src/auth/claimsIdentity.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentity.ts
@@ -21,8 +21,8 @@ export class ClaimsIdentity {
     public readonly claims: Claim[];
 
     /**
-     * Initializes a new instance of the `ClaimsIdentity` class.
-     * @param claims An array of Claims.
+     * Initializes a new instance of the [ClaimsIdentity](xref:botframework-connector.ClaimsIdentity) class.
+     * @param claims An array of [Claim](xref:botframework-connector.Claim).
      * @param isAuthenticated The value to represent the identity has been authenticated.
      */
     constructor(claims: Claim[], isAuthenticated: boolean) {

--- a/libraries/botframework-connector/src/auth/credentialProvider.ts
+++ b/libraries/botframework-connector/src/auth/credentialProvider.ts
@@ -49,7 +49,7 @@ export interface ICredentialProvider {
 }
 
 /**
- * A simple implementation of the `ICredentialProvider` interface.
+ * A simple implementation of the [ICredentialProvider](xref:botframework-connector.ICredentialProvider) interface.
  */
 export class SimpleCredentialProvider implements ICredentialProvider {
 
@@ -57,7 +57,7 @@ export class SimpleCredentialProvider implements ICredentialProvider {
     private readonly appPassword: string;
 
     /**
-     * Initializes a new instance of the `SimpleCredentialProvider` class with the provided credentials.
+     * Initializes a new instance of the [SimpleCredentialProvider](xref:botframework-connector.SimpleCredentialProvider) class with the provided credentials.
      * @param appId The app ID.
      * @param appPassword The app password.
      */

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -27,7 +27,7 @@ export class JwtTokenExtractor {
     public readonly openIdMetadata: OpenIdMetadata;
 
     /**
-     * Initializes a new instance of the `JwtTokenExtractor` class. Extracts relevant data from JWT Tokens.
+     * Initializes a new instance of the [JwtTokenExtractor](xref:botframework-connector.JwtTokenExtractor) class. Extracts relevant data from JWT Tokens.
      * @param tokenValidationParameters Token validation parameters.
      * @param metadataUrl Metadata Url.
      * @param allowedSigningAlgorithms Allowed signing algorithms.
@@ -56,7 +56,7 @@ export class JwtTokenExtractor {
      * @param authorizationHeader The raw HTTP header in the format: "Bearer [longString]".
      * @param channelId The Id of the channel being validated in the original request.
      * @param requiredEndorsements The required JWT endorsements.
-     * @returns A `Promise<ClaimsIdentity>` object.
+     * @returns A `Promise` representation for either a [ClaimsIdentity](botframework-connector:module.ClaimsIdentity) or `null`.
      */
     public async getIdentityFromAuthHeader(authorizationHeader: string, channelId: string, requiredEndorsements?: string[]): Promise<ClaimsIdentity | null> {
         if (!authorizationHeader) {
@@ -77,7 +77,7 @@ export class JwtTokenExtractor {
      * @param parameter The token.
      * @param channelId The Id of the channel being validated in the original request.
      * @param requiredEndorsements The required JWT endorsements.
-     * @returns A `Promise<ClaimsIdentity>` object.
+     * @returns A `Promise` representation for either a [ClaimsIdentity](botframework-connector:module.ClaimsIdentity) or `null`.
      */
     public async getIdentity(scheme: string, parameter: string, channelId: string, requiredEndorsements: string[] = []): Promise<ClaimsIdentity | null> {
 

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -16,7 +16,7 @@ export class MicrosoftAppCredentials extends AppCredentials {
     public appPassword: string;
 
     /**
-     * Initializes a new instance of the `MicrosoftAppCredentials` class.
+     * Initializes a new instance of the [MicrosoftAppCredentials](xref:botframework-connector.MicrosoftAppCredentials) class.
      * @param appId The Microsoft app ID.
      * @param appPassword The Microsoft app password.
      * @param channelAuthTenant Optional. The oauth token tenant.

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -21,7 +21,7 @@ export class OpenIdMetadata {
     private keys: IKey[];
 
     /**
-     * Initializes a new instance of the `OpenIdMetadata` class.
+     * Initializes a new instance of the [OpenIdMetadata](xref:botframework-connector.OpenIdMetadata) class.
      * @param url Metadata Url.
      */
     constructor(url: string) {
@@ -31,6 +31,7 @@ export class OpenIdMetadata {
     /**
      * Gets the Signing key.
      * @param keyId The key ID to search for.
+     * @returns A `Promise` representation for either a [IOpenIdMetadataKey](botframework-connector:module.IOpenIdMetadataKey) or `null`.
      */
     public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
         // If keys are more than 24 hours old, refresh them

--- a/libraries/botframework-connector/src/emulatorApiClient.ts
+++ b/libraries/botframework-connector/src/emulatorApiClient.ts
@@ -14,8 +14,8 @@ import fetch from 'cross-fetch';
  */
 export class EmulatorApiClient {
     /**
-     *
-     * @param credentials AppCredentials for OAuth.
+     * OAuth card emulation.
+     * @param credentials [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * @param emulatorUrl The URL of the emulator.
      * @param emulate `true` to send an emulated OAuth card to the emulator; or `false` to not send the card.
      */

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -29,7 +29,7 @@ export class Teams {
    * Fetches channel list for a given team.
    * @param teamId Team Id.
    * @param options Optional. The options object to be used in every request.
-   * @returns Promise<Models.TeamsFetchChannelListResponse>.
+   * @returns A `Promise<Models.TeamsFetchChannelListResponse>`.
    */
   fetchChannelList(teamId: string, options?: msRest.RequestOptionsBase): Promise<Models.TeamsFetchChannelListResponse>;
   /**
@@ -50,7 +50,7 @@ export class Teams {
    * @param teamId Team Id.
    * @param options Optional. The options object to be used in every request.
    * @param callback The callback.
-   * @returns Promise<Models.TeamsFetchChannelListResponse>.
+   * @returns A `Promise<Models.TeamsFetchChannelListResponse>`.
    */
   fetchChannelList(teamId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<ConversationList>, callback?: msRest.ServiceCallback<ConversationList>): Promise<Models.TeamsFetchChannelListResponse> {
     return this.client.sendOperationRequest(
@@ -66,7 +66,7 @@ export class Teams {
    * Fetches details related to a team.
    * @param teamId Team Id.
    * @param options Optional. The options object to be used in every request.
-   * @returns Promise<Models.TeamsFetchTeamDetailsResponse>.
+   * @returns A `Promise<Models.TeamsFetchTeamDetailsResponse>`.
    */
   fetchTeamDetails(teamId: string, options?: msRest.RequestOptionsBase): Promise<Models.TeamsFetchTeamDetailsResponse>;
   /**
@@ -87,7 +87,7 @@ export class Teams {
    * @param teamId Team Id.
    * @param options Optional. The options object to be used in every request.
    * @param callback The callback.
-   * @returns Promise<Models.TeamsFetchTeamDetailsResponse>.
+   * @returns A `Promise<Models.TeamsFetchTeamDetailsResponse>`.
    */
   fetchTeamDetails(teamId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>, callback?: msRest.ServiceCallback<TeamDetails>): Promise<Models.TeamsFetchTeamDetailsResponse> {
     return this.client.sendOperationRequest(


### PR DESCRIPTION
PR 2827 in MS, #152 in SW

Feedback applied to use xref to link to other methods and add a missing `return` tag to `openIdMetadata`.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.