### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-9

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/substring.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/substring.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class Substring extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Substring` class.
+     * Initializes a new instance of the [Substring](xref:adaptive-expressions.Substring) class.
      */
     public constructor() {
         super(ExpressionType.Substring, Substring.evaluator, ReturnType.String, Substring.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/subtract.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/subtract.ts
@@ -14,7 +14,7 @@ import { MultivariateNumericEvaluator } from './multivariateNumericEvaluator';
  */
 export class Subtract extends MultivariateNumericEvaluator {
     /**
-     * Initializes a new instance of the `Subtract` class.
+     * Initializes a new instance of the [Subtract](xref:adaptive-expressions.Subtract) class.
      */
     public constructor() {
         super(ExpressionType.Subtract, Subtract.func);

--- a/libraries/adaptive-expressions/src/builtinFunctions/subtractFromTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/subtractFromTime.ts
@@ -22,7 +22,7 @@ import { ReturnType } from '../returnType';
  */
 export class SubtractFromTime extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `SubtractFromTime` class.
+     * Initializes a new instance of the [SubtractFromTime](xref:adaptive-expressions.SubtractFromTime) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/sum.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/sum.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Sum extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Sum` class.
+     * Initializes a new instance of the [Sum](xref:adaptive-expressions.Sum) class.
      */
     public constructor() {
         super(ExpressionType.Sum, Sum.evaluator(), ReturnType.Number, Sum.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/take.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/take.ts
@@ -18,7 +18,7 @@ import { ReturnType } from '../returnType';
  */
 export class Take extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Take` class.
+     * Initializes a new instance of the [Take](xref:adaptive-expressions.Take) class.
      */
     public constructor() {
         super(ExpressionType.Take, Take.evaluator, ReturnType.Array, Take.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ticks.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ticks.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class Ticks extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Ticks` class.
+     * Initializes a new instance of the [Ticks](xref:adaptive-expressions.Ticks) class.
      */
     public constructor() {
         super(ExpressionType.Ticks, Ticks.evaluator, ReturnType.Number, Ticks.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ticksToDays.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ticksToDays.ts
@@ -21,7 +21,7 @@ export class TicksToDays extends ExpressionEvaluator {
     private static readonly TicksPerDay: number = 24 * 60 * 60 * 10000000;
 
     /**
-     * Initializes a new instance of the `TicksToDays` class.
+     * Initializes a new instance of the [TicksToDays](xref:adaptive-expressions.TicksToDays) class.
      */
     public constructor() {
         super(ExpressionType.TicksToDays, TicksToDays.evaluator, ReturnType.Number, FunctionUtils.validateUnaryNumber);

--- a/libraries/adaptive-expressions/src/builtinFunctions/ticksToHours.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ticksToHours.ts
@@ -21,7 +21,7 @@ export class TicksToHours extends ExpressionEvaluator {
     private static readonly TicksPerHour: number = 60 * 60 * 10000000;
 
     /**
-     * Initializes a new instance of the `TicksToHours` class.
+     * Initializes a new instance of the [TicksToHours](xref:adaptive-expressions.TicksToHours) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/ticksToMinutes.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/ticksToMinutes.ts
@@ -21,7 +21,7 @@ export class TicksToMinutes extends ExpressionEvaluator {
     private static readonly TicksPerMinute: number = 60 * 10000000;
 
     /**
-     * Initializes a new instance of the `TicksToMinutes` class.
+     * Initializes a new instance of the [TicksToMinutes](xref:adaptive-expressions.TicksToMinutes) class.
      */
     public constructor() {
         super(

--- a/libraries/adaptive-expressions/src/builtinFunctions/timeTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/timeTransformEvaluator.ts
@@ -22,6 +22,8 @@ import { ReturnType } from '../returnType';
 export class TimeTransformEvaluator extends ExpressionEvaluator {
     /**
      * Initializes a new instance of the [TimeTransformEvaluator](xref:adaptive-expressions.TimeTransformEvaluator) class.
+     * @param type Name of the built-in function.
+     * @param func The evaluation function, it takes a timestamp and the number of transformation, and returns a `Date`.
      */
     public constructor(type: string, func: (timestamp: Date, numOfTransformation: any) => Date) {
         super(type, TimeTransformEvaluator.evaluator(func), ReturnType.String, TimeTransformEvaluator.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/timeTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/timeTransformEvaluator.ts
@@ -21,7 +21,7 @@ import { ReturnType } from '../returnType';
  */
 export class TimeTransformEvaluator extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `TimeTransformEvaluator` class.
+     * Initializes a new instance of the [TimeTransformEvaluator](xref:adaptive-expressions.TimeTransformEvaluator) class.
      */
     public constructor(type: string, func: (timestamp: Date, numOfTransformation: any) => Date) {
         super(type, TimeTransformEvaluator.evaluator(func), ReturnType.String, TimeTransformEvaluator.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/titleCase.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/titleCase.ts
@@ -16,7 +16,7 @@ import { StringTransformEvaluator } from './stringTransformEvaluator';
  */
 export class TitleCase extends StringTransformEvaluator {
     /**
-     * Initializes a new instance of the `TitleCase` class.
+     * Initializes a new instance of the [TitleCase](xref:adaptive-expressions.TitleCase) class.
      */
     public constructor() {
         super(ExpressionType.TitleCase, TitleCase.evaluator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/toLower.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/toLower.ts
@@ -17,7 +17,7 @@ import { StringTransformEvaluator } from './stringTransformEvaluator';
  */
 export class ToLower extends StringTransformEvaluator {
     /**
-     * Initializes a new instance of the `ToLower` class.
+     * Initializes a new instance of the [ToLower](xref:adaptive-expressions.ToLower) class.
      */
     public constructor() {
         super(ExpressionType.ToLower, ToLower.evaluator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/toUpper.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/toUpper.ts
@@ -16,7 +16,7 @@ import { StringTransformEvaluator } from './stringTransformEvaluator';
  */
 export class ToUpper extends StringTransformEvaluator {
     /**
-     * Initializes a new instance of the `ToUpper` class.
+     * Initializes a new instance of the [ToUpper](xref:adaptive-expressions.ToUpper) class.
      */
     public constructor() {
         super(ExpressionType.ToUpper, ToUpper.evaluator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/trim.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/trim.ts
@@ -16,7 +16,7 @@ import { StringTransformEvaluator } from './stringTransformEvaluator';
  */
 export class Trim extends StringTransformEvaluator {
     /**
-     * Initializes a new instance of the `Trim` class.
+     * Initializes a new instance of the [Trim](xref:adaptive-expressions.Trim) class.
      */
     public constructor() {
         super(ExpressionType.Trim, Trim.evaluator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/union.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/union.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class Union extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Union` class.
+     * Initializes a new instance of the [Union](xref:adaptive-expressions.Union) class.
      */
     public constructor() {
         super(ExpressionType.Union, Union.evaluator(), ReturnType.Array, Union.validator);


### PR DESCRIPTION
PR 2850 in MS, #170 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.