### PR TITLE
[#XXX] Parity issue with getContinuationActivity method missing the type property

### DIFF
--- a/libraries/botframework-schema/src/activityEx.ts
+++ b/libraries/botframework-schema/src/activityEx.ts
@@ -442,6 +442,7 @@ export namespace ActivityEx {
      */
     export function getContinuationActivity(reference: Partial<ConversationReference>): Partial<Activity> {
         return {
+            type: ActivityTypes.Event,
             name: ActivityEventNames.ContinueConversation,
             id: uuid(),
             channelId: reference.channelId,


### PR DESCRIPTION
Fixes # XXX (Parity issue with getContinuationActivity method missing the type property # 224)

## Description
This PR fixes a parity issue in the [getContinuationActivity](https://github.com/southworks/botbuilder-js/blob/main/libraries/botframework-schema/src/activityEx.ts#L443) method, adding the missing `type` property that its DotNet counterpart has ([link](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Schema/ConversationReference.cs#L95)). Otherwise when the `ActivityHandler.run` method is executed will validate and throw the [Activity is missing its type](https://github.com/southworks/botbuilder-js/blob/main/libraries/botbuilder-core/src/activityHandlerBase.ts#L401) error when the `type` property is not found in the Activity.

## Specific Changes
- Added the `type` property to be an `ActivityTypes.Event` in the `getContinuationActivity` method.