### PR TITLE
fix: botFrameworkClientFetchImpl function missing headers from Zod validation

### DIFF
--- a/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
@@ -13,10 +13,10 @@ import { ok } from 'assert';
 
 const botFrameworkClientFetchImpl: typeof fetch = async (input, init) => {
     const url = z.string().parse(input);
-    const { body } = z.object({ body: z.string() }).parse(init);
+    const { body, headers } = z.object({ body: z.string(), headers: z.record(z.string()) }).parse(init);
 
     const response = await axios.post(url, JSON.parse(body), {
-        headers: z.record(z.string()).parse(init.headers ?? {}),
+        headers: z.record(z.string()).parse(headers ?? {}),
         validateStatus: () => true,
     });
 


### PR DESCRIPTION
Fixes #minor

## Description
This PR fixes an issue when the `Host` wants to send an `Activity` to the `Skill` using the internal `botFrameworkClientFetchImpl` function to make the `POST` request.
This validation error was found as part of the issue [BotBuilder-Samples # 3526]() to add support for MSI to the JavaScript samples, that currently is under development.

## Specific Changes
- When the Host tries to call the Skill using the internal `botFrameworkClientFetchImpl` function, the `zod` validation fails to recognize the keys from the `headers` object.

## Testing
The following images show the error and the bots working after the fix.
![image](https://user-images.githubusercontent.com/62260472/138126881-dbf2fd03-fff8-44cb-a8a1-7459775017e0.png)
![image](https://user-images.githubusercontent.com/62260472/138126891-6ef13beb-8c47-4cb4-9d51-9ba3afa7cb47.png)