### PR TITLE
[internal] Apply xref links for adaptive-expressions/converters

### DIFF
--- a/libraries/adaptive-expressions/src/converters/arrayExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/arrayExpressionConverter.ts
@@ -9,14 +9,14 @@
 import { ArrayExpression } from '../expressionProperties';
 
 /**
- * `array` to json `ArrayExpression` converter.
+ * `array` to json [ArrayExpression](xref:adaptive-expressions.ArrayExpression) converter.
  * @typeparam T The type of the items of the array.
  */
 export class ArrayExpressionConverter<T> {
     /**
-     * Converts an array into an `ArrayExpression`.
+     * Converts an array into an [ArrayExpression](xref:adaptive-expressions.ArrayExpression).
      * @param value `array` to convert.
-     * @returns The `ArrayExpression`.
+     * @returns The [ArrayExpression](xref:adaptive-expressions.ArrayExpression).
      */
     public convert(value: T[]): ArrayExpression<T> {
         return new ArrayExpression<T>(value);

--- a/libraries/adaptive-expressions/src/converters/boolExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/boolExpressionConverter.ts
@@ -9,13 +9,13 @@
 import { BoolExpression } from '../expressionProperties';
 
 /**
- * `any` value to json `BoolExpression` converter.
+ * `any` value to json [BoolExpression](xref:adaptive-expressions.BoolExpression) converter.
  */
 export class BoolExpressionConverter {
     /**
-     * Converts `any` value into a `BoolExpression`.
+     * Converts `any` value into a [BoolExpression](xref:adaptive-expressions.BoolExpression).
      * @param value `any` value to convert.
-     * @returns The `BoolExpression`.
+     * @returns The [BoolExpression](xref:adaptive-expressions.BoolExpression).
      */
     public convert(value: any): BoolExpression {
         return new BoolExpression(value);

--- a/libraries/adaptive-expressions/src/converters/enumExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/enumExpressionConverter.ts
@@ -9,23 +9,23 @@
 import { EnumExpression } from '../expressionProperties';
 
 /**
- * `string` to json `EnumExpression` converter.
+ * `string` to json [EnumExpression](xref:adaptive-expressions.EnumExpression) converter.
  */
 export class EnumExpressionConverter {
     private _enumValue: object;
 
     /**
-     * Initializes a new instance of the `EnumExpressionConverter` class.
-     * @param enumValue The enum value of the `string` to convert. 
+     * Initializes a new instance of the [EnumExpressionConverter](xref:adaptive-expressions.EnumExpressionConverter) class.
+     * @param enumValue The enum value of the `string` to convert.
      */
     public constructor(enumValue: object) {
         this._enumValue = enumValue;
     }
 
     /**
-     * Converts a `string` into an EnumExpression.
+     * Converts a `string` into an [EnumExpression](xref:adaptive-expressions.EnumExpression).
      * @param value `string` to convert.
-     * @returns The `EnumExpression`.
+     * @returns The [EnumExpression](xref:adaptive-expressions.EnumExpression).
      */
     public convert(value: string): EnumExpression<any> {
         if (typeof value == 'string') {

--- a/libraries/adaptive-expressions/src/converters/expressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/expressionConverter.ts
@@ -9,13 +9,13 @@
 import { Expression } from '../expression';
 
 /**
- * `string` to json `Expression` converter.
+ * `string` to json [Expression](xref:adaptive-expressions.Expression) converter.
  */
 export class ExpressionConverter {
     /**
-     * Converts a `string` into an `Expression`.
+     * Converts a `string` into an [Expression](xref:adaptive-expressions.Expression).
      * @param value `string` to convert.
-     * @returns The `Expression`.
+     * @returns The [Expression](xref:adaptive-expressions.Expression).
      */
     public convert(value: string): Expression {
         return Expression.parse(value);

--- a/libraries/adaptive-expressions/src/converters/intExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/intExpressionConverter.ts
@@ -9,13 +9,13 @@
 import { IntExpression } from '../expressionProperties';
 
 /**
- * `string` or `number` to json `IntExpression` converter.
+ * `string` or `number` to json [IntExpression](xref:adaptive-expressions.IntExpression) converter.
  */
 export class IntExpressionConverter {
     /**
-     * Converts a `string` or `number` into an `IntExpression`.
+     * Converts a `string` or `number` into an [IntExpression](xref:adaptive-expressions.IntExpression).
      * @param value `string` or `number` to convert.
-     * @returns The `IntExpression`.
+     * @returns The [IntExpression](xref:adaptive-expressions.IntExpression).
      */
     public convert(value: string | number): IntExpression {
         return new IntExpression(value);

--- a/libraries/adaptive-expressions/src/converters/numberExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/numberExpressionConverter.ts
@@ -9,13 +9,13 @@
 import { NumberExpression } from '../expressionProperties';
 
 /**
- * `string` or `number` to json `NumberExpression` converter.
+ * `string` or `number` to json [NumberExpression](xref:adaptive-expressions.NumberExpression) converter.
  */
 export class NumberExpressionConverter {
     /**
-     * Converts a `string` or `number` into a `NumberExpression`.
+     * Converts a `string` or `number` into a [NumberExpression](xref:adaptive-expressions.NumberExpression).
      * @param value `string` or `number` to convert.
-     * @returns The `NumberExpression`.
+     * @returns The [NumberExpression](xref:adaptive-expressions.NumberExpression).
      */
     public convert(value: string | number): NumberExpression {
         return new NumberExpression(value);

--- a/libraries/adaptive-expressions/src/converters/objectExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/objectExpressionConverter.ts
@@ -14,9 +14,9 @@ import { ObjectExpression } from '../expressionProperties';
  */
 export class ObjectExpressionConverter<T extends object = {}> {
     /**
-     * Converts value of type `T` into an [ObjectExpressionConverter](xref:adaptive-expressions.ObjectExpressionConverter).
+     * Converts value of type `T` into an [ObjectExpression](xref:adaptive-expressions.ObjectExpression).
      * @param value Value of type `T` to convert.
-     * @returns The [ObjectExpressionConverter](xref:adaptive-expressions.ObjectExpressionConverter).
+     * @returns The [ObjectExpression](xref:adaptive-expressions.ObjectExpression).
      */
     public convert(value: T): ObjectExpression<T> {
         return new ObjectExpression<T>(value);

--- a/libraries/adaptive-expressions/src/converters/objectExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/objectExpressionConverter.ts
@@ -9,14 +9,14 @@
 import { ObjectExpression } from '../expressionProperties';
 
 /**
- * `any` value to json `ObjectExpressionConverter` converter.
+ * `any` value to json [ObjectExpressionConverter](xref:adaptive-expressions.ObjectExpressionConverter) converter.
  * @typeparam T The type of the value.
  */
 export class ObjectExpressionConverter<T extends object = {}> {
     /**
-     * Converts value of type `T` into an `ObjectExpression`.
+     * Converts value of type `T` into an [ObjectExpressionConverter](xref:adaptive-expressions.ObjectExpressionConverter).
      * @param value Value of type `T` to convert.
-     * @returns The `ObjectExpression`.
+     * @returns The [ObjectExpressionConverter](xref:adaptive-expressions.ObjectExpressionConverter).
      */
     public convert(value: T): ObjectExpression<T> {
         return new ObjectExpression<T>(value);

--- a/libraries/adaptive-expressions/src/converters/stringExpressionConveter.ts
+++ b/libraries/adaptive-expressions/src/converters/stringExpressionConveter.ts
@@ -9,13 +9,13 @@
 import { StringExpression } from '../expressionProperties';
 
 /**
- * `string` to json `StringExpression` converter.
+ * `string` to json [StringExpression](xref:adaptive-expressions.StringExpression) converter.
  */
 export class StringExpressionConverter {
     /**
-     * Converts a string into an `StringExpression`.
+     * Converts a string into an [StringExpression](xref:adaptive-expressions.StringExpression).
      * @param value `string` to convert.
-     * @returns The `StringExpression`.
+     * @returns The [StringExpression](xref:adaptive-expressions.StringExpression).
      */
     public convert(value: string): StringExpression {
         return new StringExpression(value);

--- a/libraries/adaptive-expressions/src/converters/valueExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/valueExpressionConverter.ts
@@ -9,13 +9,13 @@
 import { ValueExpression } from '../expressionProperties';
 
 /**
- * `any` value to json `ValueExpression` converter.
+ * `any` value to json [ValueExpression](xref:adaptive-expressions.ValueExpression) converter.
  */
 export class ValueExpressionConverter {
     /**
-     * Converts `any` value into a `ValueExpression`.
+     * Converts `any` value into a [ValueExpression](xref:adaptive-expressions.ValueExpression).
      * @param value `any` value to convert.
-     * @returns The `ValueExpression`.
+     * @returns The [ValueExpression](xref:adaptive-expressions.ValueExpression).
      */
     public convert(value: any): ValueExpression {
         return new ValueExpression(value);


### PR DESCRIPTION
PR 2854 in MS, 173 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.