### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-7

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
@@ -15,7 +15,7 @@ import { ReturnType } from '../returnType';
  */
 export class MultivariateNumericEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `MultivariateNumericEvaluator` class.
+     * Initializes a new instance of the [MultivariateNumericEvaluator](xref:adaptive-expressions.MultivariateNumericEvaluator) class.
      */
     public constructor(type: string, func: (args: any[]) => number, verify?: VerifyExpression) {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/multivariateNumericEvaluator.ts
@@ -16,6 +16,9 @@ import { ReturnType } from '../returnType';
 export class MultivariateNumericEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [MultivariateNumericEvaluator](xref:adaptive-expressions.MultivariateNumericEvaluator) class.
+     * @param type Name of the built-in function.
+     * @param func The evaluation function, it takes a list of objects and returns a number.
+     * @param verify Optional. [VerifyExpression](xref:adaptive-expressions.VerifyExpression) function to verify each child's result.
      */
     public constructor(type: string, func: (args: any[]) => number, verify?: VerifyExpression) {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class NewGuid extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `NewGuid` class.
+     * Initializes a new instance of the [NewGuid](xref:adaptive-expressions.NewGuid) class.
      */
     public constructor() {
         super(ExpressionType.NewGuid, NewGuid.evaluator(), ReturnType.String, NewGuid.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/not.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/not.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Not extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Not` class.
+     * Initializes a new instance of the [Not](xref:adaptive-expressions.Not) class.
      */
     public constructor() {
         super(ExpressionType.Not, Not.evaluator, ReturnType.Boolean, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/notEqual.ts
@@ -16,7 +16,7 @@ import { ComparisonEvaluator } from './comparisonEvaluator';
  */
 export class NotEqual extends ComparisonEvaluator {
     /**
-     * Initializes a new instance of the `NotEqual` class.
+     * Initializes a new instance of the [NotEqual](xref:adaptive-expressions.NotEqual) class.
      */
     public constructor() {
         super(ExpressionType.NotEqual, NotEqual.func, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
@@ -16,6 +16,8 @@ import { ReturnType } from '../returnType';
 export class NumberTransformEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [NumberTransformEvaluator](xref:adaptive-expressions.NumberTransformEvaluator) class.
+     * @param type Name of the built-in function.
+     * @param func The comparison function, it takes a list of objects and returns a number.
      */
     public constructor(type: string, func: (args: any[]) => number) {
         super(type, NumberTransformEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateUnaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
@@ -15,7 +15,7 @@ import { ReturnType } from '../returnType';
  */
 export class NumberTransformEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `NumberTransformEvaluator` class.
+     * Initializes a new instance of the [NumberTransformEvaluator](xref:adaptive-expressions.NumberTransformEvaluator) class.
      */
     public constructor(type: string, func: (args: any[]) => number) {
         super(type, NumberTransformEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateUnaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numberTransformEvaluator.ts
@@ -17,7 +17,7 @@ export class NumberTransformEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [NumberTransformEvaluator](xref:adaptive-expressions.NumberTransformEvaluator) class.
      * @param type Name of the built-in function.
-     * @param func The comparison function, it takes a list of objects and returns a number.
+     * @param func The evaluation function, it takes a list of objects and returns a number.
      */
     public constructor(type: string, func: (args: any[]) => number) {
         super(type, NumberTransformEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateUnaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
@@ -17,7 +17,7 @@ export class NumericEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [NumericEvaluator](xref:adaptive-expressions.NumericEvaluator) class.
      * @param type Name of the built-in function.
-     * @param func The comparison function, it takes a list of objects and returns a number.
+     * @param func The evaluation function, it takes a list of objects and returns a number.
      */
     public constructor(type: string, func: (args: any[]) => any) {
         super(type, NumericEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
@@ -15,7 +15,7 @@ import { ReturnType } from '../returnType';
  */
 export class NumericEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `NumericEvaluator` class.
+     * Initializes a new instance of the [NumericEvaluator](xref:adaptive-expressions.NumericEvaluator) class.
      */
     public constructor(type: string, func: (args: any[]) => any) {
         super(type, NumericEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/numericEvaluator.ts
@@ -16,6 +16,8 @@ import { ReturnType } from '../returnType';
 export class NumericEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [NumericEvaluator](xref:adaptive-expressions.NumericEvaluator) class.
+     * @param type Name of the built-in function.
+     * @param func The comparison function, it takes a list of objects and returns a number.
      */
     public constructor(type: string, func: (args: any[]) => any) {
         super(type, NumericEvaluator.evaluator(func), ReturnType.Number, FunctionUtils.validateNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/optional.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Optional extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Optional` class.
+     * Initializes a new instance of the [Optional](xref:adaptive-expressions.Optional) class.
      */
     public constructor() {
         super(ExpressionType.Optional, Optional.evaluator(), ReturnType.Boolean, FunctionUtils.validateUnaryBoolean);

--- a/libraries/adaptive-expressions/src/builtinFunctions/or.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/or.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class Or extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Or` class.
+     * Initializes a new instance of the [Or](xref:adaptive-expressions.Or) class.
      */
     public constructor() {
         super(ExpressionType.Or, Or.evaluator, ReturnType.Boolean, FunctionUtils.validateAtLeastOne);

--- a/libraries/adaptive-expressions/src/builtinFunctions/power.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/power.ts
@@ -15,7 +15,7 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  */
 export class Power extends MultivariateNumericEvaluator {
     /**
-     * Initializes a new instance of the `Power` class.
+     * Initializes a new instance of the [Power](xref:adaptive-expressions.Power) class.
      */
     public constructor() {
         super(ExpressionType.Power, Power.func, FunctionUtils.verifyNumberOrNumericList);

--- a/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/rand.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Rand extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Rand` class.
+     * Initializes a new instance of the [Rand](xref:adaptive-expressions.Rand) class.
      */
     public constructor() {
         super(ExpressionType.Rand, Rand.evaluator(), ReturnType.Number, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/range.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/range.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Range extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Range` class.
+     * Initializes a new instance of the [Range](xref:adaptive-expressions.Range) class.
      */
     public constructor() {
         super(ExpressionType.Range, Range.evaluator(), ReturnType.Array, FunctionUtils.validateBinaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/removeProperty.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class RemoveProperty extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `RemoveProperty` class.
+     * Initializes a new instance of the [RemoveProperty](xref:adaptive-expressions.RemoveProperty) class.
      */
     public constructor() {
         super(ExpressionType.RemoveProperty, RemoveProperty.evaluator(), ReturnType.Object, RemoveProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class Replace extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the [XXX](xref:adaptive-expressions.XXX) class.
+     * Initializes a new instance of the [Replace](xref:adaptive-expressions.Replace) class.
      */
     public constructor() {
         super(ExpressionType.Replace, Replace.evaluator(), ReturnType.String, Replace.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replace.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class Replace extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Replace` class.
+     * Initializes a new instance of the [XXX](xref:adaptive-expressions.XXX) class.
      */
     public constructor() {
         super(ExpressionType.Replace, Replace.evaluator(), ReturnType.String, Replace.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/replaceIgnoreCase.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class ReplaceIgnoreCase extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `ReplaceIgnoreCase` class.
+     * Initializes a new instance of the [ReplaceIgnoreCase](xref:adaptive-expressions.ReplaceIgnoreCase) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/round.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/round.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Round extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Round` class.
+     * Initializes a new instance of the [Round](xref:adaptive-expressions.Round) class.
      */
     public constructor() {
         super(ExpressionType.Round, Round.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryOrBinaryNumber);


### PR DESCRIPTION
PR 2848 in MS, #169 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.