### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-6

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jPath.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class JPath extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `JPath` class.
+     * Initializes a new instance of the [JPath](xref:adaptive-expressions.JPath) class.
      */
     public constructor() {
         super(ExpressionType.JPath, JPath.evaluator(), ReturnType.Object, JPath.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/json.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/json.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Json extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Json` class.
+     * Initializes a new instance of the [Json](xref:adaptive-expressions.Json) class.
      */
     public constructor() {
         super(ExpressionType.Json, Json.evaluator(), ReturnType.Object, Json.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class JsonStringify extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `JsonStringify` class.
+     * Initializes a new instance of the [JsonStringify](xref:adaptive-expressions.JsonStringify) class.
      */
     public constructor() {
         super(ExpressionType.JsonStringify, JsonStringify.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/last.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/last.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Last extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Last` class.
+     * Initializes a new instance of the [Last](xref:adaptive-expressions.Last) class.
      */
     public constructor() {
         super(ExpressionType.Last, Last.evaluator(), ReturnType.Object, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lastIndexOf.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class LastIndexOf extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `LastIndexOf` class.
+     * Initializes a new instance of the [LastIndexOf](xref:adaptive-expressions.LastIndexOf) class.
      */
     public constructor() {
         super(ExpressionType.LastIndexOf, LastIndexOf.evaluator, ReturnType.Number, LastIndexOf.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/length.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/length.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Length extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Length` class.
+     * Initializes a new instance of the [Length](xref:adaptive-expressions.Length) class.
      */
     public constructor() {
         super(ExpressionType.Length, Length.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThan.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class LessThan extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `LessThan` class.
+     * Initializes a new instance of the [LessThan](xref:adaptive-expressions.LessThan) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/lessThanOrEqual.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class LessThanOrEqual extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `LessThanOrEqual` class.
+     * Initializes a new instance of the [LessThanOrEqual](xref:adaptive-expressions.LessThanOrEqual) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/max.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/max.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Max extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Max` class.
+     * Initializes a new instance of the [Max](xref:adaptive-expressions.Max) class.
      */
     public constructor() {
         super(ExpressionType.Max, Max.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/merge.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Merge extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Merge` class.
+     * Initializes a new instance of the [Merge](xref:adaptive-expressions.Merge) class.
      */
     public constructor() {
         super(ExpressionType.Merge, Merge.evaluator(), ReturnType.Object, Merge.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/min.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/min.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Min extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Min` class.
+     * Initializes a new instance of the [Min](xref:adaptive-expressions.Min) class.
      */
     public constructor() {
         super(ExpressionType.Min, Min.evaluator(), ReturnType.Number, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/mod.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Mod extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Mod` class.
+     * Initializes a new instance of the [Mod](xref:adaptive-expressions.Mod) class.
      */
     public constructor() {
         super(ExpressionType.Mod, Mod.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/month.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/month.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Month extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Month` class.
+     * Initializes a new instance of the [Month](xref:adaptive-expressions.Month) class.
      */
     public constructor() {
         super(ExpressionType.Month, Month.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);

--- a/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multiply.ts
@@ -14,7 +14,7 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  */
 export class Multiply extends MultivariateNumericEvaluator {
     /**
-     * Initializes a new instance of the `Multiply` class.
+     * Initializes a new instance of the [Multiply](xref:adaptive-expressions.Multiply) class.
      */
     public constructor() {
         super(ExpressionType.Multiply, Multiply.func);


### PR DESCRIPTION
PR 2847 in MS, #168 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.