### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/teams-scenarios-files

### DIFF
--- a/libraries/teams-scenarios/conversationUpdate/src/conversationUpdateBot.ts
+++ b/libraries/teams-scenarios/conversationUpdate/src/conversationUpdateBot.ts
@@ -16,10 +16,9 @@ import {
  * From the UI you can click the 3 dots on the team level, or the channel level to add, rename, or delete the channel/team.
  * You can go to the "manage team" option at the team level to add/remove people.
  */
-export class ConversationUpdateBot  extends TeamsActivityHandler {
-
+export class ConversationUpdateBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `ConversationUpdateBot` class.
+     * Initializes a new instance of the [ConversationUpdateBot](xref:conversation-update.ConversationUpdateBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/fileUpload/src/fileUploadBot.ts
+++ b/libraries/teams-scenarios/fileUpload/src/fileUploadBot.ts
@@ -17,7 +17,7 @@ import {
  */
 export class FileUploadBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `FileUploadBot` class.
+     * Initializes a new instance of the [FileUploadBot](xref:teams-file-bot.FileUploadBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/link-unfurling/src/linkUnfurling.ts
+++ b/libraries/teams-scenarios/link-unfurling/src/linkUnfurling.ts
@@ -15,7 +15,7 @@ from 'botbuilder';
  */
 export class LinkUnfurlingBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `LinkUnfurlingBot` class.
+     * Initializes a new instance of the [LinkUnfurlingBot](xref:teams-link-unfurling.LinkUnfurlingBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/mentionsBot/src/mentionsBot.ts
+++ b/libraries/teams-scenarios/mentionsBot/src/mentionsBot.ts
@@ -10,9 +10,9 @@ import {
 /**
  * You can @mention the bot from any scope and it will reply with the mention.
  */
-export class MentionsBot  extends TeamsActivityHandler {
+export class MentionsBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `MentionsBot` class.
+     * Initializes a new instance of the [MentionsBot](xref:mentions-bot.MentionsBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/messageReaction/src/activityLog.ts
+++ b/libraries/teams-scenarios/messageReaction/src/activityLog.ts
@@ -17,7 +17,7 @@ export class ActivityLog  {
     private readonly _storage: Storage;
 
     /**
-     * Initializes a new instance of the `ActivityLog` class.
+     * Initializes a new instance of the [ActivityLog](xref:reactions-bot.ActivityLog) class.
      * @param storage A storage provider that stores and retrieves plain old JSON objects.
      */
     public constructor(storage: Storage) {
@@ -25,9 +25,9 @@ export class ActivityLog  {
     }
 
     /**
-     * Saves an `Activity` with its associated id into the storage.
-     * @param activityId `Activity`'s Id.
-     * @param activity The `Activity` object.
+     * Saves an [Activity](xref:botframework-schema.Activity) with its associated id into the storage.
+     * @param activityId [Activity](xref:botframework-schema.Activity)'s Id.
+     * @param activity The [Activity](xref:botframework-schema.Activity) object.
      */
     public async append(activityId: string, activity: Partial<Activity>): Promise<void> {
         if (activityId == null)
@@ -49,9 +49,9 @@ export class ActivityLog  {
     }
 
     /**
-     * Retrieves an `Activity` from the storage by a given Id.
-     * @param activityId `Activity`'s Id.
-     * @returns The `Activity`'s object retrieved from storage.
+     * Retrieves an [Activity](xref:botframework-schema.Activity) from the storage by a given Id.
+     * @param activityId [Activity](xref:botframework-schema.Activity)'s Id.
+     * @returns The [Activity](xref:botframework-schema.Activity)'s object retrieved from storage.
      */
     public async find(activityId: string): Promise<Activity>
     {

--- a/libraries/teams-scenarios/messageReaction/src/messageReactionBot.ts
+++ b/libraries/teams-scenarios/messageReaction/src/messageReactionBot.ts
@@ -19,8 +19,8 @@ export class MessageReactionBot extends ActivityHandler {
     _log: ActivityLog;
 
     /**
-     * Initializes a new instance of the `MessageReactionBot` class.
-     * @param activityLog The `ActivityLog`.
+     * Initializes a new instance of the [MessageReactionBot](xref:reactions-bot.MessageReactionBot) class.
+     * @param activityLog The [ActivityLog](xref:reactions-bot.ActivityLog).
      */
     constructor(activityLog: ActivityLog) {
         super();
@@ -75,8 +75,8 @@ export class MessageReactionBot extends ActivityHandler {
 
     /**
      * Sends an activity reply.
-     * @param context The `TurnContext`.
-     * @param text The `Activity`'s text.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext).
+     * @param text The [Activity](xref:botframework-schema.Activity)'s text.
      */
     async sendMessageAndLogActivityId(context: TurnContext, text: string): Promise<void> {
         var replyActivity = MessageFactory.text(text);

--- a/libraries/teams-scenarios/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
+++ b/libraries/teams-scenarios/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
@@ -29,7 +29,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
     connectionName: string;
 
     /**
-     * Initializes a new instance of the `MessagingExtensionAuthBot` class.
+     * Initializes a new instance of the [MessagingExtensionAuthBot](xref:messagingextension-auth.MessagingExtensionAuthBot) class.
      * @param authConnectionName The Auth connection name.
      */
     constructor(authConnectionName: string) {

--- a/libraries/teams-scenarios/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
+++ b/libraries/teams-scenarios/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
@@ -17,12 +17,12 @@ import {
 /**
  * After uploading the manifest you can click the dots in the extension menu at the bottom, or search for the
  * exntesion in the command bar. From the extension window or the command bar you can click on the 3 dots on the specific extension to trigger
- * the onMessage function. If you click on the "Settings" tab you will fire the handleTeamsMessagingExtensionConfigurationSetting
- * function.
+ * the [ActivityHandler.onMessage](xref:botbuilder-core.ActivityHandler.onMessage) method. If you click on the "Settings" tab you will fire the [handleTeamsMessagingExtensionConfigurationSetting](xref:messaging-extension-bot.MessagingExtensionConfigBot.handleTeamsMessagingExtensionConfigurationSetting)
+ * method.
  */
-export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
+export class MessagingExtensionConfigBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `MessagingExtensionConfigBot` class.
+     * Initializes a new instance of the [MessagingExtensionConfigBot](xref:messaging-extension-bot.MessagingExtensionConfigBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/notificationOnly/src/notificationOnlyBot.ts
+++ b/libraries/teams-scenarios/notificationOnly/src/notificationOnlyBot.ts
@@ -16,7 +16,7 @@ import {
  */
 export class NotificationOnlyBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `NotificationOnlyBot` class.
+     * Initializes a new instance of the [NotificationOnlyBot](xref:notification-only.NotificationOnlyBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/office365Card/src/office365CardsBot.ts
+++ b/libraries/teams-scenarios/office365Card/src/office365CardsBot.ts
@@ -24,7 +24,7 @@ import {
  */
 export class Office365CardsBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `Office365CardsBot` class.
+     * Initializes a new instance of the [Office365CardsBot](xref:office365-cards.Office365CardsBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/replyToChannel/src/replyToChannelBot.ts
+++ b/libraries/teams-scenarios/replyToChannel/src/replyToChannelBot.ts
@@ -17,13 +17,13 @@ import {
 import { basename } from 'path';
 
 /**
- * Reply to channel bot handlers.
+ * Reply to channel bot handler.
  */
 export class ReplyToChannelBot extends TeamsActivityHandler {
     botId: string;
 
     /**
-     * Initializes a new instance of the `ReplyToChannelBot` class.
+     * Initializes a new instance of the [ReplyToChannelBot](xref:reply-to-channel.ReplyToChannelBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/roster/src/rosterBot.ts
+++ b/libraries/teams-scenarios/roster/src/rosterBot.ts
@@ -15,7 +15,7 @@ import {
  */
 export class RosterBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `RosterBot` class.
+     * Initializes a new instance of the [RosterBot](xref:teams-roster-bot.RosterBot) class.
      */
     constructor() {
         super();

--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
@@ -22,7 +22,7 @@ import {
  */
 export class TeamsSearchExtensionBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `TeamsSearchExtensionBot` class.
+     * Initializes a new instance of the [TeamsSearchExtensionBot](xref:search-extension-bot.TeamsSearchExtensionBot) class.
      * We need to change the key for the user state because the bot might not be in the conversation, which means they get a 403 error.
      * @param userState User's bot state for persistance.
      */

--- a/libraries/teams-scenarios/taskModule/src/taskModuleBot.ts
+++ b/libraries/teams-scenarios/taskModule/src/taskModuleBot.ts
@@ -20,9 +20,9 @@ import {
  * This bot can be installed at any scope. If you @mention the bot you will get the task module. You can interact with the task module to
  * hit the other functions.
  */
-export class TaskModuleBot  extends TeamsActivityHandler {
+export class TaskModuleBot extends TeamsActivityHandler {
     /**
-     * Initializes a new instance of the `TaskModuleBot` class.
+     * Initializes a new instance of the [TaskModuleBot](xref:task-module.TaskModuleBot) class.
      */
     constructor() {
         super();


### PR DESCRIPTION
PR 2841 in MS, #161 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.