### PR TITLE
[internal] Apply xref links for southworks/add/jsdoc/botbuilder-dialogs/choices-prompts

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
+++ b/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
@@ -137,12 +137,12 @@ export class ChoiceFactory {
 
 
     /**
-     * Creates a message activity that includes a list of choices that have been added as `HeroCard`'s.
+     * Creates a message [Activity](xref:botframework-schema.Activity) that includes a [Choice](xref:botbuilder-dialogs.Choice) list that have been added as `HeroCard`'s.
      * 
-     * @param choices The list of choices to add.
-     * @param text Optional, text of the message.
-     * @param speak Optional, SSML text to be spoken by the bot on a speech-enabled channel.
-     * @returns An activity with choices as HeroCard with buttons.
+     * @param choices Optional. The [Choice](xref:botbuilder-dialogs.Choice) list to add.
+     * @param text Optional. Text of the message.
+     * @param speak Optional. SSML text to be spoken by the bot on a speech-enabled channel.
+     * @returns An [Activity](xref:botframework-schema.Activity) with choices as `HeroCard` with buttons.
      */
     public static heroCard(choices: (string | Choice)[] = [], text = '', speak = ''): Activity {
         const buttons: CardAction[] = ChoiceFactory.toChoices(choices).map(choice => ({

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -144,8 +144,8 @@ export class ActivityPrompt extends Dialog {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry A boolean representing if the prompt is a retry.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -162,8 +162,8 @@ export class ActivityPrompt extends Dialog {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -31,9 +31,11 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @param options Additional information to pass to the prompt being started.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     * turn of the conversation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), additional
+     * information to pass to the prompt being started.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks 
      * If the promise is successful, the result indicates whether the prompt is still
      * active after the turn has been processed by the prompt.
@@ -61,8 +63,9 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
-     * @param dc The DialogContext for the current turn of conversation.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     * turn of conversation.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks
      * If the promise is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
@@ -104,11 +107,13 @@ export class ActivityPrompt extends Dialog {
     /**
      * Called when a prompt dialog resumes being the active dialog on the dialog stack, such as
      * when the previous active dialog on the stack completes.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @param reason An enum indicating why the dialog resumed.
-     * @param result Optional, value returned from the previous dialog on the stack.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn
+     * of the conversation.
+     * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), an enum indicating why
+     * the dialog resumed.
+     * @param result Optional. Value returned from the previous dialog on the stack.
      * The type of the value returned is dependent on the previous dialog.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
         // Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
@@ -123,9 +128,11 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog has been requested to re-prompt the user for input.
-     * @param context Context for the current turn of conversation with the user.
-     * @param instance The instance of the dialog on the stack.
-     * @returns A Promise representing the asynchronous operation.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), the instance
+     * of the dialog on the stack.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         const state: ActivityPromptState = instance.state as ActivityPromptState;
@@ -134,12 +141,13 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * When overridden in a derived class, prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
      * @param isRetry A boolean representing if the prompt is a retry.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: object, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
@@ -150,12 +158,13 @@ export class ActivityPrompt extends Dialog {
     }
 
     /**
-     * When overridden in a derived class, attempts to recognize the incoming activity.
-     * @param context Context for the current turn of conversation with the user.
+     * When overridden in a derived class, attempts to recognize the incoming [Activity](xref:botframework-schema.Activity).
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {
         return { succeeded: true, value: context.activity };

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -83,13 +83,14 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     /**
      * Prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt 
+     * options object constructed from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         // Determine locale
@@ -113,11 +114,12 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) context for the current 
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<FoundChoice>> {
 

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -86,8 +86,8 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt 
-     * options object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
      * @returns A `Promise` representing the asynchronous operation.
@@ -117,8 +117,8 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) context for the current 
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<FoundChoice>> {

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -88,8 +88,8 @@ export class ConfirmPrompt extends Prompt<boolean> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
      * @returns A `Promise` representing the asynchronous operation.
@@ -117,8 +117,8 @@ export class ConfirmPrompt extends Prompt<boolean> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<boolean>> {

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -85,13 +85,14 @@ export class ConfirmPrompt extends Prompt<boolean> {
 
     /**
      * Prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
 
@@ -113,11 +114,12 @@ export class ConfirmPrompt extends Prompt<boolean> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<boolean>> {
         const result: PromptRecognizerResult<boolean> = { succeeded: false };

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -57,13 +57,14 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
 
     /**
      * Prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
@@ -75,11 +76,12 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -60,8 +60,8 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
      * @returns A `Promise` representing the asynchronous operation.
@@ -79,8 +79,8 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -42,13 +42,14 @@ export class NumberPrompt extends Prompt<number> {
 
     /**
      * Prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current 
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
@@ -60,11 +61,12 @@ export class NumberPrompt extends Prompt<number> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<number>> {
         const result: PromptRecognizerResult<number> = { succeeded: false };

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -45,8 +45,8 @@ export class NumberPrompt extends Prompt<number> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current 
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
      * @returns A `Promise` representing the asynchronous operation.
@@ -64,8 +64,8 @@ export class NumberPrompt extends Prompt<number> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<number>> {

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -147,9 +147,11 @@ export class OAuthPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @param options Optional, additional information to pass to the prompt being started.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     * turn of the conversation.
+     * @param options Optional. [PromptOptions](xref:botbuilder-dialogs.PromptOptions),
+     * additional information to pass to the prompt being started.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the prompt is still
      * active after the turn has been processed by the prompt.
@@ -187,8 +189,9 @@ export class OAuthPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn
+     * of the conversation.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.

--- a/libraries/botbuilder-dialogs/src/prompts/prompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/prompt.ts
@@ -176,9 +176,11 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
-     * @param dc The dialog context for the current turn of the conversation.
-     * @param options Optional, additional information to pass to the prompt being started.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     * turn of the conversation.
+     * @param options Optional. [PromptOptions](xref:botbuilder-dialogs.PromptOptions),
+     * additional information to pass to the prompt being started.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the prompt is still
      * active after the turn has been processed by the prompt.
@@ -206,8 +208,8 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
-     * @param dc The DialogContext for the current turn of conversation.
-     * @returns A Promise representing the asynchronous operation.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @returns A `Promise` representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
@@ -265,8 +267,8 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called before an event is bubbled to its parent.
-     * @param dc The DialogContext for the current turn of conversation.
-     * @param event The event being raised.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param event [DialogEvent](xref:botbuilder-dialogs.DialogEvent), the event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      * @remarks
      * This is a good place to perform interception of an event as returning `true` will prevent
@@ -309,9 +311,11 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog has been requested to re-prompt the user for input.
-     * @param context Context for the current turn of conversation with the user.
-     * @param instance The instance of the dialog on the stack.
-     * @returns A Promise representing the asynchronous operation.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
+     * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), the instance
+     * of the dialog on the stack.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         const state: PromptState = instance.state as PromptState;

--- a/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
@@ -29,13 +29,14 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Prompts the user for input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
-     * @returns A Promise representing the asynchronous operation.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         if (isRetry && options.retryPrompt) {
@@ -47,11 +48,12 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context Context for the current turn of conversation with the user.
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
+     * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
-     * in the call to Prompt.
-     * @returns A Promise representing the asynchronous operation.
+     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
+     * object constructed from the options initially provided in the call to Prompt.
+     * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<string>> {
         const value: string = context.activity.text;
@@ -61,8 +63,9 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Called before an event is bubbled to its parent.
-     * @param dc The DialogContext for the current turn of conversation.
-     * @param event The event being raised.
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     * turn of conversation.
+     * @param event [DialogEvent](xref:botbuilder-dialogs.DialogEvent), the event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      * @remarks
      * This is a good place to perform interception of an event as returning `true` will prevent

--- a/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
@@ -32,8 +32,8 @@ export class TextPrompt extends Prompt<string> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @param isRetry `true` if this is the first time this prompt dialog instance
      * on the stack is prompting the user for input; otherwise, false.
      * @returns A `Promise` representing the asynchronous operation.
@@ -51,8 +51,8 @@ export class TextPrompt extends Prompt<string> {
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), a prompt options
-     * object constructed from the options initially provided in the call to Prompt.
+     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<string>> {


### PR DESCRIPTION
PR 2821 in MS, #146 in SW

Feedback applied to use xref to link to other methods.

note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.