### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-skills

### DIFF
--- a/libraries/botbuilder/src/activityValidator.ts
+++ b/libraries/botbuilder/src/activityValidator.ts
@@ -9,8 +9,9 @@
 import { Activity, ActivityTimestamps } from 'botbuilder-core';
 
 /**
- * Validates an activity and formats the timestamp fields.
- * @param activity Activity to be validated.
+ * Validates an [Activity](xref:botbuilder-core.Activity) and formats the timestamp fields.
+ * @param activity [Activity](xref:botbuilder-core.Activity) to be validated.
+ * @returns The [Activity](xref:botframework-schema.Activity).
  */
 export function validateAndFixActivity(activity: Activity): Activity {
     if (typeof activity !== 'object') { throw new Error(`validateAndFixActivity(): invalid request body.`); }

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -267,9 +267,9 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     public async continueConversation(reference: Partial<ConversationReference>, oAuthScope: string, logic: (context: TurnContext) => Promise<void>): Promise<void>
     /**
      * Asynchronously resumes a conversation with a user, possibly after some time has gone by.
-     * @param reference A reference to the conversation to continue.
+     * @param reference [ConversationReference](xref:botframework-schema.ConversationReference) of the conversation to continue.
      * @param oAuthScopeOrlogic The intended recipient of any sent activities or the function to call to continue the conversation.
-     * @param logic (Optional) The asynchronous method to call after the adapter middleware runs.
+     * @param logic Optional. The asynchronous method to call after the adapter middleware runs.
      */
     public async continueConversation(reference: Partial<ConversationReference>, oAuthScopeOrlogic: string | ((context: TurnContext) => Promise<void>), logic?: (context: TurnContext) => Promise<void>): Promise<void> {
         let audience = oAuthScopeOrlogic as string;
@@ -552,10 +552,10 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     public async getUserToken(context: TurnContext, connectionName: string, magicCode?: string, oAuthAppCredentials?: CoreAppCredentials): Promise<TokenResponse>;
     /**
      * Asynchronously attempts to retrieve the token for a user that's in a login flow.
-     * @param context The context object for the turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param connectionName The name of the auth connection to use.
      * @param magicCode Optional. The validation code the user entered.
-     * @param oAuthAppCredentials Optional. AppCredentials for OAuth.
+     * @param oAuthAppCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * 
      * @returns A [TokenResponse](xref:botframework-schema.TokenResponse) object that contains the user token.
      */
@@ -593,10 +593,10 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     /**
      * Asynchronously signs out the user from the token server.
      * 
-     * @param context The context object for the turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param connectionName Optional. The name of the auth connection to use.
      * @param userId Optional. The ID of the user to sign out.
-     * @param oAuthAppCredentials Optional. AppCredentials for OAuth. 
+     * @param oAuthAppCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      */
     public async signOutUser(context: TurnContext, connectionName?: string, userId?: string, oAuthAppCredentials?: AppCredentials): Promise<void> {
         if (!context.activity.from || !context.activity.from.id) {
@@ -630,11 +630,12 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
      * Asynchronously gets a sign-in link from the token server that can be sent as part
      * of a [SigninCard](xref:botframework-schema.SigninCard).
      * 
-     * @param context The context object for the turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param connectionName The name of the auth connection to use.
-     * @param oAuthAppCredentials Optional. The AppCredentials for OAuth.
+     * @param oAuthAppCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * @param userId Optional. The user id that will be associated with the token.
      * @param finalRedirect Optional. The final URL that the OAuth flow will redirect to.
+     * @returns The sign in link.
      */
     public async getSignInLink(context: TurnContext, connectionName: string, oAuthAppCredentials?: AppCredentials, userId?: string, finalRedirect?: string): Promise<string> {
         if (userId && userId != context.activity.from.id) {
@@ -674,12 +675,12 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     /** 
      * Asynchronously retrieves the token status for each configured connection for the given user.
      * 
-     * @param context The context object for the turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param userId Optional. If present, the ID of the user to retrieve the token status for.
-     *      Otherwise, the ID of the user who sent the current activity is used.
+     * Otherwise, the ID of the user who sent the current activity is used.
      * @param includeFilter Optional. A comma-separated list of connection's to include. If present,
-     *      the `includeFilter` parameter limits the tokens this method returns.
-     * @param oAuthAppCredentials Optional. AppCredentials for OAuth.
+     * the `includeFilter` parameter limits the tokens this method returns.
+     * @param oAuthAppCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * 
      * @returns The [TokenStatus](xref:botframework-connector.TokenStatus) objects retrieved.
      */
@@ -711,10 +712,10 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     /**
      * Asynchronously signs out the user from the token server.
      * 
-     * @param context The context object for the turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param connectionName The name of the auth connection to use.
      * @param resourceUrls The list of resource URLs to retrieve tokens for.
-     * @param oAuthAppCredentials Optional. The AppCredentials for OAuth.
+     * @param oAuthAppCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * 
      * @returns A map of the [TokenResponse](xref:botframework-schema.TokenResponse) objects by resource URL.
      */
@@ -783,11 +784,12 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     public async exchangeToken(context: TurnContext, connectionName: string, userId: string, tokenExchangeRequest: TokenExchangeRequest, appCredentials?: CoreAppCredentials): Promise<TokenResponse>
     /**
      * Asynchronously Performs a token exchange operation such as for single sign-on.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for the turn.
      * @param connectionName Name of the auth connection to use.
      * @param userId The user id that will be associated with the token.
-     * @param tokenExchangeRequest The exchange request details, either a token to exchange or a uri to exchange.
-     * @param appCredentials Optional. The AppCredentials for OAuth.
+     * @param tokenExchangeRequest The [TokenExchangeRequest](xref:botbuilder-schema.TokenExchangeRequest), either a token to exchange or a uri to exchange.
+     * @param appCredentials Optional. [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
+     * @returns A `Promise` representing the exchanged [TokenResponse](xref:botframework-schema.TokenResponse).
      */
     public async exchangeToken(context: TurnContext, connectionName: string, userId: string, tokenExchangeRequest: TokenExchangeRequest, appCredentials?: AppCredentials): Promise<TokenResponse> {
         if (!connectionName) {
@@ -1120,13 +1122,14 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
      */
     public async createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity, audience: string): Promise<ConnectorClient>
     /**
-     * Create a ConnectorClient with a ClaimsIdentity.
+     * Create a [ConnectorClient](xref:botbuilder-connector.ConnectorClient) with a [ClaimsIdentity](xref:botbuilder-connector.ClaimsIdentity).
      * @remarks
-     * If the ClaimsIdentity contains the claims for a Skills request, create a ConnectorClient for use with Skills.
-     * Derives the correct audience from the ClaimsIdentity, or the instance's credentials property.
+     * If the [ClaimsIdentity](xref:botbuilder-connector.ClaimsIdentity) contains the claims for a Skills request, create a [ConnectorClient](xref:botbuilder-connector.ConnectorClient) for use with Skills.
+     * Derives the correct audience from the [ClaimsIdentity](xref:botbuilder-connector.ClaimsIdentity), or the instance's credentials property.
      * @param serviceUrl The client's service URL.
-     * @param identity ClaimsIdentity.
-     * @param audience Optional. The recipient of the ConnectorClient's messages. Normally the Bot Framework Channel Service or the AppId of another bot.
+     * @param identity [ClaimsIdentity](xref:botbuilder-connector.ClaimsIdentity).
+     * @param audience Optional. The recipient of the [ConnectorClient](xref:botbuilder-connector.ConnectorClient)'s messages. Normally the Bot Framework Channel Service or the AppId of another bot.
+     * @returns The client.
      */
     public async createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity, audience?: string): Promise<ConnectorClient> {
         if (!identity) {
@@ -1202,9 +1205,9 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
     }
 
     /**
-     * Returns the correct OAuthScope for AppCredentials.
+     * Returns the correct [OAuthScope](xref:botframework-connector.AppCredentials.OAuthScope) for [AppCredentials](xref:botframework-connector.AppCredentials).
      * @param botAppId The bot's AppId.
-     * @param claims The list of claims to check. 
+     * @param claims The [Claim](xref:botbuilder-connector.Claim) list to check. 
      * 
      * @returns The current credentials' OAuthScope.
      */
@@ -1253,10 +1256,11 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
      * Creates an OAuth API client.
      * 
      * @param serviceUrl The client's service URL.
-     * @param oAuthAppCredentials Optional. The AppCredentials for OAuth.
+     * @param oAuthAppCredentials Optional. The [AppCredentials](xref:botframework-connector.AppCredentials)for OAuth.
      * 
      * @remarks
      * Override this in a derived class to create a mock OAuth API client for unit testing.
+     * @returns The client.
      */
     protected createTokenApiClient(serviceUrl: string, oAuthAppCredentials?: AppCredentials): TokenApiClient {
         const tokenApiClientCredentials = oAuthAppCredentials ? oAuthAppCredentials : this.credentials;
@@ -1466,7 +1470,7 @@ export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBu
 
     /**
      * Invoked when the bot is sent a health check from the hosting infrastructure or, in the case of Skills the parent bot.
-     * @param context The context object for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * 
      * @returns The result of the health check.
      */

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -35,7 +35,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
 
     /**
      * Creates a new instance of the [BotFrameworkHttpClient](xref:botbuilder.BotFrameworkHttpClient) class
-     * @param credentialProvider An instance of ICredentialProvider.
+     * @param credentialProvider An instance of [ICredentialProvider](xref:botframework-connector.ICredentialProvider).
      * @param channelService Optional. The channel service.
      */
     public constructor(credentialProvider: ICredentialProvider, channelService?: string) {
@@ -63,13 +63,14 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     public async postActivity(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse>
     /**
      * Forwards an activity to another bot.
-     * @template T The type of body in the InvokeResponse. 
+     * @template T The type of body in the [InvokeResponse](xref:botbuilder-core.InvokeResponse). 
      * @param fromBotId The MicrosoftAppId of the bot sending the activity.
      * @param toBotId The MicrosoftAppId of the bot receiving the activity.
      * @param toUrl The URL of the bot receiving the activity.
      * @param serviceUrl The callback Url for the skill host.
      * @param conversationId A conversation ID to use for the conversation with the skill.
-     * @param activity Activity to forward.
+     * @param activity [Activity](xref:botframework-schema.Activity) to forward.
+     * @returns A `Promise` representing the [InvokeResponse](xref:botbuilder-core.InvokeResponse) for the operation.
      */
     public async postActivity<T = any>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>> {
         const appCredentials = await this.getAppCredentials(fromBotId, toBotId);
@@ -146,7 +147,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     }
 
     /**
-     * Logic to build an AppCredentials object to be used to acquire tokens for this HttpClient.
+     * Logic to build an [AppCredentials](xref:botframework-connector.AppCredentials) to be used to acquire tokens for this `HttpClient`.
      * @param appId The application id.
      * @param oAuthScope Optional. The OAuth scope.
      * 

--- a/libraries/botbuilder/src/channelServiceHandler.ts
+++ b/libraries/botbuilder/src/channelServiceHandler.ts
@@ -58,10 +58,11 @@ export class ChannelServiceHandler {
     }
 
     /**
-     * Sends an activity to the end of a conversation.
+     * Sends an [Activity](xref:botframework-schema.Activity) to the end of a conversation.
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
-     * @param activity The activity to send.
+     * @param activity The [Activity](xref:botframework-schema.Activity) to send.
+     * @returns A `Promise` representing the [ResourceResponse](xref:botframework-schema.ResourceResponse) for the operation.
      */
     public async handleSendToConversation(authHeader: string, conversationId: string, activity: Activity): Promise<ResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -69,11 +70,12 @@ export class ChannelServiceHandler {
     }
 
     /**
-     * Sends a reply to an activity.
+     * Sends a reply to an [Activity](xref:botframework-schema.Activity).
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param activityId The activity Id the reply is to.
-     * @param activity The activity to send.
+     * @param activity The [Activity](xref:botframework-schema.Activity) to send.
+     * @returns A `Promise` representing the [ResourceResponse](xref:botframework-schema.ResourceResponse) for the operation.
      */
     public async handleReplyToActivity(authHeader: string, conversationId: string, activityId: string, activity: Activity): Promise<ResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -81,11 +83,12 @@ export class ChannelServiceHandler {
     }
 
     /**
-     * Edits a previously sent existing activity.
+     * Edits a previously sent existing [Activity](xref:botframework-schema.Activity).
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param activityId The activity Id to update.
-     * @param activity The replacement activity.
+     * @param activity The replacement [Activity](xref:botframework-schema.Activity).
+     * @returns A `Promise` representing the [ResourceResponse](xref:botframework-schema.ResourceResponse) for the operation.
      */
     public async handleUpdateActivity(authHeader: string, conversationId: string, activityId: string, activity: Activity): Promise<ResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -93,7 +96,7 @@ export class ChannelServiceHandler {
     }
 
     /**
-     * Deletes an existing activity.
+     * Deletes an existing [Activity](xref:botframework-schema.Activity).
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param activityId The activity Id to delete.
@@ -104,10 +107,11 @@ export class ChannelServiceHandler {
     }
 
     /**
-     * Enumerates the members of an activity.
+     * Enumerates the members of an [Activity](xref:botframework-schema.Activity).
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param activityId The activity Id.
+     * @returns The enumerated [ChannelAccount](xref:botframework-schema.ChannelAccount) list.
      */
     public async handleGetActivityMembers(authHeader: string, conversationId: string, activityId: string): Promise<ChannelAccount[]> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -117,7 +121,8 @@ export class ChannelServiceHandler {
     /**
      * Creates a new Conversation.
      * @param authHeader The authentication header.
-     * @param parameters Parameters to create the conversation from.
+     * @param parameters [ConversationParameters](xref:botbuilder-core.ConversationParameters) to create the conversation from.
+     * @returns A `Promise` representation of for the operation.
      */
     public async handleCreateConversation(authHeader: string, parameters: ConversationParameters): Promise<ConversationResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -129,6 +134,7 @@ export class ChannelServiceHandler {
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param continuationToken A skip or continuation token.
+     * @returns A `Promise` representation of for the operation.
      */
     public async handleGetConversations(authHeader: string, conversationId: string, continuationToken?: string /* some default */): Promise<ConversationsResult> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -139,6 +145,7 @@ export class ChannelServiceHandler {
      * Enumerates the members of a conversation.
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
+     * @returns The enumerated [ChannelAccount](xref:botframework-schema.ChannelAccount) list.
      */
     public async handleGetConversationMembers(authHeader: string, conversationId: string): Promise<ChannelAccount[]> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -151,6 +158,7 @@ export class ChannelServiceHandler {
      * @param conversationId The conversation Id.
      * @param pageSize Suggested page size.
      * @param continuationToken A continuation token.
+     * @returns A `Promise` representing the [PagedMembersResult](xref:botframework-schema.PagedMembersResult) for the operation.
      */
     public async handleGetConversationPagedMembers(
         authHeader: string,
@@ -176,7 +184,8 @@ export class ChannelServiceHandler {
      * Uploads the historic activities of the conversation.
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
-     * @param transcript Transcript of activities.
+     * @param transcript [Transcript](xref:botframework-schema.Transcript) of activities.
+     * @returns A `Promise` representing the [ResourceResponse](xref:botframework-schema.ResourceResponse) for the operation.
      */
     public async handleSendConversationHistory(authHeader: string, conversationId: string, transcript: Transcript): Promise<ResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -187,7 +196,8 @@ export class ChannelServiceHandler {
      * Stores data in a compliant store when dealing with enterprises.
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
-     * @param attachmentUpload Attachment data.
+     * @param attachmentUpload [AttachmentData](xref:botframework-schema.AttachmentData).
+     * @returns A `Promise` representing the [ResourceResponse](xref:botframework-schema.ResourceResponse) for the operation.
      */
     public async handleUploadAttachment(authHeader: string, conversationId: string, attachmentUpload: AttachmentData): Promise<ResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);

--- a/libraries/botbuilder/src/channelServiceHandler.ts
+++ b/libraries/botbuilder/src/channelServiceHandler.ts
@@ -122,7 +122,7 @@ export class ChannelServiceHandler {
      * Creates a new Conversation.
      * @param authHeader The authentication header.
      * @param parameters [ConversationParameters](xref:botbuilder-core.ConversationParameters) to create the conversation from.
-     * @returns A `Promise` representation of for the operation.
+     * @returns A `Promise` representation for the operation.
      */
     public async handleCreateConversation(authHeader: string, parameters: ConversationParameters): Promise<ConversationResourceResponse> {
         const claimsIdentity = await this.authenticate(authHeader);
@@ -134,7 +134,7 @@ export class ChannelServiceHandler {
      * @param authHeader The authentication header.
      * @param conversationId The conversation Id.
      * @param continuationToken A skip or continuation token.
-     * @returns A `Promise` representation of for the operation.
+     * @returns A `Promise` representation for the operation.
      */
     public async handleGetConversations(authHeader: string, conversationId: string, continuationToken?: string /* some default */): Promise<ConversationsResult> {
         const claimsIdentity = await this.authenticate(authHeader);

--- a/libraries/botbuilder/src/skills/skillHttpClient.ts
+++ b/libraries/botbuilder/src/skills/skillHttpClient.ts
@@ -16,9 +16,9 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
     private readonly conversationIdFactory: SkillConversationIdFactoryBase;
 
     /**
-     * Creates a new instance of the SkillHttpClient class.
-     * @param credentialProvider An instance of ICredentialProvider.
-     * @param conversationIdFactory An instance of a class derived from SkillConversationIdFactoryBase.
+     * Creates a new instance of the [SkillHttpClient](xref:botbuilder-core.SkillHttpClient) class.
+     * @param credentialProvider An instance of [ICredentialProvider](xref:botframework-connector.ICredentialProvider).
+     * @param conversationIdFactory An instance of a class derived from [SkillConversationIdFactoryBase](xref:botbuilder-core.SkillConversationIdFactoryBase).
      * @param channelService Optional. The channel service.
      */
     public constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string) {
@@ -50,12 +50,13 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
      */
     public async postToSkill(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
     /**
-     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
-     * @param audienceOrFromBotId The OAuth audience scope, used during token retrieval or the AppId of the bot sending the activity.
-     * @param fromBotIdOrSkill The AppId of the bot sending the activity or the skill to create the Conversation Id for.
+     * Uses the `SkillConversationIdFactory` to create or retrieve a Skill Conversation Id, and sends the [Activity](xref:botframework-schema.Activity).
+     * @param audienceOrFromBotId The OAuth audience scope, used during token retrieval or the AppId of the bot sending the [Activity](xref:botframework-schema.Activity).
+     * @param fromBotIdOrSkill The AppId of the bot sending the [Activity](xref:botframework-schema.Activity) or the skill to create the Conversation Id for.
      * @param toSkillOrCallbackUrl The skill to create the Conversation Id for or the callback Url for the skill host.
-     * @param callbackUrlOrActivity The callback Url for the skill host or the the activity to send.
-     * @param activityToForward Optional. The activity to forward.
+     * @param callbackUrlOrActivity The callback Url for the skill host or the the [Activity](xref:botframework-schema.Activity) to send.
+     * @param activityToForward Optional. The [Activity](xref:botframework-schema.Activity) to forward.
+     * @returns A `Promise` representing the [InvokeResponse](xref:botbuilder-core.InvokeResponse) for the operation.
      */
     public async postToSkill<T = any>(audienceOrFromBotId: string, fromBotIdOrSkill: string | BotFrameworkSkill, toSkillOrCallbackUrl: BotFrameworkSkill | string, callbackUrlOrActivity: string | Activity, activityToForward?: Activity): Promise<InvokeResponse<T>> {
         let originatingAudience: string;

--- a/libraries/botbuilder/src/skills/skillHttpClient.ts
+++ b/libraries/botbuilder/src/skills/skillHttpClient.ts
@@ -54,7 +54,7 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
      * @param audienceOrFromBotId The OAuth audience scope, used during token retrieval or the AppId of the bot sending the [Activity](xref:botframework-schema.Activity).
      * @param fromBotIdOrSkill The AppId of the bot sending the [Activity](xref:botframework-schema.Activity) or the skill to create the Conversation Id for.
      * @param toSkillOrCallbackUrl The skill to create the Conversation Id for or the callback Url for the skill host.
-     * @param callbackUrlOrActivity The callback Url for the skill host or the the [Activity](xref:botframework-schema.Activity) to send.
+     * @param callbackUrlOrActivity The callback Url for the skill host or the [Activity](xref:botframework-schema.Activity) to send.
      * @param activityToForward Optional. The [Activity](xref:botframework-schema.Activity) to forward.
      * @returns A `Promise` representing the [InvokeResponse](xref:botbuilder-core.InvokeResponse) for the operation.
      */

--- a/libraries/botbuilder/src/streaming/streamingHttpClient.ts
+++ b/libraries/botbuilder/src/streaming/streamingHttpClient.ts
@@ -10,7 +10,7 @@ import { WebResource, HttpOperationResponse, HttpClient } from '@azure/ms-rest-j
 import { IStreamingTransportServer, StreamingRequest } from 'botframework-streaming';
 
 /**
- * An implementation of HttpClient that adds compatibility with streaming connections.
+ * An implementation of `HttpClient` that adds compatibility with streaming connections.
  */
 export class StreamingHttpClient implements HttpClient {
     private readonly server: IStreamingTransportServer;

--- a/libraries/botbuilder/src/streaming/tokenResolver.ts
+++ b/libraries/botbuilder/src/streaming/tokenResolver.ts
@@ -30,9 +30,9 @@ export class TokenResolver {
 
     /**
      * Checks if we have token responses from OAuth cards.
-     * @param adapter The BotFramework adapter.
-     * @param context The context for this turn.
-     * @param activity The activity to be checked.
+     * @param adapter The [BotFrameworkAdapter](xref:botbuilder.BotFrameworkAdapter).
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
+     * @param activity The [Activity](xref:botframework-schema.Activity) to be checked.
      * @param log Optional. The log to write on.
      */
     public static checkForOAuthCards(adapter: BotFrameworkAdapter, context: TurnContext, activity: Activity, log?: string[]) {


### PR DESCRIPTION
PR 2818 in MS, #143 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.