### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-1

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Accessor extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Accessor` class.
+     * Initializes a new instance of the [Accessor](adaptive-expressions.Accessor) class.
      */
     public constructor() {
         super(ExpressionType.Accessor, Accessor.evaluator, ReturnType.Object, Accessor.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/accessor.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Accessor extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Accessor](adaptive-expressions.Accessor) class.
+     * Initializes a new instance of the [Accessor](xref:adaptive-expressions.Accessor) class.
      */
     public constructor() {
         super(ExpressionType.Accessor, Accessor.evaluator, ReturnType.Object, Accessor.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/add.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/add.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Add extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Add](adaptive-expressions.Add) class.
+     * Initializes a new instance of the [Add](xref:adaptive-expressions.Add) class.
      */
     public constructor() {
         super(ExpressionType.Add, Add.evaluator(), ReturnType.String | ReturnType.Number, Add.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/add.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/add.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Add extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Add` class.
+     * Initializes a new instance of the [Add](adaptive-expressions.Add) class.
      */
     public constructor() {
         super(ExpressionType.Add, Add.evaluator(), ReturnType.String | ReturnType.Number, Add.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddDays extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the [AddDays](adaptive-expressions.AddDays) class.
+     * Initializes a new instance of the [AddDays](xref:adaptive-expressions.AddDays) class.
      */
     public constructor() {
         super(ExpressionType.AddDays, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'd').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addDays.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddDays extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the `AddDays` class.
+     * Initializes a new instance of the [AddDays](adaptive-expressions.AddDays) class.
      */
     public constructor() {
         super(ExpressionType.AddDays, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'd').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddHours extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the `AddHours` class.
+     * Initializes a new instance of the [AddHours](adaptive-expressions.AddHours) class.
      */
     public constructor() {
         super(ExpressionType.AddHours, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'h').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addHours.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddHours extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the [AddHours](adaptive-expressions.AddHours) class.
+     * Initializes a new instance of the [AddHours](xref:adaptive-expressions.AddHours) class.
      */
     public constructor() {
         super(ExpressionType.AddHours, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'h').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddMinutes extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the [AddMinutes](adaptive-expressions.AddMinutes) class.
+     * Initializes a new instance of the [AddMinutes](xref:adaptive-expressions.AddMinutes) class.
      */
     public constructor() {
         super(ExpressionType.AddMinutes, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'minutes').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addMinutes.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddMinutes extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the `AddMinutes` class.
+     * Initializes a new instance of the [AddMinutes](adaptive-expressions.AddMinutes) class.
      */
     public constructor() {
         super(ExpressionType.AddMinutes, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'minutes').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddOrdinal extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [AddOrdinal](adaptive-expressions.AddOrdinal) class.
+     * Initializes a new instance of the [AddOrdinal](xref:adaptive-expressions.AddOrdinal) class.
      */
     public constructor() {
         super(ExpressionType.AddOrdinal, AddOrdinal.evaluator(), ReturnType.String, AddOrdinal.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addOrdinal.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddOrdinal extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `AddOrdinal` class.
+     * Initializes a new instance of the [AddOrdinal](adaptive-expressions.AddOrdinal) class.
      */
     public constructor() {
         super(ExpressionType.AddOrdinal, AddOrdinal.evaluator(), ReturnType.String, AddOrdinal.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddProperty extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [AddProperty](adaptive-expressions.AddProperty) class.
+     * Initializes a new instance of the [AddProperty](xref:adaptive-expressions.AddProperty) class.
      */
     public constructor() {
         super(ExpressionType.AddProperty, AddProperty.evaluator(), ReturnType.Object, AddProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addProperty.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddProperty extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `AddProperty` class.
+     * Initializes a new instance of the [AddProperty](adaptive-expressions.AddProperty) class.
      */
     public constructor() {
         super(ExpressionType.AddProperty, AddProperty.evaluator(), ReturnType.Object, AddProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddSeconds extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the `AddSeconds` class.
+     * Initializes a new instance of the [AddSeconds](adaptive-expressions.AddSeconds) class.
      */
     public constructor() {
         super(ExpressionType.AddSeconds, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'seconds').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addSeconds.ts
@@ -16,7 +16,7 @@ import { TimeTransformEvaluator } from './timeTransformEvaluator';
  */
 export class AddSeconds extends TimeTransformEvaluator {
     /**
-     * Initializes a new instance of the [AddSeconds](adaptive-expressions.AddSeconds) class.
+     * Initializes a new instance of the [AddSeconds](xref:adaptive-expressions.AddSeconds) class.
      */
     public constructor() {
         super(ExpressionType.AddSeconds, (ts: Date, num: any): Date => moment(ts).utc().add(num, 'seconds').toDate());

--- a/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddToTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `AddToTime` class.
+     * Initializes a new instance of the [AddToTime](adaptive-expressions.AddToTime) class.
      */
     public constructor() {
         super(ExpressionType.AddToTime, AddToTime.evaluator, ReturnType.String, AddToTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/addToTime.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class AddToTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [AddToTime](adaptive-expressions.AddToTime) class.
+     * Initializes a new instance of the [AddToTime](xref:adaptive-expressions.AddToTime) class.
      */
     public constructor() {
         super(ExpressionType.AddToTime, AddToTime.evaluator, ReturnType.String, AddToTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/and.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/and.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class And extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `And` class.
+     * Initializes a new instance of the [And](adaptive-expressions.And) class.
      */
     public constructor() {
         super(ExpressionType.And, And.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/and.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/and.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class And extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [And](adaptive-expressions.And) class.
+     * Initializes a new instance of the [And](xref:adaptive-expressions.And) class.
      */
     public constructor() {
         super(ExpressionType.And, And.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/average.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/average.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Average extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Average](adaptive-expressions.Average) class.
+     * Initializes a new instance of the [Average](xref:adaptive-expressions.Average) class.
      */
     public constructor() {
         super(ExpressionType.Average, Average.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/average.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/average.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Average extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Average` class.
+     * Initializes a new instance of the [Average](adaptive-expressions.Average) class.
      */
     public constructor() {
         super(ExpressionType.Average, Average.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Base64 extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Base64](adaptive-expressions.Base64) class.
+     * Initializes a new instance of the [Base64](xref:adaptive-expressions.Base64) class.
      */
     public constructor() {
         super(ExpressionType.Base64, Base64.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Base64 extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Base64` class.
+     * Initializes a new instance of the [Base64](adaptive-expressions.Base64) class.
      */
     public constructor() {
         super(ExpressionType.Base64, Base64.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
@@ -19,7 +19,7 @@ import atob = require('atob-lite');
  */
 export class Base64ToBinary extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Base64ToBinary](adaptive-expressions.Base64ToBinary) class.
+     * Initializes a new instance of the [Base64ToBinary](xref:adaptive-expressions.Base64ToBinary) class.
      */
     public constructor() {
         super(ExpressionType.Base64ToBinary, Base64ToBinary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToBinary.ts
@@ -19,7 +19,7 @@ import atob = require('atob-lite');
  */
 export class Base64ToBinary extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Base64ToBinary` class.
+     * Initializes a new instance of the [Base64ToBinary](adaptive-expressions.Base64ToBinary) class.
      */
     public constructor() {
         super(ExpressionType.Base64ToBinary, Base64ToBinary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Base64ToString extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Base64ToString](adaptive-expressions.Base64ToString) class.
+     * Initializes a new instance of the [Base64ToString](xref:adaptive-expressions.Base64ToString) class.
      */
     public constructor() {
         super(ExpressionType.Base64ToString, Base64ToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/base64ToString.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Base64ToString extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Base64ToString` class.
+     * Initializes a new instance of the [Base64ToString](adaptive-expressions.Base64ToString) class.
      */
     public constructor() {
         super(ExpressionType.Base64ToString, Base64ToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Binary extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Binary` class.
+     * Initializes a new instance of the [Binary](adaptive-expressions.Binary) class.
      */
     public constructor() {
         super(ExpressionType.Binary, Binary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/binary.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Binary extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Binary](adaptive-expressions.Binary) class.
+     * Initializes a new instance of the [Binary](xref:adaptive-expressions.Binary) class.
      */
     public constructor() {
         super(ExpressionType.Binary, Binary.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Bool extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `Bool` class.
+     * Initializes a new instance of the [Bool](adaptive-expressions.Bool) class.
      */
     public constructor() {
         super(ExpressionType.Bool, Bool.func, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Bool extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the [Bool](adaptive-expressions.Bool) class.
+     * Initializes a new instance of the [Bool](xref:adaptive-expressions.Bool) class.
      */
     public constructor() {
         super(ExpressionType.Bool, Bool.func, FunctionUtils.validateUnary);


### PR DESCRIPTION
PR 2843 in MS, #165 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.

Regarding the requested changes: I believe the comment is out of scope, referencing _coding style_ on a linter spacing fix.