### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/adaptive-expressions/root-memory-parser

### DIFF
--- a/libraries/adaptive-expressions/src/constant.ts
+++ b/libraries/adaptive-expressions/src/constant.ts
@@ -44,7 +44,7 @@ export class Constant extends Expression {
     private _value: any;
 
     /**
-     * Initializes a new instance of the `Constant` class.
+     * Initializes a new instance of the [Constant](xref:adaptive-expressions.Constant) class.
      * Constructs an expression constant.
      * @param value Constant value.
      */
@@ -62,9 +62,9 @@ export class Constant extends Expression {
     }
 
     /**
-     * Determines if the current Expression instance is deep equal to another one.
-     * @param other The other Expression instance to compare.
-     * @returns A boolean value indicating whether the two Expressions are deep equal (`true`) or not (`false`).
+     * Determines if the current [Expression](xref:adaptive-expressions.Expression) instance is deep equal to another one.
+     * @param other The other [Expression](xref:adaptive-expressions.Expression) instance to compare.
+     * @returns A boolean value indicating whether the two expressions are deep equal (`true`) or not (`false`).
      */
     public deepEquals(other: Expression): boolean {
         let eq: boolean;

--- a/libraries/adaptive-expressions/src/expression.ts
+++ b/libraries/adaptive-expressions/src/expression.ts
@@ -217,9 +217,9 @@ export class Expression {
     }
 
     /**
-     * Parse an expression string into an expression object.
+     * Parse an expression string into an [Expression](xref:adaptive-expressions.Expression) object.
      * @param expression Expression string.
-     * @param lookup Optional. Function lookup when parsing the expression. Default is Expression.lookup which uses Expression.functions table.
+     * @param lookup Optional. [EvaluatorLookup](xref:adaptive-expressions.EvaluatorLookup) function lookup when parsing the expression. Default is [Expression.lookup](xref:adaptive-expressions.Expression.lookup) which uses [Expression.functions](xref:adaptive-expressions.Expression.functions) table.
      * @returns The expression object.
      */
     public static parse(expression: string, lookup?: EvaluatorLookup): Expression {
@@ -227,9 +227,9 @@ export class Expression {
     }
 
     /**
-     * Lookup an `ExpressionEvaluator` (function) by name.
+     * Lookup an [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) function by name.
      * @param functionName Name of function to lookup.
-     * @returns An `ExpressionEvaluator` corresponding to the function name.
+     * @returns An [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) corresponding to the function name.
      */
     public static lookup(functionName: string): ExpressionEvaluator {
         const exprEvaluator = Expression.functions.get(functionName);
@@ -376,8 +376,8 @@ export class Expression {
     }
 
     /**
-     * Returns a string that represents the current Expression object.
-     * @returns A string that represents the current Expression object.
+     * Returns a string that represents the current [Expression](xref:adaptive-expressions.Expression) object.
+     * @returns A string that represents the current [Expression](xref:adaptive-expressions.Expression) object.
      */
     public toString(): string {
         let builder = '';

--- a/libraries/adaptive-expressions/src/functionTable.ts
+++ b/libraries/adaptive-expressions/src/functionTable.ts
@@ -19,7 +19,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     private readonly customFunctions = new Map<string, ExpressionEvaluator>();
 
     /**
-     * Gets a collection of string values that represent the keys of the StandardFunctions.
+     * Gets a collection of string values that represent the keys of the [ExpressionFunctions.standardFunctions](xref:adaptive-expressions.ExpressionFunctions.standardFunctions).
      * @returns A list of string values.
      */
     public keys(): IterableIterator<string> {
@@ -30,8 +30,8 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Gets a collection of ExpressionEvaluator which is the value of the StandardFunctions.
-     * @returns A list of ExpressionEvaluator.
+     * Gets a collection of [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) which is the value of the StandardFunctions.
+     * @returns A list of [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator).
      */
     public values(): IterableIterator<ExpressionEvaluator> {
         const valuesOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.values()).concat(
@@ -41,7 +41,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Gets the total number of StandardFunctions and user customFunctions.
+     * Gets the total number of [ExpressionFunctions.standardFunctions](xref:adaptive-expressions.ExpressionFunctions.standardFunctions) and user [customFunctions](xref:adaptive-expressions.FunctionTable.customFunctions).
      * @returns An integer value.
      */
     public get size(): number {
@@ -49,17 +49,17 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Gets a value indicating whether the FunctionTable is readonly.
-     * @returns A boolean value indicating whether the FunctionTable is readonly.
+     * Gets a value indicating whether the [FunctionTable](xref:adaptive-expressions.FunctionTable) is readonly.
+     * @returns A boolean value indicating whether the [FunctionTable](xref:adaptive-expressions.FunctionTable) is readonly.
      */
     public get isReadOnly(): boolean {
         return false;
     }
 
     /**
-     * Gets a value of ExpressionEvaluator corresponding to the given key.
+     * Gets a value of [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) corresponding to the given key.
      * @param key A string value of function name.
-     * @returns An ExpressionEvaluator.
+     * @returns An [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator).
      */
     public get(key: string): ExpressionEvaluator {
         if (ExpressionFunctions.standardFunctions.get(key)) {
@@ -74,9 +74,9 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Sets a value of ExpressionEvaluator corresponding to the given key.
+     * Sets a value of [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) corresponding to the given key.
      * @param key A string value of function name.
-     * @param value The value to set for the ExpressionEvaluator.
+     * @param value The value to set for the [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator).
      */
     public set(key: string, value: ExpressionEvaluator): this {
         if (ExpressionFunctions.standardFunctions.get(key)) {
@@ -92,9 +92,9 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     public add(key: string, value: customFunction): void;
 
     /**
-     * Inserts a mapping of a string key to ExpressionEvaluator into FunctionTable.
-     * @param param1 Key-Value pair for the ExpressionEvaluator or the function name to be added.
-     * @param param2 Value of the ExpressionEvaluator to be added or value of the user customized function to be added.
+     * Inserts a mapping of a string key to [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) into [FunctionTable](xref:adaptive-expressions.FunctionTable).
+     * @param param1 Key-Value pair for the [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) or the function name to be added.
+     * @param param2 Value of the [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator) to be added or value of the user customized function to be added.
      */
     public add(
         param1: { key: string; value: ExpressionEvaluator } | string,
@@ -116,14 +116,14 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Clears the user customized functions.
+     * Clears the user [customFunctions](xref:adaptive-expressions.FunctionTable.customFunctions).
      */
     public clear(): void {
         this.customFunctions.clear();
     }
 
     /**
-     * Determines if the FunctionTable has a given string key.
+     * Determines if the [FunctionTable](xref:adaptive-expressions.FunctionTable) has a given string key.
      * @param key A string key.
      * @returns `True` if the key is contained, otherwise returns `False`.
      */
@@ -132,7 +132,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Deletes a specified key from user customized functions.
+     * Deletes a specified key from user [customFunctions](xref:adaptive-expressions.FunctionTable.customFunctions).
      * @param key A string key of function name.
      * @returns A boolean value indicating whether the key is successfully deleted.
      */
@@ -141,7 +141,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     }
 
     /**
-     * Operates on each element of the StandardFunctions.
+     * Operates on each element of the [ExpressionFunctions.standardFunctions](xref:adaptive-expressions.ExpressionFunctions.standardFunctions).
      * Not implemented.
      * @param _callbackfn Callback function.
      * @param thisArg Optional. This args.

--- a/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
+++ b/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
@@ -18,8 +18,8 @@ export class SimpleObjectMemory implements MemoryInterface {
     private memory: any = undefined;
 
     /**
-     * Initializes a new instance of the `SimpleObjectMemory` class.
-     * This wraps a simple object as `MemoryInterface`.
+     * Initializes a new instance of the [SimpleObjectMemory](xref:adaptive-expressions.SimpleObjectMemory) class.
+     * This wraps a simple object as [MemoryInterface](xref:adaptive-expressions.MemoryInterface).
      * @param memory The object to wrap.
      */
     public constructor(memory: any) {
@@ -157,7 +157,7 @@ export class SimpleObjectMemory implements MemoryInterface {
     }
 
     /**
-     * Returns the version info of `SimpleObjectMemory`.
+     * Returns the version info of [SimpleObjectMemory](xref:adaptive-expressions.SimpleObjectMemory).
      * @returns A string value representing the version info.
      */
     public version(): string {
@@ -165,8 +165,8 @@ export class SimpleObjectMemory implements MemoryInterface {
     }
 
     /**
-     * Returns a string that represents the current SimpleObjectMemory object.
-     * @returns A string value representing the current SimpleObjectMemory object.
+     * Returns a string that represents the current [SimpleObjectMemory](xref:adaptive-expressions.SimpleObjectMemory) object.
+     * @returns A string value representing the current [SimpleObjectMemory](xref:adaptive-expressions.SimpleObjectMemory) object.
      */
     public toString(): string {
         return JSON.stringify(this.memory, this.getCircularReplacer());

--- a/libraries/adaptive-expressions/src/memory/stackedMemory.ts
+++ b/libraries/adaptive-expressions/src/memory/stackedMemory.ts
@@ -15,9 +15,9 @@ import { MemoryInterface } from './memoryInterface';
  */
 export class StackedMemory extends Array<MemoryInterface> implements MemoryInterface {
     /**
-     * Wraps an object that implements `MemoryInterface` into a `StackedMemory` object.
-     * @param memory An object that implements `MemoryInterface`.
-     * @returns A StackedMemory object.
+     * Wraps an object that implements [MemoryInterface](xref:adaptive-expressions.MemoryInterface) into a [StackedMemory](xref:adaptive-expressions.StackedMemory) object.
+     * @param memory An object that implements [MemoryInterface](xref:adaptive-expressions.MemoryInterface).
+     * @returns A [StackedMemory](xref:adaptive-expressions.StackedMemory) object.
      */
     public static wrap(memory: MemoryInterface): StackedMemory {
         if (memory instanceof StackedMemory) {
@@ -58,7 +58,7 @@ export class StackedMemory extends Array<MemoryInterface> implements MemoryInter
     }
 
     /**
-     * Gets the version of the current StackedMemory.
+     * Gets the version of the current [StackedMemory](xref:adaptive-expressions.StackedMemory).
      * @returns A string value representing the version.
      */
     public version(): string {

--- a/libraries/adaptive-expressions/src/options.ts
+++ b/libraries/adaptive-expressions/src/options.ts
@@ -14,8 +14,8 @@ export class Options {
     public nullSubstitution: (path: string) => any;
 
     /**
-     * Initializes a new instance of the `Options` class.
-     * @param opt An Options instance.
+     * Initializes a new instance of the [Options](xref:adaptive-expressions.Options) class.
+     * @param opt Optional. An [Options](xref:adaptive-expressions.Options) instance.
      */
     public constructor(opt?: Options) {
         this.nullSubstitution = opt ? opt.nullSubstitution : undefined;

--- a/libraries/adaptive-expressions/src/parser/expressionParser.ts
+++ b/libraries/adaptive-expressions/src/parser/expressionParser.ts
@@ -257,8 +257,8 @@ export class ExpressionParser implements ExpressionParserInterface {
     };
 
     /**
-     * Initializes a new instance of the `ExpressionParser` class.
-     * @param lookup Delegate to lookup evaluation information from type string.
+     * Initializes a new instance of the [ExpressionParser](xref:adaptive-expressions.ExpressionParser) class.
+     * @param lookup [EvaluatorLookup](xref:adaptive-expressions.EvaluatorLookup) for information from type string.
      */
     public constructor(lookup?: EvaluatorLookup) {
         this.EvaluatorLookup = lookup || Expression.lookup;

--- a/libraries/adaptive-expressions/src/parser/parseErrorListener.ts
+++ b/libraries/adaptive-expressions/src/parser/parseErrorListener.ts
@@ -21,7 +21,7 @@ export class ParseErrorListener implements ANTLRErrorListener<any> {
      * @param line The line number where the error occurred.
      * @param charPositionInLine The position of character in the line where the error occurred.
      * @param msg The error message.
-     * @param _e The RecognitionException.
+     * @param _e The `RecognitionException`.
      */
     public syntaxError<T>(
         _recognizer: Recognizer<T, any>,


### PR DESCRIPTION
PR 2856 in MS, #175 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.