### PR TITLE
[internal] Apply xref links for adaptive-expressions/builtFunctions-3

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
@@ -16,7 +16,7 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  */
 export class Divide extends MultivariateNumericEvaluator {
     /**
-     * Initializes a new instance of the [Divide](adaptive-expressions.Divide) class.
+     * Initializes a new instance of the [Divide](xref:adaptive-expressions.Divide) class.
      */
     public constructor() {
         super(ExpressionType.Divide, Divide.func, Divide.verify);

--- a/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/divide.ts
@@ -16,7 +16,7 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  */
 export class Divide extends MultivariateNumericEvaluator {
     /**
-     * Initializes a new instance of the `Divide` class.
+     * Initializes a new instance of the [Divide](adaptive-expressions.Divide) class.
      */
     public constructor() {
         super(ExpressionType.Divide, Divide.func, Divide.verify);

--- a/libraries/adaptive-expressions/src/builtinFunctions/element.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/element.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Element extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Element](adaptive-expressions.Element) class.
+     * Initializes a new instance of the [Element](xref:adaptive-expressions.Element) class.
      */
     public constructor() {
         super(ExpressionType.Element, Element.evaluator, ReturnType.Object, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/element.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/element.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Element extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Element` class.
+     * Initializes a new instance of the [Element](adaptive-expressions.Element) class.
      */
     public constructor() {
         super(ExpressionType.Element, Element.evaluator, ReturnType.Object, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
@@ -19,7 +19,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Empty extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the [Empty](adaptive-expressions.Empty) class.
+     * Initializes a new instance of the [Empty](xref:adaptive-expressions.Empty) class.
      */
     public constructor() {
         super(ExpressionType.Empty, Empty.func, FunctionUtils.validateUnary, FunctionUtils.verifyContainer);

--- a/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/empty.ts
@@ -19,7 +19,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Empty extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `Empty` class.
+     * Initializes a new instance of the [Empty](adaptive-expressions.Empty) class.
      */
     public constructor() {
         super(ExpressionType.Empty, Empty.func, FunctionUtils.validateUnary, FunctionUtils.verifyContainer);

--- a/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class EndsWith extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `EndsWith` class.
+     * Initializes a new instance of the [EndsWith](adaptive-expressions.EndsWith) class.
      */
     public constructor() {
         super(ExpressionType.EndsWith, EndsWith.evaluator(), ReturnType.Boolean, EndsWith.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/endsWith.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class EndsWith extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [EndsWith](adaptive-expressions.EndsWith) class.
+     * Initializes a new instance of the [EndsWith](xref:adaptive-expressions.EndsWith) class.
      */
     public constructor() {
         super(ExpressionType.EndsWith, EndsWith.evaluator(), ReturnType.Boolean, EndsWith.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
@@ -17,7 +17,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Equal extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the [Equal](adaptive-expressions.Equal) class.
+     * Initializes a new instance of the [Equal](xref:adaptive-expressions.Equal) class.
      */
     public constructor() {
         super(ExpressionType.Equal, InternalFunctionUtils.isEqual, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/equal.ts
@@ -17,7 +17,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Equal extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `Equal` class.
+     * Initializes a new instance of the [Equal](adaptive-expressions.Equal) class.
      */
     public constructor() {
         super(ExpressionType.Equal, InternalFunctionUtils.isEqual, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
@@ -15,7 +15,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Exists extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `Exists` class.
+     * Initializes a new instance of the [Exists](adaptive-expressions.Exists) class.
      */
     public constructor() {
         super(ExpressionType.Exists, Exists.func, FunctionUtils.validateUnary, FunctionUtils.verifyNotNull);

--- a/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/exists.ts
@@ -15,7 +15,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class Exists extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the [Exists](adaptive-expressions.Exists) class.
+     * Initializes a new instance of the [Exists](xref:adaptive-expressions.Exists) class.
      */
     public constructor() {
         super(ExpressionType.Exists, Exists.func, FunctionUtils.validateUnary, FunctionUtils.verifyNotNull);

--- a/libraries/adaptive-expressions/src/builtinFunctions/first.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/first.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class First extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [First](adaptive-expressions.First) class.
+     * Initializes a new instance of the [First](xref:adaptive-expressions.First) class.
      */
     public constructor() {
         super(ExpressionType.First, First.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/first.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/first.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class First extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `First` class.
+     * Initializes a new instance of the [First](adaptive-expressions.First) class.
      */
     public constructor() {
         super(ExpressionType.First, First.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Flatten extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Flatten](adaptive-expressions.Flatten) class.
+     * Initializes a new instance of the [Flatten](xref:adaptive-expressions.Flatten) class.
      */
     public constructor() {
         super(ExpressionType.Flatten, Flatten.evaluator(), ReturnType.Array, Flatten.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/flatten.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Flatten extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Flatten` class.
+     * Initializes a new instance of the [Flatten](adaptive-expressions.Flatten) class.
      */
     public constructor() {
         super(ExpressionType.Flatten, Flatten.evaluator(), ReturnType.Array, Flatten.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/float.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/float.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Float extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Float](adaptive-expressions.Float) class.
+     * Initializes a new instance of the [Float](xref:adaptive-expressions.Float) class.
      */
     public constructor() {
         super(ExpressionType.Float, Float.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/float.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/float.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Float extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Float` class.
+     * Initializes a new instance of the [Float](adaptive-expressions.Float) class.
      */
     public constructor() {
         super(ExpressionType.Float, Float.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
@@ -14,7 +14,7 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  */
 export class Floor extends NumberTransformEvaluator {
     /**
-     * Initializes a new instance of the [Floor](adaptive-expressions.Floor) class.
+     * Initializes a new instance of the [Floor](xref:adaptive-expressions.Floor) class.
      */
     public constructor() {
         super(ExpressionType.Floor, Floor.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/floor.ts
@@ -14,7 +14,7 @@ import { NumberTransformEvaluator } from './numberTransformEvaluator';
  */
 export class Floor extends NumberTransformEvaluator {
     /**
-     * Initializes a new instance of the `Floor` class.
+     * Initializes a new instance of the [Floor](adaptive-expressions.Floor) class.
      */
     public constructor() {
         super(ExpressionType.Floor, Floor.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Foreach extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Foreach` class.
+     * Initializes a new instance of the [Foreach](adaptive-expressions.Foreach) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/foreach.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Foreach extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [Foreach](adaptive-expressions.Foreach) class.
+     * Initializes a new instance of the [Foreach](xref:adaptive-expressions.Foreach) class.
      */
     public constructor() {
         super(


### PR DESCRIPTION
PR 2844 in MS, #166 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.