### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder dialogs/memory scopes

### DIFF
--- a/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
@@ -50,8 +50,8 @@ export class BotStateMemoryScope extends MemoryScope {
     }
 
     /**
-     * Populates the state cache for this BotState from the storage layer.
-     * @param dc The DialogContext object for this turn.
+     * Populates the state cache for this [BotState](xref:botbuilder-core.BotState) from the storage layer.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param force Optional, `true` to overwrite any existing state cache;
      * or `false` to load state from storage only if the cache doesn't already exist.
      * @returns A Promise that represents the work queued to execute.
@@ -64,8 +64,8 @@ export class BotStateMemoryScope extends MemoryScope {
     }
 
     /**
-     * Writes the state cache for this BotState to the storage layer.
-     * @param dc The DialogContext object for this turn.
+     * Writes the state cache for this [BotState](xref:botbuilder-core.BotState) to the storage layer.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param force Optional, `true` to save the state cache to storage;
      * or `false` to save state to storage only if a property in the cache has changed.
      * @returns A Promise that represents the work queued to execute.
@@ -78,8 +78,8 @@ export class BotStateMemoryScope extends MemoryScope {
     }
 
     /**
-     * Deletes any state in storage and the cache for this BotState.
-     * @param dc The DialogContext object for this turn.
+     * Deletes any state in storage and the cache for this [BotState](xref:botbuilder-core.BotState).
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns A Promise that represents the work queued to execute.
      */
     public async delete(dc: DialogContext): Promise<void> {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
@@ -15,7 +15,7 @@ import { Dialog } from '../../dialog';
  */
 export class ClassMemoryScope extends MemoryScope {
     /**
-     * Initializes a new instance of the ClassMemoryScope class.
+     * Initializes a new instance of the [ClassMemoryScope](xref:botbuilder-dialogs.ClassMemoryScope) class.
      * @param name Name of the scope class.
      */
     public constructor(name = ScopePath.class) {
@@ -24,7 +24,7 @@ export class ClassMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
     public getMemory(dc: DialogContext): object {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/conversationMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/conversationMemoryScope.ts
@@ -14,7 +14,7 @@ import { ScopePath } from '../scopePath';
 export class ConversationMemoryScope extends BotStateMemoryScope {
     protected stateKey = 'ConversationState';
     /**
-     * Initializes a new instance of the ConversationMemoryScope class.
+     * Initializes a new instance of the [ConversationMemoryScope](xref:botbuilder-dialogs.ConversationMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.conversation);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
@@ -16,7 +16,7 @@ import { DialogContainer } from '../../dialogContainer';
  */
 export class DialogClassMemoryScope extends ClassMemoryScope {
     /**
-     * Initializes a new instance of the DialogClassMemoryScope class.
+     * Initializes a new instance of the [DialogClassMemoryScope](xref:botbuilder-dialogs.DialogClassMemoryScope) class.
      */
     constructor() {
         super(ScopePath.dialogClass);
@@ -24,8 +24,8 @@ export class DialogClassMemoryScope extends ClassMemoryScope {
 
     /**
      * @protected
-     * @param dc The DialogContext object for this turn.
-     * @retuns The current Dialog.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
+     * @retuns The current [Dialog](xref:botbuilder-dialogs.Dialog).
      */
     protected onFindDialog(dc: DialogContext): Dialog {
         // Is the active dialog a container?

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
@@ -15,7 +15,7 @@ import { DialogContainer } from '../../dialogContainer';
  */
 export class DialogMemoryScope extends MemoryScope {
     /**
-     * Initializes a new instance of the DialogMemoryScope class.
+     * Initializes a new instance of the [DialogMemoryScope](xref:botbuilder-dialogs.DialogMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.dialog);
@@ -23,7 +23,7 @@ export class DialogMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
     public getMemory(dc: DialogContext): object {
@@ -41,7 +41,7 @@ export class DialogMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {
@@ -65,7 +65,7 @@ export class DialogMemoryScope extends MemoryScope {
 
     /**
      * @private
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns A boolean indicating whether is a cointainer or not.
      */
     private isContainer(dc: DialogContext): boolean {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
@@ -12,9 +12,9 @@ import { DialogContext } from '../../dialogContext';
  */
 export abstract class MemoryScope {
     /**
-     * Initializes a new instance of the MemoryScope class.
+     * Initializes a new instance of the [MemoryScope](xref:botbuilder-dialogs.MemoryScope) class.
      * @param name Name of the scope.
-     * @param includeInSnapshot Boolean value indicating whether this memory 
+     * @param includeInSnapshot Boolean value indicating whether this memory
      * should be included in snapshot. Default value is true.
      */
     public constructor(name: string, includeInSnapshot = true)

--- a/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
@@ -14,7 +14,7 @@ import { DialogContext } from '../../dialogContext';
  */
 export class SettingsMemoryScope extends MemoryScope {
     /**
-     * Initializes a new instance of the SettingsMemoryScope class.
+     * Initializes a new instance of the [SettingsMemoryScope](xref:botbuilder-dialogs.SettingsMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.settings, false);
@@ -22,7 +22,7 @@ export class SettingsMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
     public getMemory(dc: DialogContext): object {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
@@ -14,7 +14,7 @@ import { DialogContext } from '../../dialogContext';
  */
 export class ThisMemoryScope extends MemoryScope {
     /**
-     * Initializes a new instance of the ThisMemoryScope class.
+     * Initializes a new instance of the [ThisMemoryScope](xref:botbuilder-dialogs.ThisMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.this);
@@ -22,7 +22,7 @@ export class ThisMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
     public getMemory(dc: DialogContext): object {
@@ -31,7 +31,7 @@ export class ThisMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
-     * @param dc The DialogContext object for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
@@ -19,7 +19,7 @@ const TURN_STATE = Symbol('turn');
  */
 export class TurnMemoryScope extends MemoryScope {
     /**
-     * Initializes a new instance of the TurnMemoryScope class.
+     * Initializes a new instance of the [TurnMemoryScope](xref:botbuilder-dialogs.TurnMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.turn);
@@ -27,7 +27,7 @@ export class TurnMemoryScope extends MemoryScope {
 
     /**
      * Get the backing memory for this scope.
-     * @param dc The DialogContext for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for this turn.
      * @returns The memory for the scope.
      */
     public getMemory(dc: DialogContext): object {
@@ -42,7 +42,7 @@ export class TurnMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
-     * @param dc The DialogContext for this turn.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {

--- a/libraries/botbuilder-dialogs/src/memory/scopes/userMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/userMemoryScope.ts
@@ -14,7 +14,7 @@ import { ScopePath } from '../scopePath';
 export class UserMemoryScope extends BotStateMemoryScope {
     protected stateKey = 'UserState';
     /**
-     * Initializes a new instance of the UserMemoryScope class.
+     * Initializes a new instance of the [UserMemoryScope](xref:botbuilder-dialogs.UserMemoryScope) class.
      */
     public constructor() {
         super(ScopePath.user);


### PR DESCRIPTION
PR 2822 in MS, #147 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't include conflict resolution.