### PR TITLE
[internal] Apply xref links and feedback for jsdoc/botbuilder-lg-root files

### DIFF
--- a/libraries/botbuilder-lg/src/analyzer.ts
+++ b/libraries/botbuilder-lg/src/analyzer.ts
@@ -31,7 +31,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     private readonly _expressionParser: ExpressionParserInterface;
 
     /**
-     * Creates a new instance of the Analyzer class.
+     * Creates a new instance of the [Analyzer](xref:botbuilder-lg.Analyzer) class.
      * @param templates Template list.
      * @param expressionParser Expression parser.
      */
@@ -77,6 +77,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitNormalBody(ctx: lp.NormalBodyContext): AnalyzerResult {
         return this.visit(ctx.normalTemplateBody());
@@ -85,6 +86,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -98,6 +100,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitStructuredTemplateBody(ctx: lp.StructuredTemplateBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -118,6 +121,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredValue.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitStructureValue(ctx: lp.KeyValueStructureLineContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -140,6 +144,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitIfElseBody(ctx: lp.IfElseBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -161,6 +166,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -181,6 +187,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
      * @param ctx The parse tree.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     public visitNormalTemplateString(ctx: lp.NormalTemplateStringContext): AnalyzerResult {
         const result: AnalyzerResult = new AnalyzerResult();
@@ -195,6 +202,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     /**
      * Gets the default value returned by visitor methods.
      * @returns An instance of the AnalyzerResult class.
+     * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     protected defaultResult(): AnalyzerResult {
         return new AnalyzerResult();

--- a/libraries/botbuilder-lg/src/analyzerResult.ts
+++ b/libraries/botbuilder-lg/src/analyzerResult.ts
@@ -21,7 +21,7 @@ export class AnalyzerResult {
     public TemplateReferences: string[];
 
     /**
-     * Creates a new instance of the AnalyzerResult class.
+     * Creates a new instance of the [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) class.
      * @param variables Init varibales.
      * @param templateRefNames Init template references.
      */

--- a/libraries/botbuilder-lg/src/customizedMemory.ts
+++ b/libraries/botbuilder-lg/src/customizedMemory.ts
@@ -26,7 +26,7 @@ export class CustomizedMemory implements MemoryInterface {
     public localMemory: MemoryInterface;
 
     /**
-     * Creates a new instance of the CustomizedMemory class.
+     * Creates a new instance of the [CustomizedMemory](xref:botbuilder-lg.CustomizedMemory) class.
      * @param scope Optional. Scope.
      * @param localMemory Optional. Local memory.
      */

--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -30,7 +30,7 @@ export class Diagnostic {
     public message: string;
 
     /**
-     * Creates a new instance of the Diagnostic class.
+     * Creates a new instance of the [Diagnostic](xref:botbuilder-lg.Diagnostic) class.
      * @param range Range where the error or warning occurred.
      * @param message Error message of the error or warning.
      * @param severity Severity of the error or warning.
@@ -51,8 +51,8 @@ export class Diagnostic {
     }
 
     /**
-     * Returns a string that represents the current Diagnostic object.
-     * @returns A string that represents the current Diagnostic.
+     * Returns a string that represents the current [Diagnostic](xref:botbuilder-lg.Diagnostic) object.
+     * @returns A string that represents the current [Diagnostic](xref:botbuilder-lg.Diagnostic).
      */
     public toString(): string {
         // ignore error range if source is "inline content"

--- a/libraries/botbuilder-lg/src/errorListener.ts
+++ b/libraries/botbuilder-lg/src/errorListener.ts
@@ -20,7 +20,7 @@ export class ErrorListener implements ANTLRErrorListener<any> {
     private lineOffset: number;
     
     /**
-     * Creates a new instance of the ErrorListener class.
+     * Creates a new instance of the [ErrorListener](xref:botbuilder-lg.ErrorListener) class.
      * @param errorSource String value that represents the source of the error.
      * @param lineOffset Offset of the line where the error occurred.
      */

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -52,7 +52,7 @@ export class EvaluationOptions {
     public cacheScope: LGCacheScope | undefined;
 
     /**
-     * Creates a new instance of the EvaluationOptions class.
+     * Creates a new instance of the [EvaluationOptions](xref:botbuilder-lg.EvaluationOptions) class.
      * @param opt Instance to copy initial settings from.
      */
     public constructor(opt?: EvaluationOptions | string[]) {

--- a/libraries/botbuilder-lg/src/evaluationTarget.ts
+++ b/libraries/botbuilder-lg/src/evaluationTarget.ts
@@ -30,7 +30,7 @@ export class EvaluationTarget {
     public cachedEvaluatedChildren : Map<string, any>;
     
     /**
-     * Creates a new instance of the EvaluationTarget class.
+     * Creates a new instance of the [EvaluationTarget](xref:botbuilder-lg.EvaluationTarget) class.
      * @param templateName Template name.
      * @param scope Template scope.
      */

--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -52,7 +52,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     public static readonly ReExecuteSuffix = '!';
 
     /**
-     * Creates a new instance of the Evaluator class.
+     * Creates a new instance of the [Evaluator](xref:botbuilder-lg.Evaluator) class.
      * @param templates Template list.
      * @param expressionParser Expression parser.
      * @param opt Options for LG.
@@ -135,6 +135,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
      * @param ctx The parse tree.
+     * @returns The result of visiting the structured template body.
      */
     public visitStructuredTemplateBody(ctx: lp.StructuredTemplateBodyContext): any {
         const result: any = {};
@@ -205,6 +206,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The result of visiting the normal body.
      */
     public visitNormalBody(ctx: lp.NormalBodyContext): any {
         return this.visit(ctx.normalTemplateBody());
@@ -213,6 +215,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
      * @param ctx The parse tree.
+     * @returns The result of visiting the normal template body.
      */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): any {
         const normalTemplateStrs: lp.TemplateStringContext[] = ctx.templateString();
@@ -239,6 +242,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
      * @param ctx The parse tree.
+     * @returns The string result of visiting the normal template string.
      */
     public visitNormalTemplateString(ctx: lp.NormalTemplateStringContext): string {
         const prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(ctx);
@@ -279,10 +283,10 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
 
     /**
      * Constructs the scope for mapping the values of arguments to the parameters of the template.
-     * Throws errors if certain errors detected TemplateErrors.
+     * Throws errors if certain errors detected [TemplateErrors](xref:botbuilder-lg.TemplateErrors).
      * @param inputTemplateName Template name to evaluate.
      * @param args Arguments to map to the template parameters.
-     * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory
+     * @returns The current scope if the number of arguments is 0, otherwise, returns a [CustomizedMemory](xref:botbuilder-lg.CustomizedMemory)
      * with the mapping of the parameter name to the argument value added to the scope.
      */
     public constructScope(inputTemplateName: string, args: any[]): any {
@@ -313,6 +317,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The string result of visiting the switch case body.
      */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): string {
         const switchcaseNodes: lp.SwitchCaseRuleContext[] = ctx.switchCaseTemplateBody().switchCaseRule();
@@ -350,7 +355,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     }
 
     /**
-     * Replaces an expression contained in a text.
+     * Replaces an expression contained in text.
      * @param exp Expression Text.
      * @param regex Regex to select the text to replace.
      */
@@ -359,7 +364,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     }
 
     /**
-     * Gets the default value returned by visitor methods. 
+     * Gets the default value returned by visitor methods.
      * @returns Empty string.
      */
     protected defaultResult(): string {
@@ -385,7 +390,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     }
 
     /**
-     * Checks an Expression Result and throws the corresponding error.
+     * Checks an expression result and throws the corresponding error.
      * @param exp Expression text.
      * @param error Error message.
      * @param result Result.

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -53,7 +53,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
      * Creates a new instance of the Expander class.
      * @param templates Template list.
      * @param expressionParser Given expression parser.
-     * @param opt Options for LG including strictMode, replaceNull and lineBreakStyle.
+     * @param opt Options for LG.
      */
     public constructor(templates: Template[], expressionParser: ExpressionParser, opt: EvaluationOptions = undefined) {
         super();
@@ -99,6 +99,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The result of visiting the normal body.
      */
     public visitNormalBody(ctx: lp.NormalBodyContext): any[] {
         return this.visit(ctx.normalTemplateBody());
@@ -107,6 +108,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
      * @param ctx The parse tree.
+     * @returns The result of visiting the normal template body.
      */
     public visitNormalTemplateBody(ctx: lp.NormalTemplateBodyContext): any[] {
         const normalTemplateStrs: lp.TemplateStringContext[] = ctx.templateString();
@@ -136,6 +138,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredBody.
      * @param ctx The parse tree.
+     * @returns The result of visiting the structured body.
      */
     public visitStructuredBody(ctx: lp.StructuredBodyContext): any[] {
         const templateRefValues: Map<string, any> = new Map<string, any>();
@@ -253,6 +256,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
      * @param ctx The parse tree.
+     * @returns The result of visiting the switch case body.
      */
     public visitSwitchCaseBody(ctx: lp.SwitchCaseBodyContext): any[] {
         const switchcaseNodes: lp.SwitchCaseRuleContext[] = ctx.switchCaseTemplateBody().switchCaseRule();

--- a/libraries/botbuilder-lg/src/extractor.ts
+++ b/libraries/botbuilder-lg/src/extractor.ts
@@ -20,7 +20,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     public readonly templateMap: {[name: string]: Template};
     
     /**
-     * Creates a new instance of the Extractor class.
+     * Creates a new instance of the [Extractor](xref:botbuilder-lg.Extractor) class.
      * @param templates Template list.
      */
     public constructor(templates: Template[]) {
@@ -61,6 +61,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
      * @param context The parse tree.
+     * @returns The result of visiting the normal template body.
      */
     public visitNormalTemplateBody(context: lp.NormalTemplateBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
@@ -74,6 +75,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     /**
      * Visit a parse tree produced by the structuredBody labeled alternative in LGTemplateParser.body.
      * @param context The parse tree.
+     * @returns The result of visiting the structured body.
      */
     public visitStructuredBody(context: lp.StructuredBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
@@ -90,6 +92,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
      * @param context The parse tree.
+     * @returns The result of visiting the if else body.
      */
     public visitIfElseBody(context: lp.IfElseBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();
@@ -125,6 +128,7 @@ export class Extractor extends AbstractParseTreeVisitor<Map<string, any>> implem
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
      * @param context The parse tree.
+     * @returns The result of visiting the switch case body.
      */
     public visitSwitchCaseBody(context: lp.SwitchCaseBodyContext): Map<string, any> {
         const result: Map<string, any> = new Map<string, any>();

--- a/libraries/botbuilder-lg/src/lgResource.ts
+++ b/libraries/botbuilder-lg/src/lgResource.ts
@@ -27,7 +27,7 @@ export class LGResource {
      */
 
     /**
-     * Creates a new instance of the LGResource class.
+     * Creates a new instance of the [LGResource](xref:botbuilder-lg.LGResource) class.
      * @param id Resource id.
      * @param fullName The full path to the resource on disk.
      * @param content Resource content.


### PR DESCRIPTION
Applied feedback from PR 2828 in MS.

- Added missing returns
- Minor fixes in comments
- Added xref links where possible

Missing to bring changes from main and solve conflicts.