### PR TITLE
[internal] Apply xref links for botframework-streaming-websocket

### DIFF
--- a/libraries/botframework-streaming/src/payloads/payloadAssemblerManager.ts
+++ b/libraries/botframework-streaming/src/payloads/payloadAssemblerManager.ts
@@ -21,8 +21,8 @@ export class PayloadAssemblerManager {
     private readonly activeAssemblers: { [id: string]: PayloadAssembler } = {};
 
     /**
-     * Initializes a new instance of the `PayloadAssemblerManager` class.
-     * @param streamManager The `StreamManager` managing the stream being assembled.
+     * Initializes a new instance of the [PayloadAssemblerManager](xref:botframework-streaming.PayloadAssemblerManager) class.
+     * @param streamManager The [StreamManager](xref:botframework-streaming.StreamManager) managing the stream being assembled.
      * @param onReceiveResponse Function that executes when new bytes are received on a `response` stream.
      * @param onReceiveRequest Function that executes when new bytes are received on a `request` stream.
      */
@@ -35,7 +35,7 @@ export class PayloadAssemblerManager {
     /**
      * Retrieves the assembler's payload as a stream.
      * @param header The Header of the Stream to retrieve.
-     * @returns A `SubscribableStream` of the assembler's payload.
+     * @returns A [SubscribableStream](xref:botframework-streaming.SubscribableStream) of the assembler's payload.
      */
     public getPayloadStream(header: IHeader): SubscribableStream {
         if (header.payloadType === PayloadTypes.stream) {

--- a/libraries/botframework-streaming/src/payloads/requestManager.ts
+++ b/libraries/botframework-streaming/src/payloads/requestManager.ts
@@ -33,7 +33,7 @@ export class RequestManager {
     /**
      * Signal fired when all response tasks have completed.
      * @param requestId The ID of the StreamingRequest.
-     * @param response The ReceiveResponse in response to the request.
+     * @param response The [ReceiveResponse](xref:botframework-streaming.IReceiveResponse) in response to the request.
      */
     public async signalResponse(requestId: string, response: IReceiveResponse): Promise<boolean> {
         let pendingRequest = this._pendingRequests[requestId];

--- a/libraries/botframework-streaming/src/payloads/requestManager.ts
+++ b/libraries/botframework-streaming/src/payloads/requestManager.ts
@@ -33,7 +33,7 @@ export class RequestManager {
     /**
      * Signal fired when all response tasks have completed.
      * @param requestId The ID of the StreamingRequest.
-     * @param response The [ReceiveResponse](xref:botframework-streaming.IReceiveResponse) in response to the request.
+     * @param response The [IReceiveResponse](xref:botframework-streaming.IReceiveResponse) in response to the request.
      */
     public async signalResponse(requestId: string, response: IReceiveResponse): Promise<boolean> {
         let pendingRequest = this._pendingRequests[requestId];

--- a/libraries/botframework-streaming/src/payloads/sendOperations.ts
+++ b/libraries/botframework-streaming/src/payloads/sendOperations.ts
@@ -21,16 +21,16 @@ export class SendOperations {
     private readonly payloadSender: PayloadSender;
 
     /**
-     * Initializes a new instance of the `SendOperations` class.
-     * @param payloadSender The `PayloadSender` that will send the disassembled data from all of this instance's send operations.
+     * Initializes a new instance of the [SendOperations](xref:botframework-streaming.SendOperations) class.
+     * @param payloadSender The [PayloadSender](xref:botframework-streaming.PayloadSender) that will send the disassembled data from all of this instance's send operations.
      */
     public constructor(payloadSender: PayloadSender) {
         this.payloadSender = payloadSender;
     }
 
     /**
-     * The send operation used to send a `StreamingRequest`.
-     * @param id The ID to assign to the `RequestDisassembler` used by this operation.
+     * The send operation used to send a [StreamingRequest](xref:botframework-streaming.StreamingRequest).
+     * @param id The ID to assign to the [RequestDisassembler](xref:botframework-streaming.RequestDisassembler) used by this operation.
      * @param request The request to send.
      */
     public async sendRequest(id: string, request: StreamingRequest): Promise<void> {
@@ -46,8 +46,8 @@ export class SendOperations {
     }
 
     /**
-     * The send operation used to send a `PayloadTypes.response`.
-     * @param id The ID to assign to the `ResponseDisassembler` used by this operation.
+     * The send operation used to send a [PayloadTypes.response](xref:botframework-streaming.PayloadTypes.response).
+     * @param id The ID to assign to the [ResponseDisassembler](xref:botframework-streaming.ResponseDisassembler) used by this operation.
      * @param response The response to send.
      */
     public async sendResponse(id: string, response: StreamingResponse): Promise<void> {
@@ -63,8 +63,8 @@ export class SendOperations {
     }
 
     /**
-     * The send operation used to send a `PayloadTypes.cancelStream`.
-     * @param id The ID to assign to the `CancelDisassembler` used by this operation.
+     * The send operation used to send a [PayloadTypes.cancelStream](xref:botframework-streaming.PayloadTypes.cancelStream).
+     * @param id The ID to assign to the [CancelDisassembler](xref:botframework-streaming.CancelDisassembler) used by this operation.
      */
     public async sendCancelStream(id: string): Promise<void> {
         let disassembler = new CancelDisassembler(this.payloadSender, id, PayloadTypes.cancelStream);

--- a/libraries/botframework-streaming/src/payloads/streamManager.ts
+++ b/libraries/botframework-streaming/src/payloads/streamManager.ts
@@ -17,7 +17,7 @@ export class StreamManager {
     private readonly onCancelStream: Function;
 
     /**
-     * Initializes a new instance of the `StreamManager` class.
+     * Initializes a new instance of the [StreamManager](xref:botframework-streaming.StreamManager) class.
      * @param onCancelStream Function to trigger if the managed stream is cancelled.
      */
     public constructor(onCancelStream: Function) {
@@ -25,9 +25,9 @@ export class StreamManager {
     }
 
     /**
-     * Retrieves a `PayloadAssembler` with the given ID if one exists, otherwise a new instance is created and assigned the given ID.
-     * @param id The ID of the `PayloadAssembler` to retrieve or create.
-     * @returns The `PayloadAssembler` with the given ID.
+     * Retrieves a [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) with the given ID if one exists, otherwise a new instance is created and assigned the given ID.
+     * @param id The ID of the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) to retrieve or create.
+     * @returns The [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) with the given ID.
      */
     public getPayloadAssembler(id: string): PayloadAssembler {
         if (!this.activeAssemblers[id]) {
@@ -43,9 +43,9 @@ export class StreamManager {
     }
 
     /**
-     * Retrieves the `SubscribableStream` from the `PayloadAssembler` this manager manages.
-     * @param header The Header of the `SubscribableStream` to retrieve.
-     * @returns The `SubscribableStream` with the given header.
+     * Retrieves the [SubscribableStream](xref:botframework-streaming.SubscribableStream) from the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) this manager manages.
+     * @param header The Header of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) to retrieve.
+     * @returns The [SubscribableStream](xref:botframework-streaming.SubscribableStream) with the given header.
      */
     public getPayloadStream(header: IHeader): SubscribableStream {
         let assembler = this.getPayloadAssembler(header.id);
@@ -54,9 +54,9 @@ export class StreamManager {
     }
 
     /**
-     * Used to set the behavior of the managed `PayloadAssembler` when data is received.
+     * Used to set the behavior of the managed [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) when data is received.
      * @param header The Header of the stream.
-     * @param contentStream The `SubscribableStream` to write incoming data to.
+     * @param contentStream The [SubscribableStream](xref:botframework-streaming.SubscribableStream) to write incoming data to.
      * @param contentLength The amount of data to write to the contentStream.
      */
     public onReceive(header: IHeader, contentStream: SubscribableStream, contentLength: number): void {
@@ -67,8 +67,8 @@ export class StreamManager {
     }
 
     /**
-     * Closes the `PayloadAssembler` assigned to the `SubscribableStream` with the given ID.
-     * @param id The ID of the `SubscribableStream` to close.
+     * Closes the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) assigned to the [SubscribableStream](xref:botframework-streaming.SubscribableStream) with the given ID.
+     * @param id The ID of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) to close.
      */
     public closeStream(id: string): void {
         if (!this.activeAssemblers[id]) {

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
@@ -8,7 +8,7 @@
 import { IBrowserFileReader, IBrowserWebSocket, ISocket, INodeBuffer } from '../interfaces';
 
 /**
- * Represents a WebSocket that implements `ISocket`.
+ * Represents a WebSocket that implements [ISocket](xref:botframework-streaming.ISocket).
  */
 export class BrowserWebSocket implements ISocket {
     private webSocket: IBrowserWebSocket;

--- a/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
+++ b/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
@@ -16,14 +16,14 @@ import { NodeWebSocketFactoryBase } from './nodeWebSocketFactoryBase';
 export class NodeWebSocketFactory extends NodeWebSocketFactoryBase {
 
     /**
-     * Initializes a new instance of the `NodeWebSocketFactory` class.
+     * Initializes a new instance of the [NodeWebSocketFactory](xref:botframework-streaming.NodeWebSocketFactory) class.
      */
     constructor() {
         super();
     }
 
     /**
-     * Creates a NodeWebSocket instance.
+     * Creates a [NodeWebSocket](xref:botframework-streaming.NodeWebSocket) instance.
      * @remarks
      * The parameters for this method should be associated with an 'upgrade' event off of a Node.js HTTP Server.
      * @param req An IncomingMessage from the 'http' module in Node.js.

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
@@ -14,7 +14,7 @@ import { INodeIncomingMessage, INodeBuffer, INodeSocket, ISocket } from '../inte
 const NONCE_LENGTH = 16;
 
 /**
- * An implementation of `ISocket` to use with a `NodeWebSocketFactory` to create a WebSocket server.
+ * An implementation of [ISocket](xref:botframework-streaming.ISocket) to use with a [NodeWebSocketFactory](xref:botframework-streaming.NodeWebSocketFactory) to create a WebSocket server.
  */
 export class NodeWebSocket implements ISocket {
     private wsSocket: WebSocket;


### PR DESCRIPTION
PR 2825 in MS, #151 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't include the conflict resolution.