### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs-adaptive/converters

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
@@ -10,13 +10,13 @@ import { Converter } from 'botbuilder-dialogs-declarative';
 import { ActivityTemplate, StaticActivityTemplate, TextTemplate } from '../templates';
 
 /**
- * Activity template converter that implements `Converter`.
+ * Activity template converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class ActivityTemplateConverter implements Converter {
     /**
-     * Converts a template to one of the following classes `ActivityTemplate` | `StaticActivityTemplate`.
+     * Converts a template to one of the following classes [ActivityTemplate](xref:botbuilder-dialogs-adaptive.ActivityTemplate) | [StaticActivityTemplate](xref:botbuilder-dialogs-adaptive.Static.ActivityTemplate)
      * @param value The template to evaluate to create the activity.
-     * @returns A new instance that could be the following classes `ActivityTemplate` | `StaticActivityTemplate`.
+     * @returns A new instance that could be the following classes [ActivityTemplate](xref:botbuilder-dialogs-adaptive.ActivityTemplate) | [StaticActivityTemplate](xref:botbuilder-dialogs-adaptive.Static.ActivityTemplate).
      */
     public convert(value: string): ActivityTemplate | StaticActivityTemplate | TextTemplate {
         if (typeof value === 'string') {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
@@ -11,13 +11,13 @@ import { Dialog } from 'botbuilder-dialogs';
 import { DialogExpression } from '../expressions';
 
 /**
- * Dialog expression converter that implements `Converter`.
+ * Dialog expression converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class DialogExpressionConverter implements Converter {
     private _resourceExplorer: ResourceExplorer;
 
     /**
-     * Initializes a new instance of the `DialogExpressionConverter` class.
+     * Initializes a new instance of the [DialogExpressionConverter](xref:botbuilder-dialogs-adaptive.DialogExpressionConverter) class.
      * @param resouceExplorer Resource explorer to use for resolving references.
      */
     public constructor(resouceExplorer: ResourceExplorer) {
@@ -25,9 +25,9 @@ export class DialogExpressionConverter implements Converter {
     }
 
     /**
-     * Converts an object or string to a `DialogExpression` instance.
+     * Converts an object or string to a [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) instance.
      * @param value An object or string value.
-     * @returns A new `DialogExpression` instance.
+     * @returns A new [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) instance.
      */
     public convert(value: string | object): DialogExpression {
         if (typeof value == 'string') {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
@@ -10,13 +10,13 @@ import { Converter } from 'botbuilder-dialogs-declarative';
 import { ResourceMultiLanguageGenerator } from '../generators';
 
 /**
- * Language generator converter that implements `Converter`.
+ * Language generator converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class LanguageGeneratorConverter implements Converter {
     /**
-     * Creates a new `ResourceMultiLanguageGenerator` instance from Resource id value.
+     * Creates a new [ResourceMultiLanguageGenerator](xref:botbuilder-dialogs-adaptive.ResourceMultiLanguageGenerator) instance from Resource id value.
      * @param value Resource id of LG file.
-     * @returns A new `ResourceMultiLanguageGenerator` instance.
+     * @returns A new [ResourceMultiLanguageGenerator](xref:botbuilder-dialogs-adaptive.ResourceMultiLanguageGenerator) instance.
      */
     public convert(value: string|ResourceMultiLanguageGenerator): ResourceMultiLanguageGenerator {
         return typeof value === 'string' ? new ResourceMultiLanguageGenerator(value) : value;

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
@@ -11,13 +11,13 @@ import { Recognizer } from '../recognizers';
 import { RecognizerConverter } from './recognizerConverter';
 
 /**
- * Language generator converter that implements `Converter`.
+ * Language generator converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class MultiLanguageRecognizerConverter implements Converter {
     private _recognizerConverter: RecognizerConverter;
 
     /**
-     * Initializes a new instance of the `MultiLanguageRecognizerConverter` class.
+     * Initializes a new instance of the [MultiLanguageRecognizerConverter](xref:botbuilder-dialogs-adaptive.MultiLanguageRecognizerConverter) class.
      * @param resouceExplorer Resource explorer to use for resolving references.
      */
     public constructor(resouceExplorer: ResourceExplorer) {
@@ -25,9 +25,9 @@ export class MultiLanguageRecognizerConverter implements Converter {
     }
 
     /**
-     * Converts a recognizers object to an object with `Recognizer` instance for each key.
+     * Converts a recognizers object to an object with [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance for each key.
      * @param value A recognizers object.
-     * @returns The value object with `Recognizer` instance for each key.
+     * @returns The value object with [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance for each key.
      */
     public convert(value: object): { [key: string]: Recognizer } {
         const recognizers = {};

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
@@ -10,13 +10,13 @@ import { Converter, ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import { Recognizer } from '../recognizers';
 
 /**
- * Recognizer converter that implements `Converter`.
+ * Recognizer converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class RecognizerConverter implements Converter {
     private _resourceExplorer: ResourceExplorer;
 
     /**
-     * Initializes a new instance of the `RecognizerConverter` class.
+     * Initializes a new instance of the [RecognizerConverter](xref:botbuilder-dialogs-adaptive.RecognizerConverter) class.
      * @param resouceExplorer Resource explorer to use for resolving references.
      */
     public constructor(resouceExplorer: ResourceExplorer) {
@@ -24,9 +24,9 @@ export class RecognizerConverter implements Converter {
     }
 
     /**
-     * Converts an object or string to a `Recognizer` instance.
+     * Converts an object or string to a [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance.
      * @param value An object or string value.
-     * @returns A new `Recognizer` instance.
+     * @returns A new [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance.
      */
     public convert(value: string | object): Recognizer {
         if (typeof value == 'string') {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
@@ -10,13 +10,13 @@ import { Converter } from 'botbuilder-dialogs-declarative';
 import { TextTemplate } from '../templates';
 
 /**
- * Text template converter that implements `Converter`.
+ * Text template converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class TextTemplateConverter implements Converter {
     /**
-     * Converts a string to a `TextTemplate` instance.
+     * Converts a string to a [TextTemplate](xref:botbuilder-dialogs-adaptive.TextTemplate) instance.
      * @param value The template to evaluate to create text.
-     * @returns A new `TextTemplate` instance.
+     * @returns A new [TextTemplate](xref:botbuilder-dialogs-adaptive.TextTemplate) instance.
      */
     public convert(value: string): TextTemplate {
         return new TextTemplate(value);

--- a/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
@@ -9,15 +9,15 @@ import { Expression, ExpressionProperty } from 'adaptive-expressions';
 import { Dialog } from 'botbuilder-dialogs';
 
 /**
- * Represents a property which is either a Dialog or a string expression for a dialogId.
+ * Represents a property which is either a [Dialog](xref:botbuilder-dialogs.Dialog) or a string expression for a dialogId.
  * @remarks
  * String values are always interpreted as a string with interpolation, unless it has '=' prefix
  * or not. The result is interpreted as a resource Id or dialogId.
  */
 export class DialogExpression extends ExpressionProperty<Dialog> {
     /**
-     * Initializes a new instance of the `DialogExpression` class.
-     * @param value Optional. A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
+     * Initializes a new instance of the [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) class.
+     * @param value Optional. A [Dialog](xref:botbuilder-dialogs.Dialog), a `string` that is interpreted as a resource Id or dialogId, or an [Expression](xref:adaptive-expressions.Expression).
      */
     public constructor(value?: Dialog | string | Expression) {
         super(value);
@@ -25,7 +25,7 @@ export class DialogExpression extends ExpressionProperty<Dialog> {
 
     /**
      * Sets the raw value of the expression property.
-     * @param value A `Dialog`, a `string` that is interpreted as a resource Id or dialogId, or an `Expression`.
+     * @param value A [Dialog](xref:botbuilder-dialogs.Dialog), a `string` that is interpreted as a resource Id or dialogId, or an [Expression](xref:adaptive-expressions.Expression).
      */
     public setValue(value: Dialog | string | Expression): void {
         if (typeof value == 'string' && !value.startsWith('=')) {

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
@@ -18,7 +18,7 @@ import { LanguageResourceLoader } from '../languageResourceLoader';
 import { TemplateEngineLanguageGenerator } from './templateEngineLanguageGenerator';
 
 /**
- * Class which manages cache of all LG resources from a ResourceExplorer.
+ * Class which manages cache of all LG resources from a [ResourceExplorer](xref:botbuilder-dialogs-declarative.ResourceExplorer).
  */
 export class LanguageGeneratorManager {
     /**
@@ -32,7 +32,7 @@ export class LanguageGeneratorManager {
     private _multiLanguageResources: Map<string, Resource[]>;
 
     /**
-     * Initialize a new instance of LanguageResourceManager class.
+     * Initialize a new instance of [LanguageResourceManager](xref:botbuilder-dialogs-adaptive.LanguageResourceManager) class.
      * @param resourceManager Resource explorer to manager LG files.
      */
     public constructor(resourceManager: ResourceExplorer) {

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
@@ -13,7 +13,7 @@ import { LanguageGeneratorManager } from './languageGeneratorManager';
 import { languageGeneratorManagerKey } from '../languageGeneratorExtensions';
 
 /**
- * Multi language resource generator that extends `MultiLanguageGeneratorBase` class.
+ * Multi language resource generator that extends [MultiLanguageGeneratorBase](xref:botbuilder-dialogs-adaptive.MultiLanguageGeneratorBase) class.
  */
 export class ResourceMultiLanguageGenerator extends MultiLanguageGeneratorBase {
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
@@ -15,7 +15,7 @@ import { LanguageResourceLoader } from '../languageResourceLoader';
 import { LanguageGeneratorManager } from './languageGeneratorManager';
 
 /**
- * LanguageGenerator implementation which uses LGFile.
+ * [LanguageGenerator](xref:botbuilder-dialogs-adaptive.LanguageGenerator) implementation which uses LGFile.
  */
 export class TemplateEngineLanguageGenerator implements LanguageGenerator{
     private readonly DEFAULTLABEL: string  = 'Unknown';
@@ -25,8 +25,8 @@ export class TemplateEngineLanguageGenerator implements LanguageGenerator{
     public id: string = '';
 
     /**
-     * Initializes a new instance of the `TemplateEngineLanguageGenerator` class.
-     * @param arg1 Optional. An LG `Templates` or a `Resource`.
+     * Initializes a new instance of the [TemplateEngineLanguageGenerator](xref:botbuilder-dialogs-adaptive.TemplateEngineLanguageGenerator) class.
+     * @param arg1 Optional. An LG [Templates](xref:botbuilder-lg.Templates) or a [Resource](xref:botbuilder-dialogs-declarative.Resource).
      * @param arg2 Optional. A `Map` object with a `Resource` array for each key.
      */
     public constructor(arg1?: Templates | Resource, arg2?: Map<string,Resource[]>) {

--- a/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/luis/luisAdaptiveRecognizer.ts
@@ -56,8 +56,8 @@ export class LuisAdaptiveRecognizer extends Recognizer {
 
     /**
      * To recognize intents and entities in a users utterance.
-     * @param dialogContext Dialog Context.
-     * @param activity Activity.
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext).
+     * @param activity The [Activity](xref:botbuilder-core.Activity).
      * @param telemetryProperties Optional. Additional properties to be logged to telemetry with event.
      * @param telemetryMetrics Optional. Additional metrics to be logged to telemetry with event.
      */


### PR DESCRIPTION
PR 2857 in MS, #176 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

The conflicts with `main` are not solved in this PR to don't add irrelevant changes to review