### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs-declarative

### DIFF
--- a/libraries/botbuilder-dialogs-declarative/src/builderRegistration.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/builderRegistration.ts
@@ -12,7 +12,7 @@ import { TypeBuilder } from './factory/typeBuilder';
  */
 export class BuilderRegistration {
     /**
-     * Creates a new instance of the `BuilderRegistration` class.
+     * Creates a new instance of the [BuilderRegistration](xref:botbuilder-dialogs-declarative.BuilderRegistration) class.
      * @param name Name for the builder.
      * @param builder Type Builder.
      */

--- a/libraries/botbuilder-dialogs-declarative/src/converterRegistration.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/converterRegistration.ts
@@ -12,7 +12,7 @@ import { Converter } from './converter';
  */
 export class ConverterRegistration {
     /**
-     * Creates a new instance of the `ConverterRegistration` class.
+     * Creates a new instance of the [ConverterRegistration](xref:botbuilder-dialogs-declarative.ConverterRegistration) class.
      * @param name Name for the converter.
      * @param converter Converter.
      */

--- a/libraries/botbuilder-dialogs-declarative/src/factory/customTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/factory/customTypeBuilder.ts
@@ -12,9 +12,8 @@ import { TypeBuilder } from './typeBuilder';
  * Declarative custom type builder.
  */
 export class CustomTypeBuilder implements TypeBuilder {
-
     /**
-     * Creates a new instance of the `CustomTypeBuilder` class.
+     * Creates a new instance of the [CustomTypeBuilder](xref:botbuilder-dialogs-declarative.CustomTypeBuilder) class.
      * @param factory Factory for the custom type.
      */
     constructor(private factory: (config: object) => object) {}
@@ -22,6 +21,7 @@ export class CustomTypeBuilder implements TypeBuilder {
     /**
      * Builds a custom type.
      * @param config Configuration object for the type.
+     * @returns A new factory object for the custom type.
      */
     public build(config: object): object {
         return this.factory(config);

--- a/libraries/botbuilder-dialogs-declarative/src/factory/defaultTypeBuilder.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/factory/defaultTypeBuilder.ts
@@ -12,9 +12,8 @@ import { TypeBuilder } from './typeBuilder';
  * Declarative default type builder.
  */
 export class DefaultTypeBuilder implements TypeBuilder {
-
     /**
-     * Creates a new instance of the `DefaultTypeBuilder` class.
+     * Creates a new instance of the [DefaultTypeBuilder](xref:botbuilder-dialogs-declarative.DefaultTypeBuilder) class.
      * @param factory Factory for the default type.
      */
     constructor(private factory: new () => any) {}
@@ -22,6 +21,7 @@ export class DefaultTypeBuilder implements TypeBuilder {
     /**
      * Builds a default type.
      * @param config Configuration object for the type.
+     * @returns A new factory object for the default type.
      */
     public build(config: object) : object {
         return new this.factory();

--- a/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
@@ -213,7 +213,7 @@ export class ResourceExplorer {
     /**
      * @protected
      * Handler for on changed events.
-     * @param event Resource Change Event.
+     * @param event Resource change event.
      * @param resources A collection of resources to pass to the event handler.
      */
     protected onChanged(event: ResourceChangeEvent, resources: Resource[]): void {

--- a/libraries/botbuilder-dialogs-declarative/src/resources/resourceProvider.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/resourceProvider.ts
@@ -88,7 +88,7 @@ export abstract class ResourceProvider {
     /**
      * @protected
      * Actions to perform when the current object is changed.
-     * @param event Resource Change Event.
+     * @param event Resource change event.
      * @param resources A collection of changed resources.
      */
     protected onChanged(event: ResourceChangeEvent, resources: Resource[]): void {


### PR DESCRIPTION
PR 2837 in MS, #152 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.