### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder

### DIFF
--- a/libraries/botbuilder/src/fileTranscriptStore.ts
+++ b/libraries/botbuilder/src/fileTranscriptStore.ts
@@ -219,8 +219,8 @@ export class FileTranscriptStore implements TranscriptStore {
     }
 
     /**
-     * Saves the activity as a JSON file.
-     * @param activity The activity to transcript.
+     * Saves the [Activity](xref:botframework-schema.Activity) as a JSON file.
+     * @param activity The [Activity](xref:botframework-schema.Activity) to transcript.
      * @param transcriptPath The path where the transcript will be saved.
      * @param activityFilename The name for the file.
      */

--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -103,7 +103,7 @@ abstract class InterceptionMiddleware implements Middleware {
                 return await nextDelete();
             });
         }
-        
+
         if (shouldForwardToApplication) {
             try {
                 await next();
@@ -116,7 +116,7 @@ abstract class InterceptionMiddleware implements Middleware {
         }
 
         if (shouldIntercept) {
-        
+
             await this.invokeTraceState(turnContext);
         }
     }
@@ -158,7 +158,7 @@ abstract class InterceptionMiddleware implements Middleware {
  *
  * @remarks
  * InspectionMiddleware for emulator inspection of runtime Activities and BotState.
- * 
+ *
  */
 export class InspectionMiddleware extends InterceptionMiddleware {
 
@@ -187,8 +187,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
     /**
      * Indentifies open and attach commands and calls the appropriate method.
-     * @param turnContext The context for this turn.
-     * 
+     * @param turnContext The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @returns True if the command is open or attached, otherwise false.
      */
     public async processCommand(turnContext: TurnContext): Promise<any> {
@@ -220,7 +219,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
     /**
      * Processes inbound activities.
-     * @param turnContext The context for this turn.
+     * @param turnContext The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param traceActivity The trace activity.
      */
     protected async inbound(turnContext: TurnContext, traceActivity: Partial<Activity>): Promise<any> {
@@ -231,7 +230,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
         var session = await this.findSession(turnContext);
         if (session !== undefined) {
-            
+
             if (await this.invokeSend(turnContext, session, traceActivity)) {
                 return { shouldForwardToApplication: true, shouldIntercept: true };
             } else {
@@ -244,7 +243,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
     /**
      * Processes outbound activities.
-     * @param turnContext The context for this turn.
+     * @param turnContext The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param traceActivities A collection of trace activities.
      */
     protected async outbound(turnContext: TurnContext, traceActivities: Partial<Activity>[]): Promise<any> {
@@ -263,13 +262,13 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
     /**
      * Processes the state management object.
-     * @param turnContext The context for this turn.
+     * @param turnContext The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      */
     protected async traceState(turnContext: TurnContext): Promise<any> {
 
         var session = await this.findSession(turnContext);
         if (session !== undefined) {
-            
+
             if (this.userState !== undefined) {
                 await this.userState.load(turnContext, false);
             }
@@ -329,7 +328,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
             return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
               s4() + '-' + s4() + s4() + s4();
         }
-    
+
         var sessionId = generate_guid();
         sessions.openedSessions[sessionId] = conversationReference;
         return sessionId;
@@ -436,13 +435,12 @@ class InspectionSessionsByStatus {
  *
  * @remarks
  * InspectionState for use by the InspectionMiddleware for emulator inspection of runtime Activities and BotState.
- * 
+ *
  */
 export class InspectionState extends BotState {
-
     /**
-     * Creates a new instance of the InspectionState class.
-     * @param storage The storage layer this state management object will use to store and retrieve state.
+     * Creates a new instance of the [InspectionState](xref:botbuilder.InspectionState)  class.
+     * @param storage The [Storage](xref:botbuilder-core.Storage) layer this state management object will use to store and retrieve state.
      */
     constructor(storage: Storage) {
         super(storage, (context: TurnContext) => {
@@ -452,9 +450,9 @@ export class InspectionState extends BotState {
 
     /**
      * Gets the key to use when reading and writing state to and from storage.
-     * @param turnContext The context for this turn.
+     * @param turnContext The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      */
     protected getStorageKey(turnContext: TurnContext) {
         return 'InspectionState';
     }
-} 
+}

--- a/libraries/botbuilder/src/statusCodeError.ts
+++ b/libraries/botbuilder/src/statusCodeError.ts
@@ -15,7 +15,7 @@ export class StatusCodeError extends Error {
     public readonly statusCode: StatusCodes;
 
     /**
-     * Creates a new instance of the StatusCodeError class.
+     * Creates a new instance of the [StatusCodeError](xref:botbuilder.StatusCodeError) class.
      * @param statusCode The status code.
      * @param message Optional. The error message.
      */

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -31,11 +31,10 @@ import {
 import { TeamsInfo } from './teamsInfo';
 
 /**
- * The TeamsActivityHandler is derived from ActivityHandler. It adds support for 
- * the Microsoft Teams specific events and interactions.
+ * The [TeamsActivityHandler](xref:botbuilder.TeamsActivityHandler) is derived from [ActivityHandler](xref:botbuilder-core.ActivityHandler).
+ * It adds support for the Microsoft Teams specific events and interactions.
  */
 export class TeamsActivityHandler extends ActivityHandler {
-
     /**
      * Invoked when an invoke activity is received from the connector.
      * Invoke activities can be used to communicate many different things.
@@ -338,7 +337,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Receives invoke activities with the name 'composeExtension/querySettingUrl' 
+     * Receives invoke activities with the name 'composeExtension/querySettingUrl'
      * @param context A context object for this turn.
      * @param query The Messaging extension query.
      * @returns The Messaging Extension Action Response for the query.
@@ -348,7 +347,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Receives invoke activities with the name 'composeExtension/setting' 
+     * Receives invoke activities with the name 'composeExtension/setting'
      * @param context A context object for this turn.
      * @param settings Object representing the configuration settings.
      * @returns A promise that represents the work queued.
@@ -372,7 +371,7 @@ export class TeamsActivityHandler extends ActivityHandler {
                 if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
                     return await this.onTeamsMembersAdded(context);
                 }
-                
+
                 if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
                     return await this.onTeamsMembersRemoved(context);
                 }
@@ -380,15 +379,15 @@ export class TeamsActivityHandler extends ActivityHandler {
                 if (!channelData || !channelData.eventType) {
                     return await super.dispatchConversationUpdateActivity(context);
                 }
-        
+
                 switch (channelData.eventType)
                 {
                     case 'channelCreated':
                         return await this.onTeamsChannelCreated(context);
-        
+
                     case 'channelDeleted':
                         return await this.onTeamsChannelDeleted(context);
-        
+
                     case 'channelRenamed':
                         return await this.onTeamsChannelRenamed(context);
 
@@ -403,7 +402,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
                     case 'channelRestored':
                         return await this.onTeamsChannelRestored(context);
-                    
+
                     case 'teamRenamed':
                         return await this.onTeamsTeamRenamed(context);
 
@@ -452,14 +451,14 @@ export class TeamsActivityHandler extends ActivityHandler {
                     const errCode: string = err.body && err.body.error && err.body.error.code;
                     if (errCode === 'ConversationNotFound') {
                         // unable to find the member added in ConversationUpdate Activity in the response from the getMember call
-                        const teamsChannelAccount: TeamsChannelAccount = { 
+                        const teamsChannelAccount: TeamsChannelAccount = {
                             id: channelAccount.id,
                             name: channelAccount.name,
                             aadObjectId: channelAccount.aadObjectId,
                             role: channelAccount.role,
                         };
-    
-                        context.activity.membersAdded[i] = teamsChannelAccount;    
+
+                        context.activity.membersAdded[i] = teamsChannelAccount;
                     } else {
                         throw err;
                     }
@@ -501,7 +500,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Invoked when a Channel Deleted event activity is received from the connector.
      * Channel Deleted correspond to the user deleting a channel.
      * @param context A context object for this turn.
-     * @returns A promise that represents the work queued. 
+     * @returns A promise that represents the work queued.
      */
     protected async onTeamsChannelDeleted(context): Promise<void> {
         await this.handle(context, 'TeamsChannelDeleted', this.defaultNextEvent(context));
@@ -545,11 +544,11 @@ export class TeamsActivityHandler extends ActivityHandler {
      */
     protected async onTeamsTeamHardDeleted(context): Promise<void> {
         await this.handle(context, 'TeamsTeamHardDeleted', this.defaultNextEvent(context));
-    }    
+    }
 
     /**
-     * 
-     * @param context 
+     *
+     * @param context
      * Invoked when a Channel Restored event activity is received from the connector.
      * Channel Restored correspond to the user restoring a previously deleted channel.
      * @param context The context for this turn.
@@ -590,10 +589,10 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     *
      * Override this in a derived class to provide logic for when members other than the bot
      * join the channel, such as your bot's welcome logic.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsMembersAddedEvent(handler: (membersAdded: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -606,7 +605,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     /**
      * Override this in a derived class to provide logic for when members other than the bot
      * leave the channel, such as your bot's good-bye logic.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsMembersRemovedEvent(handler: (membersRemoved: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -618,7 +617,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a channel is created.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsChannelCreatedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -630,8 +629,8 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a channel is deleted.
-     * @param handler 
-     * @returns A promise that represents the work queued. 
+     * @param handler
+     * @returns A promise that represents the work queued.
      */
     public onTeamsChannelDeletedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsChannelDeleted', async (context, next) => {
@@ -642,7 +641,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a channel is renamed.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsChannelRenamedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -651,10 +650,10 @@ export class TeamsActivityHandler extends ActivityHandler {
             await handler(teamsChannelData.channel, teamsChannelData.team, context, next);
         });
     }
-    
+
     /**
      * Override this in a derived class to provide logic for when a team is archived.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamArchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -666,7 +665,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a team is deleted.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamDeletedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -678,7 +677,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a team is hard-deleted.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamHardDeletedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -690,7 +689,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a channel is restored.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsChannelRestoredEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -702,7 +701,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a team is renamed.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamRenamedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -714,7 +713,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a team is restored.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamRestoredEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
@@ -726,7 +725,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
     /**
      * Override this in a derived class to provide logic for when a team is unarchived.
-     * @param handler 
+     * @param handler
      * @returns A promise that represents the work queued.
      */
     public onTeamsTeamUnarchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this {

--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -28,10 +28,9 @@ export function teamsGetChannelId(activity: Activity): string {
 }
 
 /**
- * Gets the Team Id from the current activity.
- * @param activity The current activity.
- * 
- * @returns The current activity's team's Id, or null.
+ * Gets the Team Id from the current [Activity](xref:botframework-schema.Activity).
+ * @param activity The current [Activity](xref:botframework-schema.Activity).
+ * @returns The current [Activity](xref:botframework-schema.Activity)'s team's Id, or null.
  */
 export function teamsGetTeamId(activity: Activity): string {
     if (!activity) {
@@ -44,8 +43,8 @@ export function teamsGetTeamId(activity: Activity): string {
 }
 
 /**
- * Configures the current activity to generate a notification within Teams.
- * @param activity The current activity.
+ * Configures the current [Activity](xref:botframework-schema.Activity) to generate a notification within Teams.
+ * @param activity The current [Activity](xref:botframework-schema.Activity).
  */
 export function teamsNotifyUser(activity: Activity): void {
     if (!activity) {
@@ -61,10 +60,9 @@ export function teamsNotifyUser(activity: Activity): void {
 }
 
 /**
- * Gets the TeamsInfo object from the current activity.
- * @param activity The current activity.
- * 
- * @returns The current activity's team's info, or null.
+ * Gets the TeamsInfo object from the current [Activity](xref:botframework-schema.Activity).
+ * @param activity The current [Activity](xref:botframework-schema.Activity).
+ * @returns The current [Activity](xref:botframework-schema.Activity)'s team's info, or null.
  */
 export function teamsGetTeamInfo(activity: Activity): TeamInfo {
     if (!activity) {

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -30,7 +30,7 @@ import { BotFrameworkAdapter } from './botFrameworkAdapter';
 export class TeamsInfo {
     /**
      * Gets the details for the given team id. This only works in teams scoped conversations.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId The id of the Teams team.
      */
     public static async getTeamDetails(context: TurnContext, teamId?: string): Promise<TeamDetails> {
@@ -43,12 +43,11 @@ export class TeamsInfo {
     }
 
     /**
-     * Creates a new thread in a Teams chat and sends an activity to that new thread.
-     * @param context The context for this turn.
-     * @param activity The activity to send.
+     * Creates a new thread in a Teams chat and sends an [Activity](xref:botframework-schema.Activity) to that new thread.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
+     * @param activity The [Activity](xref:botframework-schema.Activity) to send.
      * @param teamsChannelId Id of the Teams channel.
-     * 
-     * @returns The Conversation Reference and the id of the activity (if sent).
+     * @returns The [ConversationReference](xref:botframework-schema.ConversationReference) and the id of the [Activity](xref:botframework-schema.Activity) (if sent).
      */
     public static async sendMessageToTeamsChannel(context: TurnContext, activity: Activity, teamsChannelId: string): Promise<[ConversationReference, string]> {
         if (!context) {
@@ -81,10 +80,9 @@ export class TeamsInfo {
 
     /**
      * Returns a list of channels in a Team. This only works in teams scoped conversations.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId ID of the Teams team.
-     * 
-     * @returns The list of ChannelInfo objects with the conversations.
+     * @returns The list of [ChannelInfo](xref:botframework-schema.ChannelInfo) objects with the conversations.
      */
     public static async getTeamChannels(context: TurnContext, teamId?: string): Promise<ChannelInfo[]> {
         const t = teamId || this.getTeamId(context);
@@ -98,9 +96,8 @@ export class TeamsInfo {
 
     /**
      * Gets the conversation members of a one-on-one or group chat.
-     * @param context The context for this turn.
-     * 
-     * @returns The list of TeamsChannelAccounts.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
+     * @returns The list of [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount).
      */
     public static async getMembers(context: TurnContext): Promise<TeamsChannelAccount[]> {
         const teamId = this.getTeamId(context);
@@ -115,11 +112,10 @@ export class TeamsInfo {
 
     /**
      * Gets a pagined list of members of one-on-one, group, or team conversation.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param pageSize Suggested number of entries on a page.
      * @param continuationToken A continuation token.
-     * 
-     * @returns The TeamsPagedMembersResult with the list of members.
+     * @returns The [TeamsPagedMembersResult](xref:botframework-schema.TeamsPagedMembersResult) with the list of members.
      */
     public static async getPagedMembers(context: TurnContext, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult> {
         const teamId = this.getTeamId(context);
@@ -138,10 +134,9 @@ export class TeamsInfo {
 
     /**
      * Gets the account of a single conversation member.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param userId ID of the user in question.
-     * 
-     * @returns The TeamsChannelAccount of the member.
+     * @returns The [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) of the member.
      */
     public static async getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount> {
         const teamId = this.getTeamId(context);
@@ -155,11 +150,10 @@ export class TeamsInfo {
     }
 
     /**
-     * Gets the list of TeamsChannelAccounts within a team.
-     * @param context The context for this turn.
+     * Gets the list of [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) within a team.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId ID of the Teams team.
-     * 
-     * @returns The list of TeamsChannelAccount of the members.
+     * @returns The list of [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) of the members.
      */
     public static async getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]> {
         const t = teamId || this.getTeamId(context);
@@ -171,12 +165,11 @@ export class TeamsInfo {
 
     /**
      * Gets a paginated list of members of a team.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId ID of the Teams team.
      * @param pageSize The number of entries on the page.
      * @param continuationToken The continuationToken token.
-     * 
-     * @returns A TeamsPagedMembersResult with the list of members.
+     * @returns A [TeamsPagedMembersResult](xref:botframework-schema.TeamsPagedMembersResult) with the list of members.
      */
     public static async getPagedTeamMembers(context: TurnContext, teamId?: string, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult> {
         const t = teamId || this.getTeamId(context);
@@ -193,11 +186,10 @@ export class TeamsInfo {
 
     /**
      * Gets the account of a member in a teams scoped conversation.
-     * @param context The context for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId ID of the Teams team.
      * @param userId ID of the Teams user.
-     * 
-     * @returns The TeamsChannelAccount of the member.
+     * @returns The [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) of the member.
      */
     public static async getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount> {
         const t = teamId || this.getTeamId(context);


### PR DESCRIPTION
PR 2819 in MS, #144 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.