### PR TITLE
[internal] Apply xref links for southworks/add/documentation/botbuilder-ai

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -273,27 +273,27 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
     /**
      * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
      * @param application The LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
      * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(application: string, options?: LuisPredictionOptions, includeApiResults?: boolean);
     /**
      * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
      * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(application: LuisApplication, options?: LuisPredictionOptions, includeApiResults?: boolean);
     /**
      * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
      */
     constructor(application: LuisApplication | string, options?: LuisRecognizerOptionsV3 | LuisRecognizerOptionsV2);
     /**
      * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions), [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions), [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
      * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -271,30 +271,30 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
     private luisRecognizerInternal: LuisRecognizerV2 | LuisRecognizerV3;
 
     /**
-     * Creates a new LuisRecognizer instance.
+     * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
      * @param application The LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptions` definition.
-     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by `recognize()`. Defaults to a value of `false`.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
+     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(application: string, options?: LuisPredictionOptions, includeApiResults?: boolean);
     /**
-     * Creates a new LuisRecognizer instance.
-     * @param application An object conforming to the `LuisApplication` definition.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptions` definition.
-     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by `recognize()`. Defaults to a value of `false`.
+     * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions) definition.
+     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(application: LuisApplication, options?: LuisPredictionOptions, includeApiResults?: boolean);
     /**
-     * Creates a new LuisRecognizer instance.
-     * @param application An object conforming to the `LuisApplication` definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptionsV3` or `LuisRecognizerOptionsV2` definition.
+     * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
      */
     constructor(application: LuisApplication | string, options?: LuisRecognizerOptionsV3 | LuisRecognizerOptionsV2);
     /**
-     * Creates a new LuisRecognizer instance.
-     * @param application The LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptions`, `LuisRecognizerOptionsV3` or `LuisRecognizerOptionsV2` definition.
-     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by `recognize()`. Defaults to a value of `false`.
+     * Creates a new [LuisRecognizer](xref:botbuilder-ai.LuisRecognizer) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisPredictionOptions](xref:botbuilder-ai.LuisPredictionOptions), [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) or [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
+     * @param includeApiResults (Deprecated) Flag that if set to `true` will force the inclusion of LUIS Api call in results returned by the [LuisRecognizer.recognize](xref:botbuilder-ai.LuisRecognizer.recognize) method. Defaults to a value of `false`.
      */
     constructor(
         application: LuisApplication | string,

--- a/libraries/botbuilder-ai/src/luisRecognizerOptions.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptions.ts
@@ -13,11 +13,10 @@ import { RecognizerResult, TurnContext } from 'botbuilder-core';
  * Abstract class for Luis Recognizer.
  */
 export abstract class LuisRecognizerInternal {
-
     /**
-     * Creates a new LuisRecognizerInternal instance.
-     * @param application An object conforming to the `LuisApplication` definition.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptions` definition.
+     * Creates a new [LuisRecognizerInternal](xref:botbuilder-ai.LuisRecognizerInternal) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptions](xref:botbuilder-ai.LuisRecognizerOptions) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptions) {
         if (!application) {

--- a/libraries/botbuilder-ai/src/luisRecognizerOptions.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptions.ts
@@ -16,7 +16,7 @@ export abstract class LuisRecognizerInternal {
     /**
      * Creates a new [LuisRecognizerInternal](xref:botbuilder-ai.LuisRecognizerInternal) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptions](xref:botbuilder-ai.LuisRecognizerOptions) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisRecognizerOptions](xref:botbuilder-ai.LuisRecognizerOptions) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptions) {
         if (!application) {

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
@@ -20,10 +20,9 @@ const LUIS_TRACE_TYPE = 'https://www.luis.ai/schemas/trace';
 const LUIS_TRACE_NAME = 'LuisRecognizer';
 const LUIS_TRACE_LABEL = 'Luis Trace';
 
-
 /**
- * Validates if the options provided are valid LuisRecognizerOptionsV2.
- * @returns A boolean value that indicates param options is a LuisRecognizerOptionsV2.
+ * Validates if the options provided are valid [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2).
+ * @returns A boolean value that indicates param options is a [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2).
  */
 export function isLuisRecognizerOptionsV2(options: any): options is LuisRecognizerOptionsV2 {
     return options.apiVersion && options.apiVersion === 'v2';
@@ -34,9 +33,9 @@ export function isLuisRecognizerOptionsV2(options: any): options is LuisRecogniz
  */
 export class LuisRecognizerV2 extends LuisRecognizerInternal {
     /**
-     * Creates a new LuisRecognizerV2 instance.
-     * @param application An object conforming to the `LuisApplication` definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptionsV2` definition.
+     * Creates a new [LuisRecognizerV2](xref:botbuilder-ai.LuisRecognizerV2) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptionsV2) {
         super(application);
@@ -67,8 +66,8 @@ export class LuisRecognizerV2 extends LuisRecognizerInternal {
 
     /**
      * Calls LUIS to recognize intents and entities in a users utterance.
-     * @param context Turn context.
-     * @returns Analysis of utterance.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext).
+     * @returns Analysis of utterance in form of [RecognizerResult](xref:botbuilder-core.RecognizerResult).
      */
     async recognizeInternal(context: TurnContext): Promise<RecognizerResult> {
         const luisPredictionOptions = this.options;
@@ -114,7 +113,7 @@ export class LuisRecognizerV2 extends LuisRecognizerInternal {
     }
 
     /**
-     * Remove role and ensure that dot and space are not a part of entity names since we want to do JSON paths
+     * Remove role and ensure that dot and space are not a part of entity names since we want to do JSON paths.
      * @param name Value to be normalized.
      * @returns Normalized string value.
      */

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
@@ -35,7 +35,7 @@ export class LuisRecognizerV2 extends LuisRecognizerInternal {
     /**
      * Creates a new [LuisRecognizerV2](xref:botbuilder-ai.LuisRecognizerV2) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV2](xref:botbuilder-ai.LuisRecognizerOptionsV2) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptionsV2) {
         super(application);

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
@@ -33,7 +33,7 @@ export class LuisRecognizerV3 extends LuisRecognizerInternal {
     /**
      * Creates a new [LuisRecognizerV3](xref:botbuilder-ai.LuisRecognizerV3) instance.
      * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) definition.
+     * @param options Optional. Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptionsV3) {
         super(application);

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
@@ -19,8 +19,8 @@ const _geographySubtypes = ['poi', 'city', 'countryRegion', 'continent', 'state'
 const MetadataKey = '$instance';
 
 /**
- * Validates if the options provided are valid LuisRecognizerOptionsV3.
- * @returns A boolean value that indicates param options is a LuisRecognizerOptionsV3.
+ * Validates if the options provided are valid [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3).
+ * @returns A boolean value that indicates param options is a [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3).
  */
 export function isLuisRecognizerOptionsV3(options: any): options is LuisRecognizerOptionsV3 {
     return options.apiVersion && options.apiVersion === 'v3';
@@ -30,11 +30,10 @@ export function isLuisRecognizerOptionsV3(options: any): options is LuisRecogniz
  * Recognize intents in a user utterance using a configured LUIS model.
  */
 export class LuisRecognizerV3 extends LuisRecognizerInternal {
-
     /**
-     * Creates a new LuisRecognizerV3 instance.
-     * @param application An object conforming to the `LuisApplication` definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
-     * @param options (Optional) Options object used to control predictions. Should conform to the `LuisRecognizerOptionsV3` definition.
+     * Creates a new [LuisRecognizerV3](xref:botbuilder-ai.LuisRecognizerV3) instance.
+     * @param application An object conforming to the [LuisApplication](xref:botbuilder-ai.LuisApplication) definition or a string representing a LUIS application endpoint, usually retrieved from https://luis.ai.
+     * @param options (Optional) Options object used to control predictions. Should conform to the [LuisRecognizerOptionsV3](xref:botbuilder-ai.LuisRecognizerOptionsV3) definition.
      */
     constructor(application: LuisApplication, options?: LuisRecognizerOptionsV3) {
         super(application);
@@ -57,7 +56,8 @@ export class LuisRecognizerV3 extends LuisRecognizerInternal {
 
     /**
      * Calls LUIS to recognize intents and entities in a users utterance.
-     * @param context Turn context.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext).
+     * @returns Analysis of utterance in form of [RecognizerResult](xref:botbuilder-core.RecognizerResult).
      */
     async recognizeInternal(context: TurnContext): Promise<RecognizerResult> {
         const utterance: string = context.activity.text || '';

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -167,8 +167,8 @@ export class QnAMaker implements QnAMakerTelemetryClient {
 
     /**
      * Generates an answer from the knowledge base.
-     * @param context The Turn Context that contains the user question to be queried against your knowledge base.
-     * @param options (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) that contains the user question to be queried against your knowledge base.
+     * @param options (Optional) The [QnAMakerOptions](xref:botbuilder-ai.QnAMakerOptions) for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      * @param telemetryProperties (Optional) Additional properties to be logged to telemetry with the QnaMessage event.
      * @param telemetryMetrics (Optional) Additional metrics to be logged to telemetry with the QnaMessage event.
      * @returns A list of answers for the user query, sorted in decreasing order of ranking score.

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -168,9 +168,9 @@ export class QnAMaker implements QnAMakerTelemetryClient {
     /**
      * Generates an answer from the knowledge base.
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) that contains the user question to be queried against your knowledge base.
-     * @param options (Optional) The [QnAMakerOptions](xref:botbuilder-ai.QnAMakerOptions) for the QnA Maker knowledge base. If null, constructor option is used for this instance.
-     * @param telemetryProperties (Optional) Additional properties to be logged to telemetry with the QnaMessage event.
-     * @param telemetryMetrics (Optional) Additional metrics to be logged to telemetry with the QnaMessage event.
+     * @param options Optional. The [QnAMakerOptions](xref:botbuilder-ai.QnAMakerOptions) for the QnA Maker knowledge base. If null, constructor option is used for this instance.
+     * @param telemetryProperties Optional. Additional properties to be logged to telemetry with the QnaMessage event.
+     * @param telemetryMetrics Optional. Additional metrics to be logged to telemetry with the QnaMessage event.
      * @returns A list of answers for the user query, sorted in decreasing order of ranking score.
      */
     public async getAnswersRaw(


### PR DESCRIPTION
PR 2816 in MS, #140 in SW

Feedback applied to use xref to link to other methods.

### note that the links will not work in visual studio, these links are meant to be used to build the web documentation.
### searchable here https://docs.microsoft.com/en-us/javascript/api/

This PR doesn't have conflicts, I didn't update the branch with main here to don't bring irrelevant changes.