### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-4

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatDateTime.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class FormatDateTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `FormatDateTime` class.
+     * Initializes a new instance of the [FormatDateTime](xref:adaptive-expressions.FormatDateTime) class.
      */
     public constructor() {
         super(ExpressionType.FormatDateTime, FormatDateTime.evaluator(), ReturnType.String, FormatDateTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatEpoch.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class FormatEpoch extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `FormatEpoch` class.
+     * Initializes a new instance of the [FormatEpoch](xref:adaptive-expressions.FormatEpoch) class.
      */
     public constructor() {
         super(ExpressionType.FormatEpoch, FormatEpoch.evaluator(), ReturnType.String, FormatEpoch.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class FormatNumber extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `FormatNumber` class.
+     * Initializes a new instance of the [FormatNumber](xref:adaptive-expressions.FormatNumber) class.
      */
     public constructor() {
         super(ExpressionType.FormatNumber, FormatNumber.evaluator(), ReturnType.String, FormatNumber.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatTicks.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class FormatTicks extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `FormatTicks` class.
+     * Initializes a new instance of the [FormatTicks](xref:adaptive-expressions.FormatTicks) class.
      */
     public constructor() {
         super(ExpressionType.FormatTicks, FormatTicks.evaluator(), ReturnType.String, FormatTicks.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getFutureTime.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class GetFutureTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetFutureTime` class.
+     * Initializes a new instance of the [GetFutureTime](xref:adaptive-expressions.GetFutureTime) class.
      */
     public constructor() {
         super(ExpressionType.GetFutureTime, GetFutureTime.evaluator, ReturnType.String, GetFutureTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
@@ -24,7 +24,7 @@ import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expr
  */
 export class GetNextViableDate extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetNextViableDate` class.
+     * Initializes a new instance of the [GetNextViableDate](xref:adaptive-expressions.GetNextViableDate) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
@@ -23,7 +23,7 @@ import { TimexProperty, Time } from '@microsoft/recognizers-text-data-types-time
  */
 export class GetNextViableTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetNextViableTime` class.
+     * Initializes a new instance of the [GetNextViableTime](xref:adaptive-expressions.GetNextViableTime) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPastTime.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class GetPastTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetPastTime` class.
+     * Initializes a new instance of the [GetPastTime](xref:adaptive-expressions.GetPastTime) class.
      */
     public constructor() {
         super(ExpressionType.GetPastTime, GetPastTime.evaluator, ReturnType.String, GetPastTime.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
@@ -24,7 +24,7 @@ import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expr
  */
 export class GetPreviousViableDate extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetPreviousViableDate` class.
+     * Initializes a new instance of the [GetPreviousViableDate](xref:adaptive-expressions.GetPreviousViableDate) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
@@ -23,7 +23,7 @@ import { TimexProperty, Time } from '@microsoft/recognizers-text-data-types-time
  */
 export class GetPreviousViableTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetPreviousViableTime` class.
+     * Initializes a new instance of the [GetPreviousViableTime](xref:adaptive-expressions.GetPreviousViableTime) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getProperty.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class GetProperty extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetProperty` class.
+     * Initializes a new instance of the [GetProperty](xref:adaptive-expressions.GetProperty) class.
      */
     public constructor() {
         super(ExpressionType.GetProperty, GetProperty.evaluator, ReturnType.Object, GetProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getTimeOfDay.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class GetTimeOfDay extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `GetTimeOfDay` class.
+     * Initializes a new instance of the [GetTimeOfDay](xref:adaptive-expressions.GetTimeOfDay) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThan.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class GreaterThan extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `GreaterThan` class.
+     * Initializes a new instance of the [GreaterThan](xref:adaptive-expressions.GreaterThan) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/greaterThanOrEqual.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class GreaterThanOrEqual extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `GreaterThanOrEqual` class.
+     * Initializes a new instance of the [GreaterThanOrEqual](xref:adaptive-expressions.GreaterThanOrEqual) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/if.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/if.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class If extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `If` class.
+     * Initializes a new instance of the [If](xref:adaptive-expressions.If) class.
      */
     public constructor() {
         super(ExpressionType.If, If.evaluator, ReturnType.Object, If.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ignore.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Ignore extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Ignore` class.
+     * Initializes a new instance of the [Ignore](xref:adaptive-expressions.Ignore) class.
      */
     public constructor() {
         super(ExpressionType.Ignore, Ignore.evaluator, ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);


### PR DESCRIPTION
PR 2845 in MS, #167 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.