### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-5

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/indexOf.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/indexOf.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class IndexOf extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IndexOf` class.
+     * Initializes a new instance of the [IndexOf](xref:adaptive-expressions.IndexOf) class.
      */
     public constructor() {
         super(ExpressionType.IndexOf, IndexOf.evaluator, ReturnType.Number, IndexOf.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/indicesAndValues.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/indicesAndValues.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class IndicesAndValues extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IndicesAndValues` class.
+     * Initializes a new instance of the [IndicesAndValues](xref:adaptive-expressions.IndicesAndValues) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/int.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/int.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Int extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Int` class.
+     * Initializes a new instance of the [Int](xref:adaptive-expressions.Int) class.
      */
     public constructor() {
         super(ExpressionType.Int, Int.evaluator(), ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/intersection.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/intersection.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class Intersection extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Intersection` class.
+     * Initializes a new instance of the [Intersection](xref:adaptive-expressions.Intersection) class.
      */
     public constructor() {
         super(ExpressionType.Intersection, Intersection.evaluator(), ReturnType.Array, Intersection.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isArray.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isArray.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsArray extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsArray` class.
+     * Initializes a new instance of the [IsArray](xref:adaptive-expressions.IsArray) class.
      */
     public constructor() {
         super(ExpressionType.IsArray, IsArray.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isBoolean.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isBoolean.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsBoolean extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsBoolean` class.
+     * Initializes a new instance of the [IsBoolean](xref:adaptive-expressions.IsBoolean) class.
      */
     public constructor() {
         super(ExpressionType.IsBoolean, IsBoolean.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
@@ -23,7 +23,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsDate extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsDate` class.
+     * Initializes a new instance of the [IsDate](xref:adaptive-expressions.IsDate) class.
      */
     public constructor() {
         super(ExpressionType.IsDate, IsDate.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsDateRange extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsDateRange` class.
+     * Initializes a new instance of the [IsDateRange](xref:adaptive-expressions.IsDateRange) class.
      */
     public constructor() {
         super(ExpressionType.IsDateRange, IsDateRange.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDateTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDateTime.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsDateTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsDateTime` class.
+     * Initializes a new instance of the [IsDateTime](xref:adaptive-expressions.IsDateTime) class.
      */
     public constructor() {
         super(ExpressionType.IsDateTime, IsDateTime.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsDefinite extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsDefinite` class.
+     * Initializes a new instance of the [IsDefinite](xref:adaptive-expressions.IsDefinite) class.
      */
     public constructor() {
         super(ExpressionType.IsDefinite, IsDefinite.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsDuration extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsDuration` class.
+     * Initializes a new instance of the [IsDuration](xref:adaptive-expressions.IsDuration) class.
      */
     public constructor() {
         super(ExpressionType.IsDuration, IsDuration.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isFloat.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isFloat.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsFloat extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsFloat` class.
+     * Initializes a new instance of the [IsFloat](xref:adaptive-expressions.IsFloat) class.
      */
     public constructor() {
         super(ExpressionType.IsFloat, IsFloat.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isInteger.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isInteger.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsInteger extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsInteger` class.
+     * Initializes a new instance of the [IsInteger](xref:adaptive-expressions.IsInteger) class.
      */
     public constructor() {
         super(ExpressionType.IsInteger, IsInteger.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsMatch extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsMatch` class.
+     * Initializes a new instance of the [IsMatch](xref:adaptive-expressions.IsMatch) class.
      */
     public constructor() {
         super(ExpressionType.IsMatch, IsMatch.evaluator(), ReturnType.Boolean, IsMatch.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isObject.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isObject.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsObject extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsObject` class.
+     * Initializes a new instance of the [IsObject](xref:adaptive-expressions.IsObject) class.
      */
     public constructor() {
         super(ExpressionType.IsObject, IsObject.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsPresent extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsPresent` class.
+     * Initializes a new instance of the [IsPresent](xref:adaptive-expressions.IsPresent) class.
      */
     public constructor() {
         super(ExpressionType.IsPresent, IsPresent.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isString.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsString extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsString` class.
+     * Initializes a new instance of the [IsString](xref:adaptive-expressions.IsString) class.
      */
     public constructor() {
         super(ExpressionType.IsString, IsString.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
@@ -23,7 +23,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsTime` class.
+     * Initializes a new instance of the [IsTime](xref:adaptive-expressions.IsTime) class.
      */
     public constructor() {
         super(ExpressionType.IsTime, IsTime.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class IsTimeRange extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `IsTimeRange` class.
+     * Initializes a new instance of the [IsTimeRange](xref:adaptive-expressions.IsTimeRange) class.
      */
     public constructor() {
         super(ExpressionType.IsTimeRange, IsTimeRange.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);


### PR DESCRIPTION
PR 2846 in MS, #163 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.