### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/expressionProperties

### DIFF
--- a/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
@@ -17,7 +17,7 @@ import { Expression } from '../expression';
  */
 export class ArrayExpression<T> extends ExpressionProperty<T[]> {
     /**
-     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * Initializes a new instance of the [ArrayExpression<T>](xref:adaptive-expressions.ArrayExpression) class.
      * @param value Value of `T[]` or a `string` expression to bind to a `T[]`.
      */
     public constructor(value?: T[] | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
@@ -16,7 +16,7 @@ import { Expression } from '../expression';
 export class BoolExpression extends ExpressionProperty<boolean> {
     
     /**
-     * Initializes a new instance of the `BoolExpression` class.
+     * Initializes a new instance of the [BoolExpression](xref:adaptive-expressions.BoolExpression) class.
      * @param value A `boolean` or a `string` expression which resolves to a `boolean`.
      */
     public constructor(value?: boolean | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
@@ -16,7 +16,7 @@ import { ExpressionProperty } from './expressionProperty';
  */
 export class EnumExpression<T> extends ExpressionProperty<T> {
     /**
-     * Initializes a new instance of the `EnumExpression<T>` class.
+     * Initializes a new instance of the [EnumExpression<T>](xref:adaptive-expressions.EnumExpression) class.
      * @param value An enum of `T` or a `string` expression which resolves to an `enum`.
      */
     public constructor(value: T | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
@@ -16,7 +16,7 @@ export class ExpressionProperty<T> {
     private expression: Expression;
 
     /**
-     * Initializes a new instance of the `ExpressionProperty<T>` class.
+     * Initializes a new instance of the [ExpressionProperty<T>](xref:adaptive-expressions.ExpressionProperty) class.
      * @param value Optional. Raw value of the expression property.
      * @param defaultValue Optional. Default value for the property.
      */

--- a/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
@@ -15,7 +15,7 @@ import { Expression } from '../expression';
  */
 export class IntExpression extends ExpressionProperty<number> {
     /**
-     * Initializes a new instance of the `IntExpression` class.
+     * Initializes a new instance of the [IntExpression](xref:adaptive-expressions.IntExpression) class.
      * @param value An int `number` or `string` expression which resolves to an int `number`.
      */
     public constructor(value?: number | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
@@ -15,7 +15,7 @@ import { Expression } from '../expression';
  */
 export class NumberExpression extends ExpressionProperty<number> {
     /**
-     * Initializes a new instance of the `NumberExpression` class.
+     * Initializes a new instance of the [NumberExpression](xref:adaptive-expressions.NumberExpression) class.
      * @param value A float `number` or `string` expression which resolves to a float `number`.
      */
     public constructor(value?: number | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
@@ -17,7 +17,7 @@ import { Expression } from '../expression';
  */
 export class ObjectExpression<T> extends ExpressionProperty<T> {
     /**
-     * Initializes a new instance of the `ObjectExpression<T>` class.
+     * Initializes a new instance of the [ObjectExpression<T>](xref:adaptive-expressions.ObjectExpression) class.
      * @param value An object of type `T` or a `string` expression which resolves to a object of type `T`.
      */
     public constructor(value?: T | string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -23,7 +23,7 @@ import { Expression } from '../expression';
  */
 export class StringExpression extends ExpressionProperty<string> {
     /**
-     * Initializes a new instance of the `StringExpression` class.
+     * Initializes a new instance of the [StringExpression](xref:adaptive-expressions.StringExpression) class.
      * @param value A `string` value or a `string` expression.
      */
     public constructor(value?: string | Expression) {

--- a/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
@@ -23,7 +23,7 @@ import { Expression } from '../expression';
  */
 export class ValueExpression extends ExpressionProperty<any> {
     /**
-     * Initializes a new instance of the `ValueExpression` class.
+     * Initializes a new instance of the [ValueExpression](xref:adaptive-expressions.ValueExpression) class.
      * @param value An object of `any` kind or a `string` expression.
      */
     public constructor(value?: any | string | Expression) {


### PR DESCRIPTION
PR 2855 in MS, #174 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.