### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs/root

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -84,7 +84,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * Dialog.BeginDialogAsync(DialogContext, object, CancellationToken) method
      * of the component dialog's initial dialog, as defined by InitialDialogId.
      * Override this method in a derived class to implement interrupt logic.
-     * @param outerDC The parent DialogContext for the current turn of conversation.
+     * @param outerDC The parent [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional, initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
@@ -116,9 +116,9 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the dialog is _continued_, where it is the active dialog and the
-     * user replies with a new activity.
+     * user replies with a new [Activity](xref:botframework-schema.Activity).
      * If this method is *not* overridden, the dialog automatically ends when the user replies.
-     * @param outerDC The parent DialogContext for the current turn of conversation.
+     * @param outerDC The parent [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
@@ -145,7 +145,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when a child dialog on the parent's dialog stack completed this turn, returning
      * control to this dialog component.
-     * @param outerDc The DialogContext for the current turn of conversation.
+     * @param outerDc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param reason Reason why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
@@ -174,11 +174,11 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-    * Called when the dialog should re-prompt the user for input.
-    * @param context The context object for this turn.
-    * @param instance State information for this dialog.
-    * @returns A Promise representing the asynchronous operation.
-    */
+     * Called when the dialog should re-prompt the user for input.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
+     * @param instance State information for this dialog.
+     * @returns A Promise representing the asynchronous operation.
+     */
     public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         // Forward to inner dialogs
         const innerDC: DialogContext = this.createInnerDC(context, instance);
@@ -189,15 +189,15 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-    * Called when the dialog is ending.
-    * @remarks When this method is called from the parent dialog's context, the component dialog
-    * cancels all of the dialogs on its inner dialog stack before ending.
-    * @param context The context object for this turn.
-    * @param instance State information associated with the instance of this component
-    * dialog on its parent's dialog stack.
-    * @param reason Reason why the dialog ended.
-    * @returns A Promise representing the asynchronous operation.
-    */
+     * Called when the dialog is ending.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
+     * @param instance State information associated with the instance of this component
+     * dialog on its parent's dialog stack.
+     * @param reason Reason why the dialog ended.
+     * @returns A Promise representing the asynchronous operation.
+     * @remarks When this method is called from the parent dialog's context, the component dialog
+     * cancels all of the dialogs on its inner dialog stack before ending.
+     */
     public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
         // Forward cancel to inner dialogs
         if (reason === DialogReason.cancelCalled) {
@@ -211,10 +211,9 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Adds a child dialog or prompt to the components internal `DialogSet`.
-     * @param dialog The child dialog or prompt to add.
+     * @param dialog The child [Dialog](xref:botbuilder-dialogs.Dialog) or prompt to add.
      * @remarks
-     * The `Dialog.id` of the first child added to the component will be assigned to the [initialDialogId](#initialdialogid)
-     * property.
+     * The [Dialog](xref:botbuilder-dialogs.Dialog.id) of the first child added to the component will be assigned to the initialDialogId property.
      */
     public addDialog(dialog: Dialog): this {
         this.dialogs.add(dialog);
@@ -297,16 +296,32 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
         return outerDC.endDialog(result);
     }
 
+    /**
+     * @private
+     * @param context [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
+     * @param instance Current state information for this dialog.
+     * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
+     * @remarks
+     * You should only call this if you don't have a dc to work with (such as OnResume())
+     */
     private createInnerDC(context: DialogContext, instance: DialogInstance): DialogContext;
+    /**
+     * @private
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
+     * @param instance Current state information for this dialog.
+     * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
+     * @remarks
+     * You should only call this if you don't have a dc to work with (such as OnResume())
+     */
     private createInnerDC(context: TurnContext, instance: DialogInstance): DialogContext;
-
     /**
      * @private
      * @param context Context for the current turn of conversation with the user.
      * @param instance Current state information for this dialog.
-     * @remarks 
+     * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
+     * @remarks
      * You should only call this if you don't have a dc to work with (such as OnResume())
-    */
+     */
     private createInnerDC(context: TurnContext | DialogContext, instance: DialogInstance): DialogContext {
         if (!instance) {
             const dialogInstance = { state: {} };

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -189,13 +189,13 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-     * Called when the dialog is ending.
+     * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is ending.
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information associated with the instance of this component
-     * dialog on its parent's dialog stack.
-     * @param reason Reason why the dialog ended.
+     * [Dialog](xref:botbuilder-dialogs.Dialog) on its parent's dialog stack.
+     * @param reason Reason why the [Dialog](xref:botbuilder-dialogs.Dialog) ended.
      * @returns A Promise representing the asynchronous operation.
-     * @remarks When this method is called from the parent dialog's context, the component dialog
+     * @remarks When this method is called from the parent dialog's context, the component [Dialog](xref:botbuilder-dialogs.Dialog)
      * cancels all of the dialogs on its inner dialog stack before ending.
      */
     public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
@@ -210,10 +210,10 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     }
 
     /**
-     * Adds a child dialog or prompt to the components internal `DialogSet`.
+     * Adds a child [Dialog](xref:botbuilder-dialogs.Dialog) or prompt to the components internal [DialogSet](xref:botbuilder-dialogs.DialogSet).
      * @param dialog The child [Dialog](xref:botbuilder-dialogs.Dialog) or prompt to add.
      * @remarks
-     * The [Dialog](xref:botbuilder-dialogs.Dialog.id) of the first child added to the component will be assigned to the initialDialogId property.
+     * The [Dialog.id](xref:botbuilder-dialogs.Dialog.id) of the first child added to the component will be assigned to the initialDialogId property.
      */
     public addDialog(dialog: Dialog): this {
         this.dialogs.add(dialog);
@@ -299,7 +299,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @private
      * @param context [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
-     * @param instance Current state information for this dialog.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance) which contains the current state information for this dialog.
      * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
      * @remarks
      * You should only call this if you don't have a dc to work with (such as OnResume())
@@ -308,7 +308,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * @private
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
-     * @param instance Current state information for this dialog.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance) which contains the current state information for this dialog.
      * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
      * @remarks
      * You should only call this if you don't have a dc to work with (such as OnResume())
@@ -316,8 +316,8 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     private createInnerDC(context: TurnContext, instance: DialogInstance): DialogContext;
     /**
      * @private
-     * @param context Context for the current turn of conversation with the user.
-     * @param instance Current state information for this dialog.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance) which contains the current state information for this dialog.
      * @returns A new [DialogContext](xref:botbuilder-dialogs.DialogContext) instance.
      * @remarks
      * You should only call this if you don't have a dc to work with (such as OnResume())

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -55,32 +55,32 @@ export interface DialogState {
  */
 export class DialogContext {
     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @param dialogs The dialog set for which to create the dialog context.
-      * @param contextOrDC The context object for the current turn of the bot.
-      * @param state The state object to use to read and write dialog state to storage.
-      * @remarks
-      * Passing in a dialog context instance will clone the dialog context.
-      */
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks
+     * Passing in a dialog context instance will clone the dialog context.
+     */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
 
     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @param dialogs The dialog set for which to create the dialog context.
-      * @param contextOrDC The context object for the current turn of the bot.
-      * @param state The state object to use to read and write dialog state to storage.
-      * @remarks
-      * Passing in a dialog context instance will clone the dialog context.
-      */
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks
+     * Passing in a dialog context instance will clone the dialog context.
+     */
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
 
     /**
-      * Creates an new instance of the DialogContext class.
-      * @param dialogs The dialog set for which to create the dialog context.
-      * @param contextOrDC The turn context or dialog context for the current turn of the bot.
-      * @param state The state object to use to read and write dialog state to storage.
-      * @remarks Passing in a dialog context instance will clone the dialog context.
-      */
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks Passing in a dialog context instance will clone the dialog context.
+     */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
         this.dialogs = dialogs;
         if (contextOrDC instanceof DialogContext) {
@@ -289,14 +289,10 @@ export class DialogContext {
 
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
-     * 
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
-     *      the activity to send as the initial prompt, or
+     *      the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
      *      the object with which to format the prompt dialog.
-     * @param choices Optional. Array of choices for the user to choose from,
-     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     * 
      * @remarks
      * This helper method formats the object to use as the `options` parameter, and then calls
      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
@@ -306,14 +302,29 @@ export class DialogContext {
      * ```
      */
     public async prompt(dialogId: string, promptOrOptions: string | Partial<Activity> | PromptOptions): Promise<DialogTurnResult>;
-    public async prompt(dialogId: string, promptOrOptions: string | Partial<Activity> | PromptOptions, choices: (string | Choice)[]): Promise<DialogTurnResult>;
-    
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
-     * @param promptOrOptions The text of the initial prompt to send the user, 
-     * or the activity to send as the initial prompt.
-     * @param choices Optional. Array of choices for the user to choose from, 
+     * @param promptOrOptions The text of the initial prompt to send the user,
+     *      the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
+     *      the object with which to format the prompt dialog.
+     * @param choices Optional. Array of choices for the user to choose from,
+     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * @remarks
+     * This helper method formats the object to use as the `options` parameter, and then calls
+     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+     *
+     * ```JavaScript
+     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+     * ```
+     */
+    public async prompt(dialogId: string, promptOrOptions: string | Partial<Activity> | PromptOptions, choices: (string | Choice)[]): Promise<DialogTurnResult>;
+    /**
+     * Helper function to simplify formatting the options for calling a prompt dialog.
+     * @param dialogId ID of the prompt dialog to start.
+     * @param promptOrOptions The text of the initial prompt to send the user,
+     * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
+     * @param choices Optional. Array of choices for the user to choose from,
      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
      * @remarks This helper method formats the object to use as the `options` parameter, and then calls
      * beginDialog to start the specified prompt dialog.

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -60,7 +60,7 @@ export class DialogContext {
      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
      * @remarks
-     * Passing in a dialog context instance will clone the dialog context.
+     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
      */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
 
@@ -70,7 +70,7 @@ export class DialogContext {
      * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
      * @remarks
-     * Passing in a dialog context instance will clone the dialog context.
+     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
      */
     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
 
@@ -79,7 +79,7 @@ export class DialogContext {
      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-     * @remarks Passing in a dialog context instance will clone the dialog context.
+     * @remarks Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
      */
     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
         this.dialogs = dialogs;
@@ -291,8 +291,8 @@ export class DialogContext {
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
-     *      the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
-     *      the object with which to format the prompt dialog.
+     * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
+     * the object with which to format the prompt dialog.
      * @remarks
      * This helper method formats the object to use as the `options` parameter, and then calls
      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
@@ -306,10 +306,10 @@ export class DialogContext {
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
-     *      the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
-     *      the object with which to format the prompt dialog.
+     * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
+     * the object with which to format the prompt dialog.
      * @param choices Optional. Array of choices for the user to choose from,
-     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
      * @remarks
      * This helper method formats the object to use as the `options` parameter, and then calls
      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -22,8 +22,8 @@ import { AuthConstants, GovConstants, isSkillClaim } from './prompts/skillsHelpe
 
 /**
  * Runs a dialog from a given context and accesor.
- * @param dialog The Dialog to run.
- * @param context Context object for the current turn of conversation with the user.
+ * @param dialog The [Dialog](xref:botbuilder-dialogs.Dialog) to run.
+ * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of conversation with the user.
  * @param accessor Defined methods for accessing the state property created in a BotState object.
  */
 export async function runDialog(dialog: Dialog, context: TurnContext, accessor: StatePropertyAccessor<DialogState>): Promise<void> {
@@ -128,8 +128,8 @@ export function shouldSendEndOfConversationToParent(context: TurnContext, turnRe
 
 /**
  * Recursively walk up the DC stack to find the active DC.
- * @param dialogContext Context for the current turn of conversation with the user.
- * @returns Active dialog context.
+ * @param dialogContext [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
+ * @returns Active [DialogContext](xref:botbuilder-dialogs.DialogContext).
  */
 export function getActiveDialogContext(dialogContext: DialogContext): DialogContext {
     const child = dialogContext.child;
@@ -142,7 +142,7 @@ export function getActiveDialogContext(dialogContext: DialogContext): DialogCont
 
 /**
  * Determines if the skill is acting as a skill parent.
- * @param context Context object for the current turn of conversation with the user.
+ * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of conversation with the user.
  * @returns A boolean representing if the skill is acting as a skill parent.
  */
 export function isFromParentToSkill(context: TurnContext): boolean {

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -61,8 +61,8 @@ export class DialogManager extends Configurable {
     private readonly _initialTurnState: TurnContextStateCollection = new TurnContextStateCollection();
 
     /**
-     * Creates an instance of the DialogManager class.
-     * @param rootDialog Optional, root dialog to use.
+     * Creates an instance of the [DialogSet](xref:botbuilder-dialogs.DialogManager) class.
+     * @param rootDialog Optional, root [Dialog](xref:botbuilder-dialogs.Dialog) to use.
      * @param dialogStateProperty Optional, alternate name for the dialogState property. (Default is "DialogStateProperty")
      */
     public constructor(rootDialog?: Dialog, dialogStateProperty?: string) {
@@ -104,8 +104,8 @@ export class DialogManager extends Configurable {
     }
 
     /**
-     * Gets the root dialog ID.
-     * @returns The root dialog ID.
+     * Gets the root [Dialog](xref:botbuilder-dialogs.Dialog) ID.
+     * @returns The root [Dialog](xref:botbuilder-dialogs.Dialog) ID.
      */
     public get rootDialog(): Dialog {
         return this._rootDialogId ? this.dialogs.find(this._rootDialogId) : undefined;
@@ -129,15 +129,15 @@ export class DialogManager extends Configurable {
     /**
      * Set configuration settings.
      * @param config Configuration settings to apply.
-     * @returns The cofigured dialogManager context.
+     * @returns The cofigured [DialogManager](xref:botbuilder-dialogs.DialogManager) context.
      */
     public configure(config: Partial<DialogManagerConfiguration>): this {
         return super.configure(config);
     }
 
     /**
-     * Runs dialog system in the context of an ITurnContext.
-     * @param context Context for the current turn of conversation with the user.
+     * Runs dialog system in the context of a [TurnContext](xref:botbuilder-core.TurnContext).
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
      * @returns Result of running the logic against the activity.
      */
     public async onTurn(context: TurnContext): Promise<DialogManagerResult> {
@@ -246,8 +246,8 @@ export class DialogManager extends Configurable {
     }
 
     /**
-     * Helper to send a trace activity with a memory snapshot of the active dialog DC.
-     * @param dc Context for the current turn of conversation with the user.
+     * Helper to send a trace activity with a memory snapshot of the active [DialogContext](xref:botbuilder-dialogs.DialogContext).
+     * @param dc [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
      * @param traceLabel Trace label to set for the activity.
      */
     private async sendStateSnapshotTrace(dc: DialogContext, traceLabel: string): Promise<void> {
@@ -264,7 +264,7 @@ export class DialogManager extends Configurable {
 
     /**
      * @private
-     * @param dc Context for the current turn of conversation with the user.
+     * @param dc [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
      * @returns A Promise representing the asynchronous operation.
      */
     private async handleSkillOnTurn(dc: DialogContext): Promise<DialogTurnResult> {
@@ -320,8 +320,8 @@ export class DialogManager extends Configurable {
 
     /**
      * @private
-     * @param dc Context for the current turn of conversation with the user.
-     * @returns The DialogTurnResult.
+     * @param dc [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation with the user.
+     * @returns The [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult).
      */
     private async handleBotOnTurn(dc: DialogContext): Promise<DialogTurnResult> {
         let turnResult: DialogTurnResult;

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -67,7 +67,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is started and pushed onto the dialog stack.
-     * @param dc The DialogContext for the current turn of conversation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
@@ -101,10 +101,10 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is _continued_, where it is the active dialog and the
-     * user replies with a new activity.
-     * @param dc The DialogContext for the current turn of conversation.
+     * user replies with a new [Activity](xref:botframework-schema.Activity).
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
-     * @remarks 
+     * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
      * return value.
@@ -140,9 +140,9 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is ending.
-     * @param context The context object for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information associated with the instance of this dialog on the dialog stack.
-     * @param reason Reason why the dialog ended.
+     * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog ended.
      * @returns A Promise representing the asynchronous operation.
      */
     public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
@@ -166,7 +166,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog should re-prompt the user for input.
-     * @param context The context object for this turn.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information for this dialog.
      * @returns A Promise representing the asynchronous operation.
      */
@@ -186,8 +186,8 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when a child skill dialog completed its turn, returning control to this dialog.
-     * @param dc The dialog context for the current turn of the conversation.
-     * @param reason Reason why the dialog resumed.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the conversation.
+     * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -342,9 +342,9 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * @private
-     * Create a conversationId to interact with the skill and send the activity.
-     * @param context Context for the current turn of conversation with the user.
-     * @param activity Activity to send.
+     * Create a conversationId to interact with the skill and send the [Activity](xref:botframework-schema.Activity).
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
+     * @param activity [Activity](xref:botframework-schema.Activity) to send.
      * @returns The Skill Conversation ID.
      */
     private async createSkillConversationId(context: TurnContext, activity: Activity) {
@@ -371,7 +371,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     /**
      * @private
      * Gets the Skill Conversation ID from a given instance.
-     * @param instance Instance from which to look for its ID.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance) from which to look for its ID.
      * @returns Instance conversation ID.
      */
     private getSkillConversationIdFromInstance(instance: DialogInstance): string {

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -144,12 +144,12 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when the waterfall dialog is started and pushed onto the dialog stack.
-     * @remarks 
-     * If the task is successful, the result indicates whether the dialog is still
-     * active after the turn has been processed by the dialog.
-     * @param dc The DialogContext for the current turn of conversation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional, initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
+     * @remarks
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog.
      */
     public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
         // Initialize waterfall state
@@ -172,10 +172,10 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when the waterfall dialog is _continued_, where it is the active dialog and the
-     * user replies with a new activity.
-     * @param dc The DialogContext for the current turn of conversation.
+     * user replies with a new [Activity](xref:botframework-schema.Activity).
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
-     * @remarks 
+     * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog. The result may also contain a
      * return value.
@@ -192,8 +192,8 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when a child waterfall dialog completed its turn, returning control to this dialog.
-     * @param dc The dialog context for the current turn of the conversation.
-     * @param reason Reason why the dialog resumed.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the conversation.
+     * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -239,9 +239,9 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Executes a step of the waterfall dialog.
-     * @param dc The DialogContext for the current turn of conversation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param index The index of the current waterfall step to execute.
-     * @param reason The reason the waterfall step is being executed.
+     * @param reason The [Reason](xref:botbuilder-dialogs.DialogReason) the waterfall step is being executed.
      * @param result Optional, result returned by a dialog called in the previous waterfall step.
      * @returns A Promise that represents the work queued to execute.
      */

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -143,12 +143,12 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     }
 
     /**
-     * Called when the waterfall dialog is started and pushed onto the dialog stack.
+     * Called when the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) is started and pushed onto the dialog stack.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional, initial information to pass to the dialog.
+     * @param options Optional, initial information to pass to the [Dialog](xref:botbuilder-dialogs.Dialog).
      * @returns A Promise representing the asynchronous operation.
      * @remarks
-     * If the task is successful, the result indicates whether the dialog is still
+     * If the task is successful, the result indicates whether the [Dialog](xref:botbuilder-dialogs.Dialog) is still
      * active after the turn has been processed by the dialog.
      */
     public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
@@ -171,7 +171,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     }
 
     /**
-     * Called when the waterfall dialog is _continued_, where it is the active dialog and the
+     * Called when the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) is _continued_, where it is the active dialog and the
      * user replies with a new [Activity](xref:botframework-schema.Activity).
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
@@ -191,7 +191,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     }
 
     /**
-     * Called when a child waterfall dialog completed its turn, returning control to this dialog.
+     * Called when a child [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) completed its turn, returning control to this dialog.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the conversation.
      * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
@@ -238,7 +238,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     }
 
     /**
-     * Executes a step of the waterfall dialog.
+     * Executes a step of the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog).
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param index The index of the current waterfall step to execute.
      * @param reason The [Reason](xref:botbuilder-dialogs.DialogReason) the waterfall step is being executed.


### PR DESCRIPTION
PR 2820 in MS, #145 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.