### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs/memory-path-resolver

### DIFF
--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
@@ -16,7 +16,7 @@ export class AliasPathResolver implements PathResolver {
     private readonly postfix: string;
 
     /**
-     * Initializes a new instance of the AliasPathResolver class.
+     * Initializes a new instance of the [AliasPathResolver](xref:botbuilder-dialogs.AliasPathResolver) class.
      * @param alias Alias name.
      * @param prefix Prefix name.
      * @param postfix Postfix name.

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/atAtPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/atAtPathResolver.ts
@@ -13,7 +13,7 @@ import { AliasPathResolver } from './aliasPathResolver';
 export class AtAtPathResolver extends AliasPathResolver {
 
     /**
-     * Initializes a new instance of the AtAtPathResolver class.
+     * Initializes a new instance of the [AtAtPathResolver](xref:botbuilder-dialogs.AtAtPathResolver) class.
      */
     constructor() {
         super('@@', 'turn.recognized.entities.');

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
@@ -16,7 +16,7 @@ export class AtPathResolver extends AliasPathResolver {
     private readonly _delims = ['.', '['];
 
     /**
-     * Initializes a new instance of the AtPathResolver class.
+     * Initializes a new instance of the [AtPathResolver](xref:botbuilder-dialogs.AtPathResolver) class.
      */
     public constructor() {
         super('@', '');

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/dollarPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/dollarPathResolver.ts
@@ -13,7 +13,7 @@ import { AliasPathResolver } from './aliasPathResolver';
 export class DollarPathResolver extends AliasPathResolver {
 
     /**
-     * Initializes a new instance of the DollarPathResolver class.
+     * Initializes a new instance of the [DollarPathResolver](xref:botbuilder-dialogs.DollarPathResolver) class.
      */
     constructor() {
         super('$', 'dialog.');

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/hashPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/hashPathResolver.ts
@@ -13,7 +13,7 @@ import { AliasPathResolver } from './aliasPathResolver';
 export class HashPathResolver extends AliasPathResolver {
 
     /**
-     * Initializes a new instance of the HashPathResolver class.
+     * Initializes a new instance of the [HashPathResolver](botbuilder-dialogs.HashPathResolver) class.
      */
     constructor() {
         super('#', 'turn.recognized.intents.');

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/percentPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/percentPathResolver.ts
@@ -13,7 +13,7 @@ import { AliasPathResolver } from './aliasPathResolver';
 export class PercentPathResolver extends AliasPathResolver {
 
     /**
-     * Initializes a new instance of the PercentPathResolver class.
+     * Initializes a new instance of the [PercentPathResolver](xref:botbuilder-dialogs.PercentPathResolver) class.
      */
     constructor() {
         super('%', 'class.');


### PR DESCRIPTION
PR 2823 in MS, #148 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't include conflict resolution.