### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/teams-scenarios-root

### DIFF
--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
@@ -29,7 +29,7 @@ import { SubmitExampleData } from './submitExampleData';
  */
 export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `ActionBasedMessagingExtensionFetchTaskBot` class.
+     * Initializes a new instance of the [ActionBasedMessagingExtensionFetchTaskBot](xref:action-based-messaging-extension-fetchtask.ActionBasedMessagingExtensionFetchTaskBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/adaptiveCardHelper.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/adaptiveCardHelper.ts
@@ -13,13 +13,13 @@ import {
 import { SubmitExampleData } from './submitExampleData';
 
 /**
- * Helper for AdaptiveCard.
+ * Helper for [CardFactory.adaptiveCard](xref:botbuilder-core.CardFactory.adaptiveCard).
  */
 export class AdaptiveCardHelper {
     /**
      * Creates an example data.
      * @param action Messaging extension action.
-     * @returns A `SubmitExampleData` object.
+     * @returns A [SubmitExampleData](xref:action-based-messaging-extension-fetchtask.SubmitExampleData) object.
      */
     public static toSubmitExampleData(action: MessagingExtensionAction): SubmitExampleData {
         const activityPreview = action.botActivityPreview[0];
@@ -38,13 +38,13 @@ export class AdaptiveCardHelper {
     }
 
     /**
-     * Creates a `MessagingExtensionActionResponse` with an AdaptiveCard.
+     * Creates a [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) with an AdaptiveCard.
      * @param userText Question text.
      * @param isMultiSelect Multi select.
      * @param option1 Option 1.
      * @param option2 Option 2.
      * @param option3 Option 3.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static createTaskModuleAdaptiveCardResponse(
         userText: string = null,
@@ -126,7 +126,7 @@ export class AdaptiveCardHelper {
     /**
      * Creates an AdaptiveCard attachment.
      * @param data Example data.
-     * @returns An `Attachment` object.
+     * @returns An [Attachment](xref:botframework-schema.Attachment) object.
      */
     public static toAdaptiveCardAttachment(data: SubmitExampleData): Attachment {
         return CardFactory.adaptiveCard({

--- a/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/cardResponseHelpers.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension-fetchTask/src/cardResponseHelpers.ts
@@ -14,13 +14,13 @@ import {
 } from 'botbuilder';
 
 /**
- * Helper for an Attachment as CardResponse.
+ * Helper for an [Attachment](xref:botframework-schema.Attachment) as CardResponse.
  */
 export class CardResponseHelpers {
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a task.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object as a task.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toTaskModuleResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
@@ -36,9 +36,9 @@ export class CardResponseHelpers {
     }
 
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a compose extension.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object as a compose extension.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toComposeExtensionResultResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
@@ -52,10 +52,10 @@ export class CardResponseHelpers {
     }
 
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object
      * as a compose extension with type of botMessagePreview.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toMessagingExtensionBotMessagePreviewResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {

--- a/libraries/teams-scenarios/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
+++ b/libraries/teams-scenarios/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
@@ -20,7 +20,7 @@ import {
  */
 export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `ActionBasedMessagingExtensionBot` class.
+     * Initializes a new instance of the [ActionBasedMessagingExtensionBot](xref:messaging-extension-action.ActionBasedMessagingExtensionBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/activityUpdateAndDelete/src/activityUpdateAndDeleteBot.ts
+++ b/libraries/teams-scenarios/activityUpdateAndDelete/src/activityUpdateAndDeleteBot.ts
@@ -15,7 +15,7 @@ export class ActivityUpdateAndDeleteBot extends ActivityHandler {
     protected activityIds: string[];
 
     /**
-     * Initializes a new instance of the `ActivityUpdateAndDeleteBot` class.
+     * Initializes a new instance of the [ActivityUpdateAndDeleteBot](xref:activity-update-delete-bot.ActivityUpdateAndDeleteBot) class.
      * @param activityIds An array of activity ids.
      */
     constructor(activityIds: string[]) {

--- a/libraries/teams-scenarios/adaptiveCards/src/adaptiveCardsBot.ts
+++ b/libraries/teams-scenarios/adaptiveCards/src/adaptiveCardsBot.ts
@@ -16,11 +16,11 @@ import {
 
 /**
  * You can @mention the bot the text "1", "2", or "3". "1" will send back adaptive cards. "2" will send back a
- * task module that contains an adpative card. "3" will return an adpative card that contains BF card actions.
+ * task module that contains an adaptive card. "3" will return an adaptive card that contains BF card actions.
  */
 export class AdaptiveCardsBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `AdaptiveCardsBot` class.
+     * Initializes a new instance of the [AdaptiveCardsBot](xref:adaptive-cards-bot.AdaptiveCardsBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/cardBotFramework/src/cardsBot.ts
+++ b/libraries/teams-scenarios/cardBotFramework/src/cardsBot.ts
@@ -19,7 +19,7 @@ export class CardsBot extends TeamsActivityHandler {
     protected cardTypes: string[];
 
     /**
-     * Initializes a new instance of the `CardsBot` class.
+     * Initializes a new instance of the [CardsBot](xref:cards-bot.CardsBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/integrationBot/src/activityLog.ts
+++ b/libraries/teams-scenarios/integrationBot/src/activityLog.ts
@@ -10,13 +10,13 @@ import{
 } from 'botframework-schema'
 
 /**
- * `Activity`'s class with a Storage provider.
+ * [Activity](xref:botframework-schema.Activity)'s class with a [Storage](xref:botbuilder-core.Storage) provider.
  */
 export class ActivityLog  {
     private readonly _storage: Storage;
 
     /**
-     * Initializes a new instance of the `ActivityLog` class.
+     * Initializes a new instance of the [ActivityLog](xref:integration-bot.ActivityLog) class.
      * @param storage A storage provider that stores and retrieves plain old JSON objects.
      */
     public constructor(storage: Storage) {
@@ -24,9 +24,9 @@ export class ActivityLog  {
     }
 
     /**
-     * Saves an `Activity` with its associated id into the storage.
-     * @param activityId `Activity`'s Id.
-     * @param activity The `Activity` object.
+     * Saves an [Activity](xref:botframework-schema.Activity) with its associated id into the storage.
+     * @param activityId [Activity](xref:botframework-schema.Activity)'s Id.
+     * @param activity The [Activity](xref:botframework-schema.Activity) object.
      */
     public async append(activityId: string, activity: Partial<Activity>): Promise<void> {
         if (activityId == null)
@@ -48,9 +48,9 @@ export class ActivityLog  {
     }
 
     /**
-     * Retrieves an `Activity` from the storage by a given Id.
-     * @param activityId `Activity`'s Id.
-     * @returns The `Activity`'s object retrieved from storage.
+     * Retrieves an [Activity](xref:botframework-schema.Activity) from the storage by a given Id.
+     * @param activityId [Activity](xref:botframework-schema.Activity)'s Id.
+     * @returns The [Activity](xref:botframework-schema.Activity)'s object retrieved from storage.
      */
     public async find(activityId: string): Promise<Activity>
     {

--- a/libraries/teams-scenarios/integrationBot/src/adaptiveCardHelper.ts
+++ b/libraries/teams-scenarios/integrationBot/src/adaptiveCardHelper.ts
@@ -13,13 +13,13 @@ import {
 import { SubmitExampleData } from './submitExampleData';
 
 /**
- * Helper for AdaptiveCard.
+ * Helper for [CardFactory.adaptiveCard](xref:botbuilder-core.CardFactory.adaptiveCard).
  */
 export class AdaptiveCardHelper {
     /**
      * Creates an example data.
      * @param action Messaging extension action
-     * @returns A `SubmitExampleData` object.
+     * @returns A [SubmitExampleData](xref:integration-bot.SubmitExampleData) object.
      */
     public static toSubmitExampleData(action: MessagingExtensionAction): SubmitExampleData {
         const activityPreview = action.botActivityPreview[0];
@@ -38,13 +38,13 @@ export class AdaptiveCardHelper {
     }
 
     /**
-     * Creates a `MessagingExtensionActionResponse` with an AdaptiveCard.
+     * Creates a [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) with an AdaptiveCard.
      * @param userText Question text.
      * @param isMultiSelect Multi select.
      * @param option1 Option 1.
      * @param option2 Option 2.
      * @param option3 Option 3.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static createTaskModuleAdaptiveCardResponse(
         userText: string = null,
@@ -126,7 +126,7 @@ export class AdaptiveCardHelper {
     /**
      * Creates an AdaptiveCard attachment.
      * @param data Example data.
-     * @returns An `Attachment` object.
+     * @returns An [Attachment](xref:botframework-schema.Attachment) object.
      */
     public static toAdaptiveCardAttachment(data: SubmitExampleData): Attachment {
         return CardFactory.adaptiveCard({

--- a/libraries/teams-scenarios/integrationBot/src/cardResponseHelpers.ts
+++ b/libraries/teams-scenarios/integrationBot/src/cardResponseHelpers.ts
@@ -14,13 +14,13 @@ import {
 } from 'botbuilder';
 
 /**
- * Helper for an Attachment as CardResponse.
+ * Helper for an [Attachment](xref:botframework-schema.Attachment) as CardResponse.
  */
 export class CardResponseHelpers {
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a task.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object as a task.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toTaskModuleResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
@@ -36,9 +36,9 @@ export class CardResponseHelpers {
     }
 
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object as a compose extension.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object as a compose extension.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toComposeExtensionResultResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {
@@ -52,10 +52,10 @@ export class CardResponseHelpers {
     }
 
     /**
-     * Assigns an Attachment to a new `MessagingExtensionActionResponse` object
+     * Assigns an [Attachment](xref:botframework-schema.Attachment) to a new [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object
      * as a compose extension with type of botMessagePreview.
-     * @param cardAttachment Attachment to be assigned.
-     * @returns A `MessagingExtensionActionResponse` object.
+     * @param cardAttachment [Attachment](xref:botframework-schema.Attachment) to be assigned.
+     * @returns A [MessagingExtensionActionResponse](xref:botframework-schema.MessagingExtensionActionResponse) object.
      */
     public static toMessagingExtensionBotMessagePreviewResponse(cardAttachment: Attachment): MessagingExtensionActionResponse {
         return {

--- a/libraries/teams-scenarios/integrationBot/src/integrationBot.ts
+++ b/libraries/teams-scenarios/integrationBot/src/integrationBot.ts
@@ -79,11 +79,11 @@ export class IntegrationBot extends TeamsActivityHandler {
     protected _log: ActivityLog;
 
     /**
-     * Initializes a new instance of the `IntegrationBot` class.
+     * Initializes a new instance of the [IntegrationBot](xref:integration-bot.IntegrationBot) class.
      * See README.md on what this bot supports.
      * @param userState User's bot state for persistance.
      * @param activityIds An array of activity ids.
-     * @param activityLog The `ActivityLog`.
+     * @param activityLog The [ActivityLog](xref:integration-bot.ActivityLog).
      */
     constructor(public userState: BotState, activityIds: string[], activityLog: ActivityLog) {
         super();

--- a/libraries/teams-scenarios/integrationBot/src/teamsTenantFilteringMiddleware.ts
+++ b/libraries/teams-scenarios/integrationBot/src/teamsTenantFilteringMiddleware.ts
@@ -19,7 +19,7 @@ export class TeamsTenantFilteringMiddleware implements Middleware {
     // tslint:enable:variable-name
 
     /**
-     * Initializes a new instance of the TeamsTenantFilteringMiddleware class.
+     * Initializes a new instance of the [TeamsTenantFilteringMiddleware](xref:integration-bot.TeamsTenantFilteringMiddleware) class.
      * @param allowedTenants Either a single Tenant Id or array of Tenant Ids.
      */
     constructor(allowedTenants: string | string[]) {


### PR DESCRIPTION
PR 2839 in MS, #160 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.