### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/builtFunctions-10

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/unique.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Unique extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Unique` class.
+     * Initializes a new instance of the [Unique](xref:adaptive-expressions.Unique) class.
      */
     public constructor() {
         super(ExpressionType.Unique, Unique.evaluator(), ReturnType.Array, Unique.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponent.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriComponent extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriComponent` class.
+     * Initializes a new instance of the [UriComponent](xref:adaptive-expressions.UriComponent) class.
      */
     public constructor() {
         super(ExpressionType.UriComponent, UriComponent.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriComponentToString.ts
@@ -16,7 +16,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriComponentToString extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriComponentToString` class.
+     * Initializes a new instance of the [UriComponentToString](xref:adaptive-expressions.UriComponentToString) class.
      */
     public constructor() {
         super(ExpressionType.UriComponentToString, UriComponentToString.evaluator(), ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriHost.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriHost extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriHost` class.
+     * Initializes a new instance of the [UriHost](xref:adaptive-expressions.UriHost) class.
      */
     public constructor() {
         super(ExpressionType.UriHost, UriHost.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPath.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriPath extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriPath` class.
+     * Initializes a new instance of the [UriPath](xref:adaptive-expressions.UriPath) class.
      */
     public constructor() {
         super(ExpressionType.UriPath, UriPath.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPathAndQuery.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriPathAndQuery extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriPathAndQuery` class.
+     * Initializes a new instance of the [UriPathAndQuery](xref:adaptive-expressions.UriPathAndQuery) class.
      */
     public constructor() {
         super(ExpressionType.UriPathAndQuery, UriPathAndQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriPort.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriPort extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriPort` class.
+     * Initializes a new instance of the [UriPort](xref:adaptive-expressions.UriPort) class.
      */
     public constructor() {
         super(ExpressionType.UriPort, UriPort.evaluator, ReturnType.Number, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriQuery.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriQuery extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriQuery` class.
+     * Initializes a new instance of the [UriQuery](xref:adaptive-expressions.UriQuery) class.
      */
     public constructor() {
         super(ExpressionType.UriQuery, UriQuery.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/uriScheme.ts
@@ -20,7 +20,7 @@ import { ReturnType } from '../returnType';
  */
 export class UriScheme extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UriScheme` class.
+     * Initializes a new instance of the [UriScheme](xref:adaptive-expressions.UriScheme) class.
      */
     public constructor() {
         super(ExpressionType.UriScheme, UriScheme.evaluator, ReturnType.String, FunctionUtils.validateUnary);

--- a/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/utcNow.ts
@@ -19,7 +19,7 @@ import { ReturnType } from '../returnType';
  */
 export class UtcNow extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `UtcNow` class.
+     * Initializes a new instance of the [UtcNow](xref:adaptive-expressions.UtcNow) class.
      */
     public constructor() {
         super(ExpressionType.UtcNow, UtcNow.evaluator(), ReturnType.String, UtcNow.validator);

--- a/libraries/adaptive-expressions/src/builtinFunctions/where.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/where.ts
@@ -23,7 +23,7 @@ import { ReturnType } from '../returnType';
  */
 export class Where extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Where` class.
+     * Initializes a new instance of the [Where](xref:adaptive-expressions.Where) class.
      */
     public constructor() {
         super(ExpressionType.Where, Where.evaluator, ReturnType.Array, InternalFunctionUtils.validateForeach);

--- a/libraries/adaptive-expressions/src/builtinFunctions/year.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/year.ts
@@ -17,7 +17,7 @@ import { ReturnType } from '../returnType';
  */
 export class Year extends ExpressionEvaluator {
     /**
-     * Initializes a new instance of the `Year` class.
+     * Initializes a new instance of the [Year](xref:adaptive-expressions.Year) class.
      */
     public constructor() {
         super(ExpressionType.Year, Year.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryString);


### PR DESCRIPTION
PR 2851 in MS, #171 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.