### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-2

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/ceiling.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ceiling.ts
@@ -14,7 +14,7 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  */
 export class Ceiling extends NumberTransformEvaluator {
     /**
-     * Initializes a new instance of the `Ceiling` class.
+     * Initializes a new instance of the [Ceiling](xref:adaptive-expressions.Ceiling) class.
      */
     public constructor() {
         super(ExpressionType.Ceiling, Ceiling.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/coalesce.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/coalesce.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Coalesce extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Coalesce` class.
+     * Initializes a new instance of the [Coalesce](xref:adaptive-expressions.Coalesce) class.
      */
     public constructor() {
         super(ExpressionType.Coalesce, Coalesce.evaluator(), ReturnType.Object, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/comparisonEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/comparisonEvaluator.ts
@@ -23,11 +23,11 @@ import { ReturnType } from '../returnType';
  */
 export class ComparisonEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `ComparisonEvaluator` class.
+     * Initializes a new instance of the [ComparisonEvaluator](xref:adaptive-expressions.ComparisonEvaluator) class.
      * @param type Name of the built-in function.
      * @param func The comparison function, it takes a list of objects and returns a boolean.
-     * @param validator Validator of input arguments.
-     * @param verify Optional. Function to verify each child's result.
+     * @param validator [ValidateExpressionDelegate](xref:adaptive-expressions.ValidateExpressionDelegate) for input arguments.
+     * @param verify Optional. [VerifyExpression](xref:adaptive-expressions.VerifyExpression) function to verify each child's result.
      */
     public constructor(
         type: string,

--- a/libraries/adaptive-expressions/src/builtinFunctions/concat.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/concat.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Concat extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Concat` class.
+     * Initializes a new instance of the [Concat](xref:adaptive-expressions.Concat) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/contains.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/contains.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Contains extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Contains` class.
+     * Initializes a new instance of the [Contains](xref:adaptive-expressions.Contains) class.
      */
     public constructor() {
         super(ExpressionType.Contains, Contains.evaluator, ReturnType.Boolean, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/convertFromUTC.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/convertFromUTC.ts
@@ -25,7 +25,7 @@ export class ConvertFromUTC extends ExpressionEvaluator {
     private static readonly NoneUtcDefaultDateTimeFormat: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
     /**
-     * Initializes a new instance of the `ConvertFromUTC` class.
+     * Initializes a new instance of the [ConvertFromUTC](xref:adaptive-expressions.ConvertFromUTC) class.
      */
     public constructor() {
         super(ExpressionType.ConvertFromUTC, ConvertFromUTC.evaluator, ReturnType.String, ConvertFromUTC.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/convertToUTC.ts
@@ -23,7 +23,7 @@ import { TimeZoneConverter } from '../timeZoneConverter';
  */
 export class ConvertToUTC extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `ConvertToUTC` class.
+     * Initializes a new instance of the [ConvertToUTC](xref:adaptive-expressions.ConvertToUTC) class.
      */
     public constructor() {
         super(ExpressionType.ConvertToUTC, ConvertToUTC.evaluator, ReturnType.String, ConvertToUTC.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/count.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/count.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Count extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Count` class.
+     * Initializes a new instance of the [Count](xref:adaptive-expressions.Count) class.
      */
     public constructor() {
         super(ExpressionType.Count, Count.evaluator(), ReturnType.Number, Count.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/countWord.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/countWord.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class CountWord extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `CountWord` class.
+     * Initializes a new instance of the [CountWord](xref:adaptive-expressions.CountWord) class.
      */
     public constructor() {
         super(ExpressionType.CountWord, CountWord.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/createArray.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/createArray.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class CreateArray extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `CreateArray` class.
+     * Initializes a new instance of the [CreateArray](xref:adaptive-expressions.CreateArray) class.
      */
     public constructor() {
         super(ExpressionType.CreateArray, CreateArray.evaluator(), ReturnType.Array);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUri.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUri.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class DataUri extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DataUri` class.
+     * Initializes a new instance of the [DataUri](xref:adaptive-expressions.DataUri) class.
      */
     public constructor() {
         super(ExpressionType.DataUri, DataUri.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUriToBinary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUriToBinary.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class DataUriToBinary extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DataUriToBinary` class.
+     * Initializes a new instance of the [DataUriToBinary](xref:adaptive-expressions.DataUriToBinary) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/dataUriToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dataUriToString.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class DataUriToString extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DataUriToString` class.
+     * Initializes a new instance of the [DataUriToString](xref:adaptive-expressions.DataUriToString) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateFunc.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateFunc.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class DateFunc extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DateFunc` class.
+     * Initializes a new instance of the [DateFunc](xref:adaptive-expressions.DateFunc) class.
      */
     public constructor() {
         super(ExpressionType.Date, DateFunc.evaluator(), ReturnType.String, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class DateReadBack extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DateReadBack` class.
+     * Initializes a new instance of the [DateReadBack](xref:adaptive-expressions.DateReadBack) class.
      */
     public constructor() {
         super(ExpressionType.DateReadBack, DateReadBack.evaluator(), ReturnType.String, DateReadBack.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class DateTimeDiff extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DateTimeDiff` class.
+     * Initializes a new instance of the [DateTimeDiff](xref:adaptive-expressions.DateTimeDiff) class.
      */
     public constructor() {
         super(ExpressionType.DateTimeDiff, DateTimeDiff.evaluator, ReturnType.Number, DateTimeDiff.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfMonth.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfMonth.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class DayOfMonth extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DayOfMonth` class.
+     * Initializes a new instance of the [DayOfMonth](xref:adaptive-expressions.DayOfMonth) class.
      */
     public constructor() {
         super(ExpressionType.DayOfMonth, DayOfMonth.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfWeek.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfWeek.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class DayOfWeek extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DayOfWeek` class.
+     * Initializes a new instance of the [DayOfWeek](xref:adaptive-expressions.DayOfWeek) class.
      */
     public constructor() {
         super(ExpressionType.DayOfWeek, DayOfWeek.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dayOfYear.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dayOfYear.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class DayOfYear extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `DayOfYear` class.
+     * Initializes a new instance of the [DayOfYear](xref:adaptive-expressions.DayOfYear) class.
      */
     public constructor() {
         super(ExpressionType.DayOfYear, DayOfYear.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
@@ -16,7 +16,7 @@ export class BotStateMemoryScope extends MemoryScope {
     protected stateKey: string;
 
     /**
-     * Initializes a new instance of the `BotStateMemoryScope` class.
+     * Initializes a new instance of the [BotStateMemoryScope](xref:adaptive-expressions.BotStateMemoryScope) class.
      * @param name name of the property.
      */
     public constructor(name: string) {


### PR DESCRIPTION
PR 2842 in MS, #162 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.