### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botframework-config

### DIFF
--- a/libraries/botframework-config/src/botRecipe.ts
+++ b/libraries/botframework-config/src/botRecipe.ts
@@ -88,9 +88,9 @@ export class BotRecipe {
     }
 
     /**
-     * Creates a new `BotRecipe` instance from a JSON object.
-     * @param source JSON object of `BotRecipe` type.
-     * @returns A new `BotRecipe` instance.
+     * Creates a new [BotRecipe](xref:botframework-config.BotRecipe) instance from a JSON object.
+     * @param source JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type.
+     * @returns A new [BotRecipe](xref:botframework-config.BotRecipe) instance.
      */
     public static fromJSON(source: Partial<BotRecipe> = {}): BotRecipe {
         const botRecipe: BotRecipe = new BotRecipe();
@@ -103,7 +103,7 @@ export class BotRecipe {
 
     /**
      * Creates a JSON object from `this` class instance.
-     * @returns A JSON object of `BotRecipe` type;
+     * @returns A JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type;
      */
     public toJSON(): Partial<BotRecipe> {
         const { version, resources } = this;


### PR DESCRIPTION
PR 2829 in MS, #154 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.