### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-core

### DIFF
--- a/libraries/botbuilder-core/src/activityFactory.ts
+++ b/libraries/botbuilder-core/src/activityFactory.ts
@@ -96,9 +96,9 @@ export class ActivityFactory {
     }
 
     /**
-     * Builds an Activity with a given message.
+     * Builds an [Activity](xref:botframework-schema.Activity) with a given message.
      * @param messageValue Message value on which to base the activity.
-     * @returns Activity with the given message.
+     * @returns [Activity](xref:botframework-schema.Activity) with the given message.
      */
     private static buildActivity(messageValue: any): Partial<Activity> {
         let activity: Partial<Activity> = { type: ActivityTypes.Message };

--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -866,9 +866,9 @@ export class ActivityHandler extends ActivityHandlerBase {
     }
 
     /**
-     * An InvokeResponse factory that initializes the body to the parameter passed and status equal to OK.
+     * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
      * @param body JSON serialized content from a POST response.
-     * @returns A new InvokeResponse object.
+     * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
      */
     protected static createInvokeResponse(body?: any): InvokeResponse {
         return { status: 200, body };

--- a/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
+++ b/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
@@ -59,7 +59,7 @@ export class AutoSaveStateMiddleware implements Middleware {
     }
 
     /**
-     * Called by the adapter (for example, a `BotFrameworkAdapter`) at runtime in order to process an inbound `Activity`.
+     * Called by the adapter (for example, a `BotFrameworkAdapter`) at runtime in order to process an inbound [Activity](xref:botframework-schema.Activity).
      * @param context The context object for this turn.
      * @param next {function} The next delegate function.
      */

--- a/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
+++ b/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
@@ -11,9 +11,9 @@ import { TurnContext } from './turnContext';
 /**
  * Defines methods for accessing a state property created in a
  * [BotState](xref:botbuilder-core.BotState) object.
- * 
+ *
  * @typeparam T Optional. The type of the state property to access. Default type is `any`.
- * 
+ *
  * @remarks
  * To create a state property in a state management objet, use the
  * [createProperty\<T>](xref:botbuilder-core.BotState.createProperty) method.
@@ -91,7 +91,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     /**
      * Deletes the persisted property from its backing storage object.
-     * @param context Context object for this turn.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      */
     public async delete(context: TurnContext): Promise<void> {
         const obj: any = await this.state.load(context);
@@ -100,11 +100,22 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
         }
     }
 
+    /**
+     * Reads a persisted property from its backing storage object.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
+     * @returns A JSON representation of the cached state.
+     */
     public async get(context: TurnContext): Promise<T|undefined>;
+    /**
+     * Reads a persisted property from its backing storage object.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
+     * @param defaultValue Default value for the property.
+     * @returns A JSON representation of the cached state.
+     */
     public async get(context: TurnContext, defaultValue: T): Promise<T>;
     /**
      * Reads a persisted property from its backing storage object.
-     * @param context Context object for this turn.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param defaultValue Optional. Default value for the property.
      * @returns A JSON representation of the cached state.
      */
@@ -121,7 +132,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     /**
      * Assigns a new value to the properties backing storage object.
-     * @param context Context object for this turn.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param value Value to set on the property.
      */
     public async set(context: TurnContext, value: T): Promise<void> {

--- a/libraries/botbuilder-core/src/botTelemetryClient.ts
+++ b/libraries/botbuilder-core/src/botTelemetryClient.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-    
+
 /**
  * Defines the level of severity for the event.
  */
@@ -36,7 +36,7 @@ export interface TelemetryDependency {
     target: string;
     name: string;
     data: string;
-    duration: number; 
+    duration: number;
     success: boolean;
     resultCode: number;
 }
@@ -47,7 +47,7 @@ export interface TelemetryEvent {
     metrics?: {[key: string]: number };
 }
 
-export interface TelemetryException { 
+export interface TelemetryException {
     exception: Error;
     handledAt?: string;
     properties?: {[key: string]: string};
@@ -68,12 +68,12 @@ export interface TelemetryPageView {
 }
 
 /**
- * A null bot telemetry client that implements `IBotTelemetryClient`.
+ * A null bot telemetry client that implements [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient).
  */
 export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelemetryClient {
 
     /**
-     * Creates a new instance of the `NullTelemetryClient` class.
+     * Creates a new instance of the [NullTelemetryClient](xref:botbuilder-core.NullTelemetryClient) class.
      * @param settings Optional. Settings for the telemetry client.
      */
     constructor(settings?: any) {
@@ -82,7 +82,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs an Application Insights page view.
-     * @param telemetry Telemetry Page View.
+     * @param telemetry An object implementing [TelemetryPageView](xref:botbuilder-core.TelemetryPageView).
      */
     trackPageView(telemetry: TelemetryPageView) {
         // noop
@@ -90,7 +90,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Sends information about an external dependency (outgoing call) in the application.
-     * @param telemetry Telemetry Dependency.
+     * @param telemetry An object implementing [TelemetryDependency](xref:botbuilder-core.TelemetryDependency).
      */
     trackDependency(telemetry: TelemetryDependency) {
         // noop
@@ -98,7 +98,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs custom events with extensible named fields.
-     * @param telemetry Telemetry Event.
+     * @param telemetry An object implementing [TelemetryEvent](xref:botbuilder-core.TelemetryEvent).
      */
     trackEvent(telemetry: TelemetryEvent) {
         // noop
@@ -106,7 +106,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs a system exception.
-     * @param telemetry Telemetry Exception to log.
+     * @param telemetry An object implementing [TelemetryException](xref:botbuilder-core.TelemetryException).
      */
     trackException(telemetry: TelemetryException)  {
         // noop
@@ -114,7 +114,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Sends a trace message.
-     * @param telemetry Telemetry Trace.
+     * @param telemetry An object implementing [TelemetryTrace](xref:botbuilder-core.TelemetryTrace).
      */
     trackTrace(telemetry: TelemetryTrace) {
         // noop
@@ -129,9 +129,9 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 }
 
 /**
- * Logs a DialogView using the TrackPageView method on the BotTelemetryClient if BotPageViewTelemetryClient has been implemented.
+ * Logs a DialogView using the [trackPageView](xref:botbuilder-core.BotTelemetryClient.trackPageView) method on the [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient) if [BotPageViewTelemetryClient](xref:botbuilder-core.BotPageViewTelemetryClient) has been implemented.
  * Alternatively logs the information out via TrackTrace.
- * @param telemetryClient TelemetryClient that implements BotTelemetryClient.
+ * @param telemetryClient TelemetryClient that implements [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient).
  * @param dialogName Name of the dialog to log the entry / start for.
  * @param properties Named string values you can use to search and classify events.
  * @param metrics Measurements associated with this event.

--- a/libraries/botbuilder-core/src/browserStorage.ts
+++ b/libraries/botbuilder-core/src/browserStorage.ts
@@ -22,7 +22,7 @@ import { MemoryStorage } from './memoryStorage';
  */
 export class BrowserLocalStorage extends MemoryStorage {
     /**
-     * Creates a new BrowserLocalStorage instance.
+     * Creates a new [BrowserLocalStorage](xref:botbuilder-core.BrowserLocalStorage) instance.
      */
     public constructor() {
         super(localStorage as any);
@@ -46,7 +46,7 @@ export class BrowserLocalStorage extends MemoryStorage {
  */
 export class BrowserSessionStorage extends MemoryStorage {
     /**
-     * Creates a new BrowserSessionStorage instance.
+     * Creates a new [BrowserSessionStorage](xref:botbuilder-core.BrowserSessionStorage) instance.
      */
     public constructor() {
         super(sessionStorage as any);

--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -47,7 +47,8 @@ export class CardFactory {
      * Returns an attachment for an Adaptive Card.
      *
      * @param card A description of the Adaptive Card to return.
-     * 
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
      * @remarks
      * Adaptive Cards are an open card exchange format enabling developers to exchange UI content in a common and consistent way.
      * For channels that don't yet support Adaptive Cards natively, the Bot Framework will
@@ -85,12 +86,13 @@ export class CardFactory {
 
     /**
      * Returns an attachment for an animation card.
-     * 
+     *
      * @param title The card title.
      * @param media The media URLs for the card.
      * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
      *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
      */
     public static animationCard(
         title: string,
@@ -103,12 +105,13 @@ export class CardFactory {
 
     /**
      * Returns an attachment for an audio card.
-     * 
+     *
      * @param title The card title.
      * @param media The media URL for the card.
      * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
      *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
      */
     public static audioCard(
         title: string,
@@ -123,17 +126,16 @@ export class CardFactory {
      * Returns an attachment for a hero card.
      *
      * @param title The card title.
-     * @param text Optional. The card text.
      * @param images Optional. The array of images to include on the card. Each element can be a
      *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
      * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
      *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
-     * 
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
      * @remarks
      * Hero cards tend to have one dominant, full-width image.
      * Channels typically render the card's text and buttons below the image.
-     * 
      * For example:
      * ```javascript
      * const card = CardFactory.heroCard(
@@ -149,6 +151,30 @@ export class CardFactory {
         buttons?: (CardAction | string)[],
         other?: Partial<HeroCard>
     ): Attachment;
+    /**
+     * Returns an attachment for a hero card.
+     *
+     * @param title The card title.
+     * @param text The card text.
+     * @param images Optional. The array of images to include on the card. Each element can be a
+     *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
+     * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
+     *      is converted to an `imBack` button with a title and value set to the value of the string.
+     * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
+     * @remarks
+     * Hero cards tend to have one dominant, full-width image.
+     * Channels typically render the card's text and buttons below the image.
+     * For example:
+     * ```javascript
+     * const card = CardFactory.heroCard(
+     *      'White T-Shirt',
+     *      ['https://example.com/whiteShirt.jpg'],
+     *      ['buy']
+     * );
+     * ```
+     */
     public static heroCard(
         title: string,
         text: string,
@@ -161,9 +187,24 @@ export class CardFactory {
      *
      * @param title The card title.
      * @param text Optional. The card text.
-     * @param images Optional. Images to include on the card.
-     * @param buttons Optional. Buttons to include on the card.
+     * @param images Optional. The array of images to include on the card. Each element can be a
+     *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
+     * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
+     *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
+     * @remarks
+     * Hero cards tend to have one dominant, full-width image.
+     * Channels typically render the card's text and buttons below the image.
+     * For example:
+     * ```javascript
+     * const card = CardFactory.heroCard(
+     *      'White T-Shirt',
+     *      ['https://example.com/whiteShirt.jpg'],
+     *      ['buy']
+     * );
+     * ```
      */
     public static heroCard(
         title: string,
@@ -179,12 +220,13 @@ export class CardFactory {
 
     /**
      * Returns an attachment for an OAuth card.
-     * 
+     *
      * @param connectionName The name of the OAuth connection to use.
      * @param title The title for the card's sign-in button.
      * @param text Optional. Additional text to include on the card.
      * @param link Optional. The sign-in link to use.
-     * 
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
      * @remarks
      * OAuth cards support the Bot Framework's single sign on (SSO) service.
      */
@@ -206,7 +248,8 @@ export class CardFactory {
     * Returns an attachment for an Office 365 connector card.
     *
     * @param card a description of the Office 365 connector card to return.
-    * 
+    * @returns An [Attachment](xref:botframework-schema.Attachment).
+    *
     * @remarks
     * For example:
     * ```JavaScript
@@ -231,8 +274,9 @@ export class CardFactory {
 
     /**
      * Returns an attachment for a receipt card.
-     * 
+     *
      * @param card A description of the receipt card to return.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
      */
     public static receiptCard(card: ReceiptCard): Attachment {
         return { contentType: CardFactory.contentTypes.receiptCard, content: card };
@@ -244,7 +288,8 @@ export class CardFactory {
      * @param title The title for the card's sign-in button.
      * @param url The URL of the sign-in page to use.
      * @param text Optional. Additional text to include on the card.
-     * 
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
      * @remarks
      * For channels that don't natively support sign-in cards, an alternative message is rendered.
      */
@@ -259,13 +304,13 @@ export class CardFactory {
      * Returns an attachment for a thumbnail card.
      *
      * @param title The card title.
-     * @param text Optional. The card text.
      * @param images Optional. The array of images to include on the card. Each element can be a
      *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
      * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
      *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
-     * 
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
      * @remarks
      * Thumbnail cards are similar to hero cards but instead of a full width image,
      * they're typically rendered with a smaller thumbnail version of the image.
@@ -278,6 +323,24 @@ export class CardFactory {
         buttons?: (CardAction | string)[],
         other?: Partial<ThumbnailCard>
     ): Attachment;
+    /**
+     * Returns an attachment for a thumbnail card.
+     *
+     * @param title The card title.
+     * @param text The card text.
+     * @param images Optional. The array of images to include on the card. Each element can be a
+     *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
+     * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
+     *      is converted to an `imBack` button with a title and value set to the value of the string.
+     * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
+     * @remarks
+     * Thumbnail cards are similar to hero cards but instead of a full width image,
+     * they're typically rendered with a smaller thumbnail version of the image.
+     * Channels typically render the card's text to one side of the image,
+     * with any buttons displayed below the card.
+     */
     public static thumbnailCard(
         title: string,
         text: string,
@@ -290,9 +353,18 @@ export class CardFactory {
      *
      * @param title The card title.
      * @param text Optional. The card text.
-     * @param images Optional. Images to include on the card.
-     * @param buttons Optional. Buttons to include on the card.
+     * @param images Optional. The array of images to include on the card. Each element can be a
+     *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
+     * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
+     *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
+     * @remarks
+     * Thumbnail cards are similar to hero cards but instead of a full width image,
+     * they're typically rendered with a smaller thumbnail version of the image.
+     * Channels typically render the card's text to one side of the image,
+     * with any buttons displayed below the card.
      */
     public static thumbnailCard(
         title: string,
@@ -318,12 +390,13 @@ export class CardFactory {
 
     /**
      * Returns an attachment for a video card.
-     * 
+     *
      * @param title The card title.
      * @param media The media URLs for the card.
      * @param buttons Optional. The array of buttons to include on the card. Each `string` in the array
      *      is converted to an `imBack` button with a title and value set to the value of the string.
      * @param other Optional. Any additional properties to include on the card.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
      */
     public static videoCard(
         title: string,
@@ -355,7 +428,7 @@ export class CardFactory {
 
     /**
      * Returns a properly formatted array of card images.
-     * 
+     *
      * @param images The array of images to include on the card. Each element can be a
      *      [CardImage](ref:botframework-schema.CardImage) or the URL of the image to include.
      */
@@ -374,7 +447,7 @@ export class CardFactory {
 
     /**
      * Returns a properly formatted array of media URL objects.
-     * 
+     *
      * @param links The media URLs. Each `string` is converted to a media URL object.
      */
     public static media(links: (MediaUrl | string)[] | undefined): MediaUrl[] {

--- a/libraries/botbuilder-core/src/memoryStorage.ts
+++ b/libraries/botbuilder-core/src/memoryStorage.ts
@@ -39,7 +39,7 @@ export class MemoryStorage  implements Storage {
 
     /**
      * Reads storage items from storage.
-     * @param keys Keys of the `StoreItem` objects to read.
+     * @param keys Keys of the [StoreItems](xref:botbuilder-core.StoreItems) objects to read.
      * @returns The read items.
      */
     public read(keys: string[]): Promise<StoreItems> {
@@ -58,7 +58,7 @@ export class MemoryStorage  implements Storage {
 
     /**
      * Writes storage items to storage.
-     * @param changes The items to write, indexed by key.
+     * @param changes The [StoreItems](xref:botbuilder-core.StoreItems) to write, indexed by key.
      */
     public write(changes: StoreItems): Promise<void> {
         const that: MemoryStorage = this;
@@ -90,7 +90,7 @@ export class MemoryStorage  implements Storage {
 
     /**
      * Deletes storage items from storage.
-     * @param keys Keys of the objects to delete.
+     * @param keys Keys of the [StoreItems](xref:botbuilder-core.StoreItems) objects to delete.
      */
     public delete(keys: string[]): Promise<void> {
         return new Promise<void>((resolve: any, reject: any): void => {

--- a/libraries/botbuilder-core/src/middlewareSet.ts
+++ b/libraries/botbuilder-core/src/middlewareSet.ts
@@ -79,7 +79,7 @@ export class MiddlewareSet implements Middleware {
 
     /**
      * Processes an incoming activity.
-     * @param context Context object for this turn.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param next Delegate to call to continue the bot middleware pipeline.
      */
     public onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -24,7 +24,7 @@ import { TurnContext } from './turnContext';
 export class SkypeMentionNormalizeMiddleware implements Middleware {
     /**
      * Performs the normalization of Skype mention Entities.
-     * @param activity Activity containing the mentions to normalize.
+     * @param activity [Activity](xref:botframework-schema.Activity) containing the mentions to normalize.
      */
     public static normalizeSkypeMentionText(activity: Activity): void {
         if (activity.channelId === 'skype' && activity.type === 'message'){
@@ -42,8 +42,8 @@ export class SkypeMentionNormalizeMiddleware implements Middleware {
     }
 
     /**
-     * Middleware implementation which corrects Entity.Mention.Text to a value RemoveMentionText can work with.
-     * @param turnContext Context for the current turn of conversation.
+     * Middleware implementation which corrects the Entity text of type [Mention](xref:botframework-schema.Mention) to a value that [removeMentionText](xref:botbuilder-core.TurnContext.removeMentionText) can work with.
+     * @param turnContext [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation.
      * @param next Delegate to call to continue the bot middleware pipeline.
      */
     public async onTurn(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -467,10 +467,11 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Gets a sign-in resource.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User ID
      * @param finalRedirect Final redirect URL.
+     * @returns A `Promise` with a new [SignInUrlResponse](xref:botframework-schema.SignInUrlResponse) object.
      */
     public async getSignInResource(context: TurnContext, connectionName: string, userId?: string, finalRedirect?: string): Promise<SignInUrlResponse> {
         return {
@@ -486,7 +487,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Performs a token exchange operation such as for single sign-on.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User id associated with the token.
      * @param tokenExchangeRequest Exchange request details, either a token to exchange or a uri to exchange.

--- a/libraries/botbuilder-core/src/turnContextStateCollection.ts
+++ b/libraries/botbuilder-core/src/turnContextStateCollection.ts
@@ -6,9 +6,9 @@
 const TURN_STATE_SCOPE_CACHE = Symbol('turnStateScopeCache');
 
 /**
- * Values persisted for the lifetime of the turn as part of the `TurnContext`.
+ * Values persisted for the lifetime of the turn as part of the [TurnContext](xref:botbuilder-core.TurnContext).
  * @remarks Typical values stored here are objects which are needed for the lifetime of a turn, such
- * as `Storage`, `BotState`, `ConversationState`, `LanguageGenerator`, `ResourceExplorer`, etc.
+ * as [Storage](xref:botbuilder-core.Storage), [BotState](xref:botbuilder-core.BotState), [ConversationState](xref:botbuilder-core.ConversationState), [LanguageGenerator](xref:botbuilder-dialogs-adaptive.LanguageGenerator), [ResourceExplorer](xref:botbuilder-dialogs-declarative.ResourceExplorer), etc.
  */
 export class TurnContextStateCollection extends Map<any, any> {
     /**


### PR DESCRIPTION
PR 2832 in MS, #157 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.