### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-8

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/select.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/select.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class Select extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Select` class.
+     * Initializes a new instance of the [Select](xref:adaptive-expressions.Select) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/sentenceCase.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/sentenceCase.ts
@@ -16,7 +16,7 @@ import { StringTransformEvaluator } from './stringTransformEvaluator';
  */
 export class SentenceCase extends StringTransformEvaluator {
     /**
-     * Initializes a new instance of the `SentenceCase` class.
+     * Initializes a new instance of the [SentenceCase](xref:adaptive-expressions.SentenceCase) class.
      */
     public constructor() {
         super(ExpressionType.SentenceCase, SentenceCase.evaluator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/setPathToValue.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/setPathToValue.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class SetPathToValue extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SetPathToValue` class.
+     * Initializes a new instance of the [SetPathToValue](xref:adaptive-expressions.SetPathToValue) class.
      */
     public constructor() {
         super(ExpressionType.SetPathToValue, SetPathToValue.evaluator, ReturnType.Object, FunctionUtils.validateBinary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/setProperty.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/setProperty.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class SetProperty extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SetProperty` class.
+     * Initializes a new instance of the [SetProperty](xref:adaptive-expressions.SetProperty) class.
      */
     public constructor() {
         super(ExpressionType.SetProperty, SetProperty.evaluator(), ReturnType.Object, SetProperty.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/skip.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/skip.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class Skip extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Skip` class.
+     * Initializes a new instance of the [Skip](xref:adaptive-expressions.Skip) class.
      */
     public constructor() {
         super(ExpressionType.Skip, Skip.evaluator, ReturnType.Array, Skip.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/sortBy.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/sortBy.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class SortBy extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SortBy` class.
+     * Initializes a new instance of the [SortBy](xref:adaptive-expressions.SortBy) class.
      */
     public constructor() {
         super(ExpressionType.SortBy, InternalFunctionUtils.sortBy(false), ReturnType.Array, SortBy.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/sortByDescending.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/sortByDescending.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class SortByDescending extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SortByDescending` class.
+     * Initializes a new instance of the [SortByDescending](xref:adaptive-expressions.SortByDescending) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/split.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/split.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class Split extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Split` class.
+     * Initializes a new instance of the [Split](xref:adaptive-expressions.Split) class.
      */
     public constructor() {
         super(ExpressionType.Split, Split.evaluator(), ReturnType.Array, Split.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/startOfDay.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/startOfDay.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class StartOfDay extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `StartOfDay` class.
+     * Initializes a new instance of the [StartOfDay](xref:adaptive-expressions.StartOfDay) class.
      */
     public constructor() {
         super(ExpressionType.StartOfDay, StartOfDay.evaluator, ReturnType.String, StartOfDay.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/startOfHour.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/startOfHour.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class StartOfHour extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `StartOfHour` class.
+     * Initializes a new instance of the [StartOfHour](xref:adaptive-expressions.StartOfHour) class.
      */
     public constructor() {
         super(ExpressionType.StartOfHour, StartOfHour.evaluator, ReturnType.String, StartOfHour.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/startOfMonth.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/startOfMonth.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class StartOfMonth extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `StartOfMonth` class.
+     * Initializes a new instance of the [StartOfMonth](xref:adaptive-expressions.StartOfMonth) class.
      */
     public constructor() {
         super(ExpressionType.StartOfMonth, StartOfMonth.evaluator, ReturnType.String, StartOfMonth.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/startsWith.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/startsWith.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class StartsWith extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `StartsWith` class.
+     * Initializes a new instance of the [StartsWith](xref:adaptive-expressions.StartsWith) class.
      */
     public constructor() {
         super(ExpressionType.StartsWith, StartsWith.evaluator(), ReturnType.Boolean, StartsWith.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/string.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/string.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class String extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `String` class.
+     * Initializes a new instance of the [String](xref:adaptive-expressions.String) class.
      */
     public constructor() {
         super(ExpressionType.String, String.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/stringTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/stringTransformEvaluator.ts
@@ -15,7 +15,7 @@ import { ReturnType } from '../returnType';
  */
 export class StringTransformEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `StringTransformEvaluator` class.
+     * Initializes a new instance of the [StringTransformEvaluator](xref:adaptive-expressions.StringTransformEvaluator) class.
      * @param type Name of the built-in function.
      * @param func The string transformation function, it takes a list of objects and returns an string.
      */

--- a/libraries/adaptive-expressions/src/builtinFunctions/subArray.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/subArray.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class SubArray extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SubArray` class.
+     * Initializes a new instance of the [SubArray](xref:adaptive-expressions.SubArray) class.
      */
     public constructor() {
         super(ExpressionType.SubArray, SubArray.evaluator, ReturnType.Array, SubArray.validator);


### PR DESCRIPTION
PR 2849 in MS, #164 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.