### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-lg

### DIFF
--- a/libraries/botbuilder-lg/src/position.ts
+++ b/libraries/botbuilder-lg/src/position.ts
@@ -14,7 +14,7 @@ export class Position {
     public character: number;
 
     /**
-     * Creates a new instance of the Position class.
+     * Creates a new instance of the [Position](xref:botbuilder-lg.Position) class.
      * @param line Line number of the current position.
      * @param character Character number of the current line.
      */

--- a/libraries/botbuilder-lg/src/range.ts
+++ b/libraries/botbuilder-lg/src/range.ts
@@ -16,14 +16,28 @@ export class Range {
     public end: Position;
     public static readonly DefaultRange: Range = new Range(1, 0, 1, 0);
 
-    public constructor(start: Position, end: Position)
-    public constructor(startLine: number, startChar: number, endLine: number, endChar: number) 
     /**
-     * Creates a new instance of the Range class.
+     * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
+     * @param start Starting [Position](xref:botbuilder-lg.Position).
+     * @param end Ending [Position](xref:botbuilder-lg.Position).
+     */
+    public constructor(start: Position, end: Position)
+
+    /**
+     * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
      * @param x Starting line number in a file.
      * @param y Starting character number in a file.
      * @param endLine Ending line number in a file.
      * @param endChar Ending character number in the end line.
+     */
+    public constructor(startLine: number, startChar: number, endLine: number, endChar: number)
+
+    /**
+     * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
+     * @param x Starting line number in a file or [Position](xref:botbuilder-lg.Position).
+     * @param y Starting character number in a file or [Position](xref:botbuilder-lg.Position).
+     * @param endLine Optional. Ending line number in a file.
+     * @param endChar Optional. Ending character number in the end line.
      */
     public constructor(x: number|Position, y: number|Position, endLine?: number, endChar?: number){
         if (typeof x === 'number' && typeof y === 'number') {

--- a/libraries/botbuilder-lg/src/sourceRange.ts
+++ b/libraries/botbuilder-lg/src/sourceRange.ts
@@ -24,11 +24,24 @@ export class SourceRange {
      */
     public source: string;
 
-    public constructor(parseTree: ParserRuleContext, source?: string, offset?: number)
-    public constructor(range: Range, source?: string)
     /**
-     * Creates a new instance of the SourceRange class.
-     * @param x Rule invocation record for parsing.
+     * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     * @param parseTree `ParserRuleContext`. Rule invocation record for parsing.
+     * @param source Optional. Source, used as the lg file path.
+     * @param offset Optional. Offset in the parse tree.
+     */
+    public constructor(parseTree: ParserRuleContext, source?: string, offset?: number)
+
+    /**
+     * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     * @param range [Range](xref:botbuilder-lg.Range) of block.
+     * @param source Optional. Source, used as the lg file path.
+     */
+    public constructor(range: Range, source?: string)
+
+    /**
+     * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     * @param x [Range](xref:botbuilder-lg.Range) of block or `ParserRuleContext`, rule invocation record for parsing.
      * @param source Optional. Source, used as the lg file path.
      * @param offset Optional. Offset in the parse tree.
      */

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -28,8 +28,8 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     private _expressionParser: ExpressionParserInterface;
 
     /**
-     * Creates a new instance of the StaticChecker class.
-     * @param templates Templates to be checked.
+     * Creates a new instance of the [StaticChecker](xref:botbuilder-lg.StaticChecker) class.
+     * @param templates [Templates](xref:botbuilder-lg.Templates) to be checked.
      */
     public constructor(templates: Templates) {
         super();
@@ -90,7 +90,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     }
 
     /**
-     * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     * Visit a parse tree produced by `LGTemplateParser.normalTemplateBody`.
      * @param context The parse tree.
      */
     public visitNormalTemplateBody(context: lp.NormalTemplateBodyContext): Diagnostic[] {
@@ -109,7 +109,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     }
 
     /**
-     * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
+     * Visit a parse tree produced by `LGTemplateParser.structuredTemplateBody`.
      * @param context The parse tree.
      */
     public visitStructuredTemplateBody(context: lp.StructuredTemplateBodyContext): Diagnostic[] {
@@ -155,7 +155,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     }
 
     /**
-     * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     * Visit a parse tree produced by the `ifElseBody` labeled alternative in `LGTemplateParser.body`.
      * @param context The parse tree.
      */
     public visitIfElseBody(context: lp.IfElseBodyContext): Diagnostic[] {
@@ -218,7 +218,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     }
 
     /**
-     * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     * Visit a parse tree produced by the `switchCaseBody` labeled alternative in `LGTemplateParser.body`.
      * @param context The parse tree.
      */
     public visitSwitchCaseBody(context: lp.SwitchCaseBodyContext): Diagnostic[] {
@@ -287,7 +287,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     }
 
     /**
-     * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     * Visit a parse tree produced by `LGTemplateParser.normalTemplateString`.
      * @param context The parse tree.
      */
     public visitNormalTemplateString(context: lp.NormalTemplateStringContext): Diagnostic[] {
@@ -309,7 +309,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
 
     /**
      * Gets the default value returned by visitor methods.
-     * @returns Empty Diagnostic array.
+     * @returns Empty [Diagnostic](xref:botbuilder-lg.Diagnostic) array.
      */
     protected defaultResult(): Diagnostic[] {
         return [];

--- a/libraries/botbuilder-lg/src/template.ts
+++ b/libraries/botbuilder-lg/src/template.ts
@@ -33,11 +33,11 @@ export class Template {
     public templateBodyParseTree: lp.BodyContext;
 
     /**
-     * Creates a new instance of the Template class.
+     * Creates a new instance of the [Template](xref:botbuilder-lg.Template) class.
      * @param templatename Template name without parameters.
      * @param parameters Parameter list.
      * @param templatebody Template content.
-     * @param sourceRange Source range of template.
+     * @param sourceRange [SourceRange](xref:botbuilder-lg.SourceRange) of template.
      */
     public constructor(templatename: string, parameters: string[], templatebody: string, sourceRange: SourceRange) {
         this.name = templatename || '';
@@ -47,8 +47,8 @@ export class Template {
     }
 
     /**
-     * Returns a string representing the current Template object.
-     * @returns A string representing the Template.
+     * Returns a string representing the current [Template](xref:botbuilder-lg.Template) object.
+     * @returns A string representing the [Template](xref:botbuilder-lg.Template).
      */
     public toString(): string {
         return `[${ this.name }(${ this.parameters.join(', ') })]"${ this.body }"`;

--- a/libraries/botbuilder-lg/src/templateException.ts
+++ b/libraries/botbuilder-lg/src/templateException.ts
@@ -15,9 +15,9 @@ export class TemplateException  extends Error {
     private diagnostics: Diagnostic[];
     
     /**
-     * Creates a new instance of the TemplateException class.
+     * Creates a new instance of the [TemplateException](xref:botbuilder-lg.TemplateException) class.
      * @param m Error message.
-     * @param diagnostics List of diagnostics to throw.
+     * @param diagnostics List of [Diagnostic](xref:botbuilder-lg.Diagnostic) to throw.
      */
     public constructor(m: string, diagnostics: Diagnostic[]) {
         super(m);

--- a/libraries/botbuilder-lg/src/templateImport.ts
+++ b/libraries/botbuilder-lg/src/templateImport.ts
@@ -29,10 +29,10 @@ export class TemplateImport {
     public sourceRange: SourceRange;
 
     /**
-     * Creates a new instance of the TemplateImport class.
+     * Creates a new instance of the [TemplateImport](xref:botbuilder-lg.TemplateImport) class.
      * @param description Import description, which is in [].
      * @param id Import id, which is a path, in ().
-     * @param sourceRange Source range of template.
+     * @param sourceRange [SourceRange](xref:botbuilder-lg.SourceRange) of template.
      */
     public constructor(description: string, id: string, sourceRange: SourceRange) {
         this.description = description;

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -88,17 +88,17 @@ export class Templates implements Iterable<Template> {
     public options: string[];
 
     /**
-     * Creates a new instance of the Templates class.
-     * @param items List of Template instances.
-     * @param imports List of TemplateImport instances.
-     * @param diagnostics List of Diagnostic instances.
-     * @param references List of Templates instances.
-     * @param content Content of the current Templates instance.
-     * @param id Id of the current Templates instance.
-     * @param expressionParser ExpressionParser to parse the expressions in the content.
-     * @param importResolverDelegate Resolver to resolve LG import id to template text.
-     * @param options List of strings representing the options during evaluation of the templates.
-     * @param source Templates source.
+     * Creates a new instance of the [Templates](xref:botbuilder-lg.Templates) class.
+     * @param items Optional. List of [Template](xref:botbuilder-lg.Template) instances.
+     * @param imports Optional. List of [TemplateImport](xref:botbuilder-lg.TemplateImport) instances.
+     * @param diagnostics Optional. List of [Diagnostic](xref:botbuilder-lg.Diagnostic) instances.
+     * @param references Optional. List of [Templates](xref:botbuilder-lg.Templates) instances.
+     * @param content Optional. Content of the current Templates instance.
+     * @param id Optional. Id of the current Templates instance.
+     * @param expressionParser Optional. [ExpressionParser](xref:adaptive-expressions.ExpressionParser) to parse the expressions in the content.
+     * @param importResolverDelegate Optional. Resolver to resolve LG import id to template text.
+     * @param options Optional. List of strings representing the options during evaluation of the templates.
+     * @param source Optional. Templates source.
      */
     public constructor(items?: Template[],
         imports?: TemplateImport[],
@@ -396,8 +396,8 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * Returns a string representation of a Templates content.
-     * @returns A string representation of a Templates content.
+     * Returns a string representation of a [Templates](xref:botbuilder-lg.Templates) content.
+     * @returns A string representation of a [Templates](xref:botbuilder-lg.Templates) content.
      */
     public toString(): string {
         return this.content;

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -259,7 +259,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<any> implemen
     private readonly templates: Templates;
 
     /**
-     * Creates a new instance of the TemplatesTransformer class.
+     * Creates a new instance of the [TemplatesTransformer](xref:botbuilder-lg.TemplatesTransformer) class.
      * @param templates Templates.
      */
     public constructor(templates: Templates) {
@@ -297,7 +297,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<any> implemen
     }
 
     /**
-     * Visit a parse tree produced by LGFileParser.errorDefinition.
+     * Visit a parse tree produced by `LGFileParser.errorDefinition`.
      * @param context The parse tree.
      */
     public visitErrorDefinition(context: lp.ErrorDefinitionContext): any {
@@ -309,7 +309,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<any> implemen
     }
 
     /**
-     * Visit a parse tree produced by LGFileParser.importDefinition.
+     * Visit a parse tree produced by `LGFileParser.importDefinition`.
      * @param context The parse tree.
      */
     public visitImportDefinition(context: lp.ImportDefinitionContext): any {
@@ -326,7 +326,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<any> implemen
     }
 
     /**
-     * Visit a parse tree produced by LGFileParser.optionDefinition.
+     * Visit a parse tree produced by `LGFileParser.optionDefinition`.
      * @param context The parse tree.
      */
     public visitOptionDefinition(context: lp.OptionDefinitionContext): any {
@@ -346,7 +346,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<any> implemen
     }
 
     /**
-     * Visit a parse tree produced by LGFileParser.templateDefinition.
+     * Visit a parse tree produced by `LGFileParser.templateDefinition`.
      * @param context The parse tree.
      */
     public visitTemplateDefinition(context: lp.TemplateDefinitionContext): any {


### PR DESCRIPTION
PR 2830 in MS, #155 in SW

Feedback applied to use xref to link to other methods and missing documentation instances.

Changes requested for `Template` don't apply to our additions.
There's also one question regarding our C# port convention for private methods. The method `expressionParser` is documented for C#, so we ported it.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.