### PR TITLE
[#3997] Move Javascript generators from Samples to "generators" - Core Bot

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/README.md.js
@@ -1,0 +1,86 @@
+# <%= botname %>
+
+<%= description %>
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to:
+
+- Use [LUIS](https://www.luis.ai) to implement core AI capabilities
+- Implement a multi-turn conversation using Dialogs
+- Handle user interruptions for such things as `Help` or `Cancel`
+- Prompt for and validate requests for information from the user
+
+## Prerequisites
+
+This sample **requires** prerequisites in order to run.
+
+### Overview
+
+This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
+
+- [Node.js](https://nodejs.org) version 10.14.1 or higher
+
+    ```bash
+    # determine node version
+    node --version
+    ```
+
+### Create a LUIS Application to enable language understanding
+
+The LUIS model for this example can be found under `cognitiveModels/FlightBooking.json` and the LUIS language model setup, training, and application configuration steps can be found [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=javascript).
+
+Once you created the LUIS model, update `.env` with your `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName`.
+
+```text
+LuisAppId="Your LUIS App Id"
+LuisAPIKey="Your LUIS Subscription key here"
+LuisAPIHostName="Your LUIS App region here (i.e: westus.api.cognitive.microsoft.com)"
+```
+
+# To run the bot
+
+- Install modules
+
+    ```bash
+    npm install
+    ```
+- Setup LUIS
+
+The prerequisite outlined above contain the steps necessary to provision a language understanding model on www.luis.ai.  Refer to _Create a LUIS Application to enable language understanding_ above for directions to setup and configure LUIS.
+
+- Start the bot
+
+    ```bash
+    npm start
+    ```
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Deploy the bot to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Dialogs](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-dialog?view=azure-bot-service-4.0)
+- [Gathering Input Using Prompts](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)
+- [Restify](https://www.npmjs.com/package/restify)
+- [dotenv](https://www.npmjs.com/package/dotenv)

--- a/generators/generator-botbuilder/generators/app/templates/core/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/README.md.ts
@@ -1,0 +1,99 @@
+# <%= botname %>
+
+<%= description %>
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to:
+
+- Use [LUIS](https://www.luis.ai) to implement core AI capabilities
+- Implement a multi-turn conversation using Dialogs
+- Handle user interruptions for such things as `Help` or `Cancel`
+- Prompt for and validate requests for information from the user
+
+## Prerequisites
+
+This sample **requires** prerequisites in order to run.
+
+### Overview
+
+This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
+
+- [Node.js](https://nodejs.org) version 10.14.1 or higher
+
+
+    ```bash
+    # determine node version
+    node --version
+    ```
+
+### Create a LUIS Application to enable language understanding
+
+The LUIS model for this example can be found under `cognitiveModels/FlightBooking.json` and the LUIS language model setup, training, and application configuration steps can be found [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=javascript).
+
+Once you created the LUIS model, update `.env` with your `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName`.
+
+```text
+LuisAppId="Your LUIS App Id"
+LuisAPIKey="Your LUIS Subscription key here"
+LuisAPIHostName="Your LUIS App region here (i.e: westus.api.cognitive.microsoft.com)"
+```
+
+## To run the bot
+
+- Install modules
+
+    ```bash
+    npm install
+    ```
+- Build the bot source code
+
+    ```bash
+    npm run build
+    ```
+- Setup LUIS
+
+The prerequisite outlined above contain the steps necessary to provision a language understanding model on www.luis.ai.  Refer to _Create a LUIS Application to enable language understanding_ above for directions to setup and configure LUIS.
+
+- Start the bot
+
+    ```bash
+    npm start
+    ```
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Deploy the bot to Azure
+
+### Publishing Changes to Azure Bot Service
+
+    ```bash
+    # build the TypeScript bot before you publish
+    npm run build
+    ```
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Dialogs](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-dialog?view=azure-bot-service-4.0)
+- [Gathering Input Using Prompts](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)
+- [TypeScript](https://www.typescriptlang.org)
+- [Restify](https://www.npmjs.com/package/restify)
+- [dotenv](https://www.npmjs.com/package/dotenv)

--- a/generators/generator-botbuilder/generators/app/templates/core/_env
+++ b/generators/generator-botbuilder/generators/app/templates/core/_env
@@ -1,0 +1,7 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=
+LuisAppId=
+LuisAPIKey=
+LuisAPIHostName=

--- a/generators/generator-botbuilder/generators/app/templates/core/_eslintrc.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/_eslintrc.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+module.exports = {
+  "extends": "standard",
+  "rules": {
+    "semi": [2, "always"],
+    "indent": [2, 4],
+    "no-return-await": 0,
+    "space-before-function-paren": [2, {
+      "named": "never",
+      "anonymous": "never",
+      "asyncArrow": "always"
+    }],
+    "template-curly-spacing": [2, "always"]
+  }
+};

--- a/generators/generator-botbuilder/generators/app/templates/core/_gitignore
+++ b/generators/generator-botbuilder/generators/app/templates/core/_gitignore
@@ -1,0 +1,5 @@
+lib/
+node_modules/
+.nyc_output/
+.vscode/
+.env 

--- a/generators/generator-botbuilder/generators/app/templates/core/bots/dialogAndWelcomeBot.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/bots/dialogAndWelcomeBot.js
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { CardFactory } = require('botbuilder-core');
+const { DialogBot } = require('./dialogBot');
+const WelcomeCard = require('../resources/welcomeCard.json');
+
+class DialogAndWelcomeBot extends DialogBot {
+    constructor(conversationState, userState, dialog) {
+        super(conversationState, userState, dialog);
+
+        this.onMembersAdded(async (context, next) => {
+            const membersAdded = context.activity.membersAdded;
+            for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+                if (membersAdded[cnt].id !== context.activity.recipient.id) {
+                    const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
+                    await context.sendActivity({ attachments: [welcomeCard] });
+                    await dialog.run(context, conversationState.createProperty('DialogState'));
+                }
+            }
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}
+
+module.exports.DialogAndWelcomeBot = DialogAndWelcomeBot;

--- a/generators/generator-botbuilder/generators/app/templates/core/bots/dialogAndWelcomeBot.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/bots/dialogAndWelcomeBot.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BotState, CardFactory } from 'botbuilder';
+import { Dialog, DialogState } from 'botbuilder-dialogs';
+import { MainDialog } from '../dialogs/mainDialog';
+import { DialogBot } from './dialogBot';
+
+const WelcomeCard = require('../../resources/welcomeCard.json');
+
+export class DialogAndWelcomeBot extends DialogBot {
+    constructor(conversationState: BotState, userState: BotState, dialog: Dialog) {
+        super(conversationState, userState, dialog);
+
+        this.onMembersAdded(async (context, next) => {
+            const membersAdded = context.activity.membersAdded;
+            for (const member of membersAdded) {
+                if (member.id !== context.activity.recipient.id) {
+                    const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
+                    await context.sendActivity({ attachments: [welcomeCard] });
+                    await (dialog as MainDialog).run(context, conversationState.createProperty<DialogState>('DialogState'));
+                }
+            }
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/bots/dialogBot.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/bots/dialogBot.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityHandler } = require('botbuilder');
+
+class DialogBot extends ActivityHandler {
+    /**
+     *
+     * @param {ConversationState} conversationState
+     * @param {UserState} userState
+     * @param {Dialog} dialog
+     */
+    constructor(conversationState, userState, dialog) {
+        super();
+        if (!conversationState) throw new Error('[DialogBot]: Missing parameter. conversationState is required');
+        if (!userState) throw new Error('[DialogBot]: Missing parameter. userState is required');
+        if (!dialog) throw new Error('[DialogBot]: Missing parameter. dialog is required');
+
+        this.conversationState = conversationState;
+        this.userState = userState;
+        this.dialog = dialog;
+        this.dialogState = this.conversationState.createProperty('DialogState');
+
+        this.onMessage(async (context, next) => {
+            console.log('Running dialog with Message Activity.');
+
+            // Run the Dialog with the new message Activity.
+            await this.dialog.run(context, this.dialogState);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+
+        this.onDialog(async (context, next) => {
+            // Save any state changes. The load happened during the execution of the Dialog.
+            await this.conversationState.saveChanges(context, false);
+            await this.userState.saveChanges(context, false);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}
+
+module.exports.DialogBot = DialogBot;

--- a/generators/generator-botbuilder/generators/app/templates/core/bots/dialogBot.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/bots/dialogBot.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActivityHandler, BotState, ConversationState, StatePropertyAccessor, UserState } from 'botbuilder';
+import { Dialog, DialogState } from 'botbuilder-dialogs';
+import { MainDialog } from '../dialogs/mainDialog';
+
+export class DialogBot extends ActivityHandler {
+    private conversationState: BotState;
+    private userState: BotState;
+    private dialog: Dialog;
+    private dialogState: StatePropertyAccessor<DialogState>;
+
+    /**
+     *
+     * @param {BotState} conversationState
+     * @param {BotState} userState
+     * @param {Dialog} dialog
+     */
+    constructor(conversationState: BotState, userState: BotState, dialog: Dialog) {
+        super();
+        if (!conversationState) {
+            throw new Error('[DialogBot]: Missing parameter. conversationState is required');
+        }
+        if (!userState) {
+            throw new Error('[DialogBot]: Missing parameter. userState is required');
+        }
+        if (!dialog) {
+            throw new Error('[DialogBot]: Missing parameter. dialog is required');
+        }
+
+        this.conversationState = conversationState as ConversationState;
+        this.userState = userState as UserState;
+        this.dialog = dialog;
+        this.dialogState = this.conversationState.createProperty<DialogState>('DialogState');
+
+        this.onMessage(async (context, next) => {
+            console.log('Running dialog with Message Activity.');
+
+            // Run the Dialog with the new message Activity.
+            await (this.dialog as MainDialog).run(context, this.dialogState);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+
+        this.onDialog(async (context, next) => {
+            // Save any state changes. The load happened during the execution of the Dialog.
+            await this.conversationState.saveChanges(context, false);
+            await this.userState.saveChanges(context, false);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/cognitiveModels/FlightBooking.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/cognitiveModels/FlightBooking.json
@@ -1,0 +1,339 @@
+{
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "FlightBooking",
+  "desc": "Luis Model for CoreBot",
+  "culture": "en-us",
+  "tokenizerVersion": "1.0.0",
+  "intents": [
+    {
+      "name": "BookFlight"
+    },
+    {
+      "name": "Cancel"
+    },
+    {
+      "name": "GetWeather"
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [],
+  "composites": [
+    {
+      "name": "From",
+      "children": [
+        "Airport"
+      ],
+      "roles": []
+    },
+    {
+      "name": "To",
+      "children": [
+        "Airport"
+      ],
+      "roles": []
+    }
+  ],
+  "closedLists": [
+    {
+      "name": "Airport",
+      "subLists": [
+        {
+          "canonicalForm": "Paris",
+          "list": [
+            "paris",
+            "cdg"
+          ]
+        },
+        {
+          "canonicalForm": "London",
+          "list": [
+            "london",
+            "lhr"
+          ]
+        },
+        {
+          "canonicalForm": "Berlin",
+          "list": [
+            "berlin",
+            "txl"
+          ]
+        },
+        {
+          "canonicalForm": "New York",
+          "list": [
+            "new york",
+            "jfk"
+          ]
+        },
+        {
+          "canonicalForm": "Seattle",
+          "list": [
+            "seattle",
+            "sea"
+          ]
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "patternAnyEntities": [],
+  "regex_entities": [],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    }
+  ],
+  "model_features": [],
+  "regex_features": [],
+  "patterns": [],
+  "utterances": [
+    {
+      "text": "book a flight",
+      "intent": "BookFlight",
+      "entities": []
+    },
+    {
+      "text": "book a flight from new york",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "book a flight from seattle",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 19,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "book a hotel in new york",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "book a restaurant",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "book flight from london to paris on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 17,
+          "endPos": 22
+        },
+        {
+          "entity": "To",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "book flight to berlin on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 15,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "book me a flight from london to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 22,
+          "endPos": 27
+        },
+        {
+          "entity": "To",
+          "startPos": 32,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "bye",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "cancel booking",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "exit",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "find an airport near me",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "flight to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "flight to paris from london on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "From",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "fly from berlin to paris on may 5th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "To",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "go to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 6,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "going from paris to berlin",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "To",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "i'd like to rent a car",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "ignore",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "travel from new york to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 12,
+          "endPos": 19
+        },
+        {
+          "entity": "To",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "travel to new york",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "travel to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what's the forecast for this friday?",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like for tomorrow",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like in new york",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like?",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "winter is coming",
+      "intent": "None",
+      "entities": []
+    }
+  ],
+  "settings": []
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentScripts/webConfigPrep.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentScripts/webConfigPrep.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// DO NOT MODIFY THIS CODE
+// This script is run as part of the Post Deploy step when
+// deploying the bot to Azure.  It ensures the Azure Web App
+// is configured correctly to host a TypeScript authored bot.
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace');
+const WEB_CONFIG_FILE = './web.config';
+
+if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
+    replace({
+        regex: "url=\"index.js\"",
+        replacement: "url=\"lib/index.js\"",
+        paths: ['./web.config'],
+        recursive: false,
+        silent: true,
+    })
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/new-rg-parameters.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/preexisting-rg-parameters.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-new-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,258 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "defaultValue": "F0",
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the new App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "appServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan."
+            }
+        },
+        "existingAppServicePlan": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+        "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+        "resourcesLocation": "[parameters('appServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+            "type": "Microsoft.Web/serverfarms",
+            "condition": "[not(variables('useExistingAppServicePlan'))]",
+            "name": "[variables('servicePlanName')]",
+            "apiVersion": "2018-02-01",
+            "location": "[variables('resourcesLocation')]",
+            "sku": "[parameters('newAppServicePlanSku')]",
+            "properties": {
+                "name": "[variables('servicePlanName')]"
+            }
+        },
+        {
+            "comments": "Create a Web App using an App Service Plan",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2015-08-01",
+            "location": "[variables('resourcesLocation')]",
+            "kind": "app",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+            ],
+            "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
+            "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "10.14.1"
+                        },
+                        {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
+                            "name": "MicrosoftAppId",
+                            "value": "[parameters('appId')]"
+                        },
+                        {
+                            "name": "MicrosoftAppPassword",
+                            "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
+                        }
+                    ],
+                    "cors": {
+                        "allowedOrigins": [
+                            "https://botservice.hosting.portal.azure.net",
+                            "https://hosting.onecloud.azure-test.net/"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
+            "location": "global",
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
+            },
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        }
+    ]
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDetails.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDetails.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class BookingDetails {
+    public intent: string;
+    public origin: string;
+    public destination: string;
+    public travelDate: string;
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDialog.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDialog.js
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { InputHints, MessageFactory } = require('botbuilder');
+const { ConfirmPrompt, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');
+const { DateResolverDialog } = require('./dateResolverDialog');
+
+const CONFIRM_PROMPT = 'confirmPrompt';
+const DATE_RESOLVER_DIALOG = 'dateResolverDialog';
+const TEXT_PROMPT = 'textPrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+class BookingDialog extends CancelAndHelpDialog {
+    constructor(id) {
+        super(id || 'bookingDialog');
+
+        this.addDialog(new TextPrompt(TEXT_PROMPT))
+            .addDialog(new ConfirmPrompt(CONFIRM_PROMPT))
+            .addDialog(new DateResolverDialog(DATE_RESOLVER_DIALOG))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.destinationStep.bind(this),
+                this.originStep.bind(this),
+                this.travelDateStep.bind(this),
+                this.confirmStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * If a destination city has not been provided, prompt for one.
+     */
+    async destinationStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        if (!bookingDetails.destination) {
+            const messageText = 'To what city would you like to travel?';
+            const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        }
+        return await stepContext.next(bookingDetails.destination);
+    }
+
+    /**
+     * If an origin city has not been provided, prompt for one.
+     */
+    async originStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the response to the previous step's prompt
+        bookingDetails.destination = stepContext.result;
+        if (!bookingDetails.origin) {
+            const messageText = 'From what city will you be travelling?';
+            const msg = MessageFactory.text(messageText, 'From what city will you be travelling?', InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        }
+        return await stepContext.next(bookingDetails.origin);
+    }
+
+    /**
+     * If a travel date has not been provided, prompt for one.
+     * This will use the DATE_RESOLVER_DIALOG.
+     */
+    async travelDateStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the results of the previous step
+        bookingDetails.origin = stepContext.result;
+        if (!bookingDetails.travelDate || this.isAmbiguous(bookingDetails.travelDate)) {
+            return await stepContext.beginDialog(DATE_RESOLVER_DIALOG, { date: bookingDetails.travelDate });
+        }
+        return await stepContext.next(bookingDetails.travelDate);
+    }
+
+    /**
+     * Confirm the information the user has provided.
+     */
+    async confirmStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the results of the previous step
+        bookingDetails.travelDate = stepContext.result;
+        const messageText = `Please confirm, I have you traveling to: ${ bookingDetails.destination } from: ${ bookingDetails.origin } on: ${ bookingDetails.travelDate }. Is this correct?`;
+        const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+
+        // Offer a YES/NO prompt.
+        return await stepContext.prompt(CONFIRM_PROMPT, { prompt: msg });
+    }
+
+    /**
+     * Complete the interaction and end the dialog.
+     */
+    async finalStep(stepContext) {
+        if (stepContext.result === true) {
+            const bookingDetails = stepContext.options;
+            return await stepContext.endDialog(bookingDetails);
+        }
+        return await stepContext.endDialog();
+    }
+
+    isAmbiguous(timex) {
+        const timexPropery = new TimexProperty(timex);
+        return !timexPropery.types.has('definite');
+    }
+}
+
+module.exports.BookingDialog = BookingDialog;

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDialog.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/bookingDialog.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { InputHints, MessageFactory } from 'botbuilder';
+import {
+    ConfirmPrompt,
+    DialogTurnResult,
+    TextPrompt,
+    WaterfallDialog,
+    WaterfallStepContext
+} from 'botbuilder-dialogs';
+import { BookingDetails } from './bookingDetails';
+import { CancelAndHelpDialog } from './cancelAndHelpDialog';
+import { DateResolverDialog } from './dateResolverDialog';
+
+const CONFIRM_PROMPT = 'confirmPrompt';
+const DATE_RESOLVER_DIALOG = 'dateResolverDialog';
+const TEXT_PROMPT = 'textPrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+export class BookingDialog extends CancelAndHelpDialog {
+    constructor(id: string) {
+        super(id || 'bookingDialog');
+
+        this.addDialog(new TextPrompt(TEXT_PROMPT))
+            .addDialog(new ConfirmPrompt(CONFIRM_PROMPT))
+            .addDialog(new DateResolverDialog(DATE_RESOLVER_DIALOG))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.destinationStep.bind(this),
+                this.originStep.bind(this),
+                this.travelDateStep.bind(this),
+                this.confirmStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * If a destination city has not been provided, prompt for one.
+     */
+    private async destinationStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const bookingDetails = stepContext.options as BookingDetails;
+
+        if (!bookingDetails.destination) {
+            const messageText = 'To what city would you like to travel?';
+            const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        } else {
+            return await stepContext.next(bookingDetails.destination);
+        }
+    }
+
+    /**
+     * If an origin city has not been provided, prompt for one.
+     */
+    private async originStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const bookingDetails = stepContext.options as BookingDetails;
+
+        // Capture the response to the previous step's prompt
+        bookingDetails.destination = stepContext.result;
+        if (!bookingDetails.origin) {
+            const messageText = 'From what city will you be travelling?';
+            const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        } else {
+            return await stepContext.next(bookingDetails.origin);
+        }
+    }
+
+    /**
+     * If a travel date has not been provided, prompt for one.
+     * This will use the DATE_RESOLVER_DIALOG.
+     */
+    private async travelDateStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const bookingDetails = stepContext.options as BookingDetails;
+
+        // Capture the results of the previous step
+        bookingDetails.origin = stepContext.result;
+        if (!bookingDetails.travelDate || this.isAmbiguous(bookingDetails.travelDate)) {
+            return await stepContext.beginDialog(DATE_RESOLVER_DIALOG, { date: bookingDetails.travelDate });
+        } else {
+            return await stepContext.next(bookingDetails.travelDate);
+        }
+    }
+
+    /**
+     * Confirm the information the user has provided.
+     */
+    private async confirmStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const bookingDetails = stepContext.options as BookingDetails;
+
+        // Capture the results of the previous step
+        bookingDetails.travelDate = stepContext.result;
+        const messageText = `Please confirm, I have you traveling to: ${ bookingDetails.destination } from: ${ bookingDetails.origin } on: ${ bookingDetails.travelDate }. Is this correct?`;
+        const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+
+        // Offer a YES/NO prompt.
+        return await stepContext.prompt(CONFIRM_PROMPT, { prompt: msg });
+    }
+
+    /**
+     * Complete the interaction and end the dialog.
+     */
+    private async finalStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        if (stepContext.result === true) {
+            const bookingDetails = stepContext.options as BookingDetails;
+
+            return await stepContext.endDialog(bookingDetails);
+        }
+        return await stepContext.endDialog();
+    }
+
+    private isAmbiguous(timex: string): boolean {
+        const timexPropery = new TimexProperty(timex);
+        return !timexPropery.types.has('definite');
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/cancelAndHelpDialog.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/cancelAndHelpDialog.js
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { InputHints } = require('botbuilder');
+const { ComponentDialog, DialogTurnStatus } = require('botbuilder-dialogs');
+
+/**
+ * This base class watches for common phrases like "help" and "cancel" and takes action on them
+ * BEFORE they reach the normal bot logic.
+ */
+class CancelAndHelpDialog extends ComponentDialog {
+    async onContinueDialog(innerDc) {
+        const result = await this.interrupt(innerDc);
+        if (result) {
+            return result;
+        }
+        return await super.onContinueDialog(innerDc);
+    }
+
+    async interrupt(innerDc) {
+        if (innerDc.context.activity.text) {
+            const text = innerDc.context.activity.text.toLowerCase();
+
+            switch (text) {
+            case 'help':
+            case '?': {
+                const helpMessageText = 'Show help here';
+                await innerDc.context.sendActivity(helpMessageText, helpMessageText, InputHints.ExpectingInput);
+                return { status: DialogTurnStatus.waiting };
+            }
+            case 'cancel':
+            case 'quit': {
+                const cancelMessageText = 'Cancelling...';
+                await innerDc.context.sendActivity(cancelMessageText, cancelMessageText, InputHints.IgnoringInput);
+                return await innerDc.cancelAllDialogs();
+            }
+            }
+        }
+    }
+}
+
+module.exports.CancelAndHelpDialog = CancelAndHelpDialog;

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/cancelAndHelpDialog.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/cancelAndHelpDialog.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InputHints } from 'botbuilder';
+import { ComponentDialog, DialogContext, DialogTurnResult, DialogTurnStatus } from 'botbuilder-dialogs';
+
+/**
+ * This base class watches for common phrases like "help" and "cancel" and takes action on them
+ * BEFORE they reach the normal bot logic.
+ */
+export class CancelAndHelpDialog extends ComponentDialog {
+    constructor(id: string) {
+        super(id);
+    }
+
+    public async onContinueDialog(innerDc: DialogContext): Promise<DialogTurnResult> {
+        const result = await this.interrupt(innerDc);
+        if (result) {
+            return result;
+        }
+        return await super.onContinueDialog(innerDc);
+    }
+
+    private async interrupt(innerDc: DialogContext): Promise<DialogTurnResult|undefined> {
+        if (innerDc.context.activity.text) {
+            const text = innerDc.context.activity.text.toLowerCase();
+
+            switch (text) {
+                case 'help':
+                case '?':
+                    const helpMessageText = 'Show help here';
+                    await innerDc.context.sendActivity(helpMessageText, helpMessageText, InputHints.ExpectingInput);
+                    return { status: DialogTurnStatus.waiting };
+                case 'cancel':
+                case 'quit':
+                    const cancelMessageText = 'Cancelling...';
+                    await innerDc.context.sendActivity(cancelMessageText, cancelMessageText, InputHints.IgnoringInput);
+                    return await innerDc.cancelAllDialogs();
+            }
+        }
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/dateResolverDialog.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/dateResolverDialog.js
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { InputHints, MessageFactory } = require('botbuilder');
+const { DateTimePrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+
+const DATETIME_PROMPT = 'datetimePrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+class DateResolverDialog extends CancelAndHelpDialog {
+    constructor(id) {
+        super(id || 'dateResolverDialog');
+        this.addDialog(new DateTimePrompt(DATETIME_PROMPT, this.dateTimePromptValidator.bind(this)))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.initialStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    async initialStep(stepContext) {
+        const timex = stepContext.options.date;
+
+        const promptMessageText = 'On what date would you like to travel?';
+        const promptMessage = MessageFactory.text(promptMessageText, promptMessageText, InputHints.ExpectingInput);
+
+        const repromptMessageText = "I'm sorry, for best results, please enter your travel date including the month, day and year.";
+        const repromptMessage = MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput);
+
+        if (!timex) {
+            // We were not given any date at all so prompt the user.
+            return await stepContext.prompt(DATETIME_PROMPT,
+                {
+                    prompt: promptMessage,
+                    retryPrompt: repromptMessage
+                });
+        }
+        // We have a Date we just need to check it is unambiguous.
+        const timexProperty = new TimexProperty(timex);
+        if (!timexProperty.types.has('definite')) {
+            // This is essentially a "reprompt" of the data we were given up front.
+            return await stepContext.prompt(DATETIME_PROMPT, { prompt: repromptMessage });
+        }
+        return await stepContext.next([{ timex: timex }]);
+    }
+
+    async finalStep(stepContext) {
+        const timex = stepContext.result[0].timex;
+        return await stepContext.endDialog(timex);
+    }
+
+    async dateTimePromptValidator(promptContext) {
+        if (promptContext.recognized.succeeded) {
+            // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+            // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+            const timex = promptContext.recognized.value[0].timex.split('T')[0];
+
+            // If this is a definite Date including year, month and day we are good otherwise reprompt.
+            // A better solution might be to let the user know what part is actually missing.
+            return new TimexProperty(timex).types.has('definite');
+        }
+        return false;
+    }
+}
+
+module.exports.DateResolverDialog = DateResolverDialog;

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/dateResolverDialog.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/dateResolverDialog.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { InputHints, MessageFactory } from 'botbuilder';
+import { DateTimePrompt, DateTimeResolution, DialogTurnResult, PromptValidatorContext, WaterfallDialog, WaterfallStepContext } from 'botbuilder-dialogs';
+import { CancelAndHelpDialog } from './cancelAndHelpDialog';
+
+const DATETIME_PROMPT = 'datetimePrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+export class DateResolverDialog extends CancelAndHelpDialog {
+
+    private static async dateTimePromptValidator(promptContext: PromptValidatorContext<DateTimeResolution>): Promise<boolean> {
+        if (promptContext.recognized.succeeded) {
+            // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+            // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+            const timex = promptContext.recognized.value[0].timex.split('T')[0];
+
+            // If this is a definite Date including year, month and day we are good otherwise reprompt.
+            // A better solution might be to let the user know what part is actually missing.
+            return new TimexProperty(timex).types.has('definite');
+        }
+        return false;
+    }
+
+    constructor(id: string) {
+        super(id || 'dateResolverDialog');
+        this.addDialog(new DateTimePrompt(DATETIME_PROMPT, DateResolverDialog.dateTimePromptValidator.bind(this)))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.initialStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    private async initialStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const timex = (stepContext.options as any).date;
+
+        const promptMessageText = 'On what date would you like to travel?';
+        const promptMessage = MessageFactory.text(promptMessageText, promptMessageText, InputHints.ExpectingInput);
+
+        const repromptMessageText = 'I\'m sorry, for best results, please enter your travel date including the month, day and year.';
+        const repromptMessage = MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput);
+
+        if (!timex) {
+            // We were not given any date at all so prompt the user.
+            return await stepContext.prompt(DATETIME_PROMPT,
+                {
+                    prompt: promptMessage,
+                    retryPrompt: repromptMessage
+                });
+        }
+        // We have a Date we just need to check it is unambiguous.
+        const timexProperty = new TimexProperty(timex);
+        if (!timexProperty.types.has('definite')) {
+            // This is essentially a "reprompt" of the data we were given up front.
+            return await stepContext.prompt(DATETIME_PROMPT, { prompt: repromptMessage });
+        }
+        return await stepContext.next([{ timex }]);
+    }
+
+    private async finalStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const timex = stepContext.result[0].timex;
+        return await stepContext.endDialog(timex);
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.js
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { LuisRecognizer } = require('botbuilder-ai');
+
+class FlightBookingRecognizer {
+    constructor(config) {
+        const luisIsConfigured = config && config.applicationId && config.endpointKey && config.endpoint;
+        if (luisIsConfigured) {
+            // Set the recognizer options depending on which endpoint version you want to use e.g v2 or v3.
+            // More details can be found in https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
+            const recognizerOptions = {
+                apiVersion: 'v3'
+            };
+
+            this.recognizer = new LuisRecognizer(config, recognizerOptions);
+        }
+    }
+
+    get isConfigured() {
+        return (this.recognizer !== undefined);
+    }
+
+    /**
+     * Returns an object with preformatted LUIS results for the bot's dialogs to consume.
+     * @param {TurnContext} context
+     */
+    async executeLuisQuery(context) {
+        return await this.recognizer.recognize(context);
+    }
+
+    getFromEntities(result) {
+        let fromValue, fromAirportValue;
+        if (result.entities.$instance.From) {
+            fromValue = result.entities.$instance.From[0].text;
+        }
+        if (fromValue && result.entities.From[0].Airport) {
+            fromAirportValue = result.entities.From[0].Airport[0][0];
+        }
+
+        return { from: fromValue, airport: fromAirportValue };
+    }
+
+    getToEntities(result) {
+        let toValue, toAirportValue;
+        if (result.entities.$instance.To) {
+            toValue = result.entities.$instance.To[0].text;
+        }
+        if (toValue && result.entities.To[0].Airport) {
+            toAirportValue = result.entities.To[0].Airport[0][0];
+        }
+
+        return { to: toValue, airport: toAirportValue };
+    }
+
+    /**
+     * This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+     * TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+     */
+    getTravelDate(result) {
+        const datetimeEntity = result.entities.datetime;
+        if (!datetimeEntity || !datetimeEntity[0]) return undefined;
+
+        const timex = datetimeEntity[0].timex;
+        if (!timex || !timex[0]) return undefined;
+
+        const datetime = timex[0].split('T')[0];
+        return datetime;
+    }
+}
+
+module.exports.FlightBookingRecognizer = FlightBookingRecognizer;

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RecognizerResult, TurnContext } from 'botbuilder';
+import { LuisApplication, LuisRecognizer, LuisRecognizerOptionsV3 } from 'botbuilder-ai';
+
+export class FlightBookingRecognizer {
+    private recognizer: LuisRecognizer;
+
+    constructor(config: LuisApplication) {
+        const luisIsConfigured = config && config.applicationId && config.endpoint && config.endpointKey;
+        if (luisIsConfigured) {
+            // Set the recognizer options depending on which endpoint version you want to use e.g LuisRecognizerOptionsV2 or LuisRecognizerOptionsV3.
+            // More details can be found in https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
+            const recognizerOptions: LuisRecognizerOptionsV3 = {
+                apiVersion : 'v3'
+            };
+
+            this.recognizer = new LuisRecognizer(config, recognizerOptions);
+        }
+    }
+
+    public get isConfigured(): boolean {
+        return (this.recognizer !== undefined);
+    }
+
+    /**
+     * Returns an object with preformatted LUIS results for the bot's dialogs to consume.
+     * @param {TurnContext} context
+     */
+    public async executeLuisQuery(context: TurnContext): Promise<RecognizerResult> {
+        return this.recognizer.recognize(context);
+    }
+
+    public getFromEntities(result) {
+        let fromValue, fromAirportValue;
+        if (result.entities.$instance.From) {
+            fromValue = result.entities.$instance.From[0].text;
+        }
+        if (fromValue && result.entities.From[0].Airport) {
+            fromAirportValue = result.entities.From[0].Airport[0][0];
+        }
+
+        return { from: fromValue, airport: fromAirportValue };
+    }
+
+    public getToEntities(result) {
+        let toValue, toAirportValue;
+        if (result.entities.$instance.To) {
+            toValue = result.entities.$instance.To[0].text;
+        }
+        if (toValue && result.entities.To[0].Airport) {
+            toAirportValue = result.entities.To[0].Airport[0][0];
+        }
+
+        return { to: toValue, airport: toAirportValue };
+    }
+
+    /**
+     * This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+     * TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+     */
+    public getTravelDate(result) {
+        const datetimeEntity = result.entities.datetime;
+        if (!datetimeEntity || !datetimeEntity[0]) return undefined;
+
+        const timex = datetimeEntity[0].timex;
+        if (!timex || !timex[0]) return undefined;
+
+        const datetime = timex[0].split('T')[0];
+        return datetime;
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/mainDialog.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/mainDialog.js
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { MessageFactory, InputHints } = require('botbuilder');
+const { LuisRecognizer } = require('botbuilder-ai');
+const { ComponentDialog, DialogSet, DialogTurnStatus, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+
+const MAIN_WATERFALL_DIALOG = 'mainWaterfallDialog';
+
+class MainDialog extends ComponentDialog {
+    constructor(luisRecognizer, bookingDialog) {
+        super('MainDialog');
+
+        if (!luisRecognizer) throw new Error('[MainDialog]: Missing parameter \'luisRecognizer\' is required');
+        this.luisRecognizer = luisRecognizer;
+
+        if (!bookingDialog) throw new Error('[MainDialog]: Missing parameter \'bookingDialog\' is required');
+
+        // Define the main dialog and its related components.
+        // This is a sample "book a flight" dialog.
+        this.addDialog(new TextPrompt('TextPrompt'))
+            .addDialog(bookingDialog)
+            .addDialog(new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
+                this.introStep.bind(this),
+                this.actStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = MAIN_WATERFALL_DIALOG;
+    }
+
+    /**
+     * The run method handles the incoming activity (in the form of a TurnContext) and passes it through the dialog system.
+     * If no dialog is active, it will start the default dialog.
+     * @param {*} turnContext
+     * @param {*} accessor
+     */
+    async run(turnContext, accessor) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(turnContext);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+
+    /**
+     * First step in the waterfall dialog. Prompts the user for a command.
+     * Currently, this expects a booking request, like "book me a flight from Paris to Berlin on march 22"
+     * Note that the sample LUIS model will only recognize Paris, Berlin, New York and London as airport cities.
+     */
+    async introStep(stepContext) {
+        if (!this.luisRecognizer.isConfigured) {
+            const messageText = 'NOTE: LUIS is not configured. To enable all capabilities, add `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName` to the .env file.';
+            await stepContext.context.sendActivity(messageText, null, InputHints.IgnoringInput);
+            return await stepContext.next();
+        }
+
+        const messageText = stepContext.options.restartMsg ? stepContext.options.restartMsg : 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"';
+        const promptMessage = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+        return await stepContext.prompt('TextPrompt', { prompt: promptMessage });
+    }
+
+    /**
+     * Second step in the waterfall.  This will use LUIS to attempt to extract the origin, destination and travel dates.
+     * Then, it hands off to the bookingDialog child dialog to collect any remaining details.
+     */
+    async actStep(stepContext) {
+        const bookingDetails = {};
+
+        if (!this.luisRecognizer.isConfigured) {
+            // LUIS is not configured, we just run the BookingDialog path.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+        }
+
+        // Call LUIS and gather any potential booking details. (Note the TurnContext has the response to the prompt)
+        const luisResult = await this.luisRecognizer.executeLuisQuery(stepContext.context);
+        switch (LuisRecognizer.topIntent(luisResult)) {
+        case 'BookFlight': {
+            // Extract the values for the composite entities from the LUIS result.
+            const fromEntities = this.luisRecognizer.getFromEntities(luisResult);
+            const toEntities = this.luisRecognizer.getToEntities(luisResult);
+
+            // Show a warning for Origin and Destination if we can't resolve them.
+            await this.showWarningForUnsupportedCities(stepContext.context, fromEntities, toEntities);
+
+            // Initialize BookingDetails with any entities we may have found in the response.
+            bookingDetails.destination = toEntities.airport;
+            bookingDetails.origin = fromEntities.airport;
+            bookingDetails.travelDate = this.luisRecognizer.getTravelDate(luisResult);
+            console.log('LUIS extracted these booking details:', JSON.stringify(bookingDetails));
+
+            // Run the BookingDialog passing in whatever details we have from the LUIS call, it will fill out the remainder.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+        }
+
+        case 'GetWeather': {
+            // We haven't implemented the GetWeatherDialog so we just display a TODO message.
+            const getWeatherMessageText = 'TODO: get weather flow here';
+            await stepContext.context.sendActivity(getWeatherMessageText, getWeatherMessageText, InputHints.IgnoringInput);
+            break;
+        }
+
+        default: {
+            // Catch all for unhandled intents
+            const didntUnderstandMessageText = `Sorry, I didn't get that. Please try asking in a different way (intent was ${ LuisRecognizer.topIntent(luisResult) })`;
+            await stepContext.context.sendActivity(didntUnderstandMessageText, didntUnderstandMessageText, InputHints.IgnoringInput);
+        }
+        }
+
+        return await stepContext.next();
+    }
+
+    /**
+     * Shows a warning if the requested From or To cities are recognized as entities but they are not in the Airport entity list.
+     * In some cases LUIS will recognize the From and To composite entities as a valid cities but the From and To Airport values
+     * will be empty if those entity values can't be mapped to a canonical item in the Airport.
+     */
+    async showWarningForUnsupportedCities(context, fromEntities, toEntities) {
+        const unsupportedCities = [];
+        if (fromEntities.from && !fromEntities.airport) {
+            unsupportedCities.push(fromEntities.from);
+        }
+
+        if (toEntities.to && !toEntities.airport) {
+            unsupportedCities.push(toEntities.to);
+        }
+
+        if (unsupportedCities.length) {
+            const messageText = `Sorry but the following airports are not supported: ${ unsupportedCities.join(', ') }`;
+            await context.sendActivity(messageText, messageText, InputHints.IgnoringInput);
+        }
+    }
+
+    /**
+     * This is the final step in the main waterfall dialog.
+     * It wraps up the sample "book a flight" interaction with a simple confirmation.
+     */
+    async finalStep(stepContext) {
+        // If the child dialog ("bookingDialog") was cancelled or the user failed to confirm, the Result here will be null.
+        if (stepContext.result) {
+            const result = stepContext.result;
+            // Now we have all the booking details.
+
+            // This is where calls to the booking AOU service or database would go.
+
+            // If the call to the booking service was successful tell the user.
+            const timeProperty = new TimexProperty(result.travelDate);
+            const travelDateMsg = timeProperty.toNaturalLanguage(new Date(Date.now()));
+            const msg = `I have you booked to ${ result.destination } from ${ result.origin } on ${ travelDateMsg }.`;
+            await stepContext.context.sendActivity(msg, msg, InputHints.IgnoringInput);
+        }
+
+        // Restart the main dialog with a different message the second time around
+        return await stepContext.replaceDialog(this.initialDialogId, { restartMsg: 'What else can I do for you?' });
+    }
+}
+
+module.exports.MainDialog = MainDialog;

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/mainDialog.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/mainDialog.ts
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { BookingDetails } from './bookingDetails';
+
+import { InputHints, MessageFactory, StatePropertyAccessor, TurnContext } from 'botbuilder';
+import { LuisRecognizer } from 'botbuilder-ai';
+
+import {
+    ComponentDialog,
+    DialogSet,
+    DialogState,
+    DialogTurnResult,
+    DialogTurnStatus,
+    TextPrompt,
+    WaterfallDialog,
+    WaterfallStepContext
+} from 'botbuilder-dialogs';
+import { BookingDialog } from './bookingDialog';
+import { FlightBookingRecognizer } from './flightBookingRecognizer';
+
+const MAIN_WATERFALL_DIALOG = 'mainWaterfallDialog';
+
+export class MainDialog extends ComponentDialog {
+    private luisRecognizer: FlightBookingRecognizer;
+
+    constructor(luisRecognizer: FlightBookingRecognizer, bookingDialog: BookingDialog) {
+        super('MainDialog');
+
+        if (!luisRecognizer) throw new Error('[MainDialog]: Missing parameter \'luisRecognizer\' is required');
+        this.luisRecognizer = luisRecognizer;
+
+        if (!bookingDialog) throw new Error('[MainDialog]: Missing parameter \'bookingDialog\' is required');
+
+        // Define the main dialog and its related components.
+        // This is a sample "book a flight" dialog.
+        this.addDialog(new TextPrompt('TextPrompt'))
+            .addDialog(bookingDialog)
+            .addDialog(new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
+                this.introStep.bind(this),
+                this.actStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = MAIN_WATERFALL_DIALOG;
+    }
+
+    /**
+     * The run method handles the incoming activity (in the form of a DialogContext) and passes it through the dialog system.
+     * If no dialog is active, it will start the default dialog.
+     * @param {TurnContext} context
+     */
+    public async run(context: TurnContext, accessor: StatePropertyAccessor<DialogState>) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(context);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+
+    /**
+     * First step in the waterfall dialog. Prompts the user for a command.
+     * Currently, this expects a booking request, like "book me a flight from Paris to Berlin on march 22"
+     * Note that the sample LUIS model will only recognize Paris, Berlin, New York and London as airport cities.
+     */
+    private async introStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        if (!this.luisRecognizer.isConfigured) {
+            const luisConfigMsg = 'NOTE: LUIS is not configured. To enable all capabilities, add `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName` to the .env file.';
+            await stepContext.context.sendActivity(luisConfigMsg, null, InputHints.IgnoringInput);
+            return await stepContext.next();
+        }
+
+        const messageText = (stepContext.options as any).restartMsg ? (stepContext.options as any).restartMsg : 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"';
+        const promptMessage = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+        return await stepContext.prompt('TextPrompt', { prompt: promptMessage });
+    }
+
+    /**
+     * Second step in the waterall.  This will use LUIS to attempt to extract the origin, destination and travel dates.
+     * Then, it hands off to the bookingDialog child dialog to collect any remaining details.
+     */
+    private async actStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        const bookingDetails = new BookingDetails();
+
+        if (!this.luisRecognizer.isConfigured) {
+            // LUIS is not configured, we just run the BookingDialog path.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+        }
+
+        // Call LUIS and gather any potential booking details. (Note the TurnContext has the response to the prompt)
+        const luisResult = await this.luisRecognizer.executeLuisQuery(stepContext.context);
+        switch (LuisRecognizer.topIntent(luisResult)) {
+        case 'BookFlight':
+            // Extract the values for the composite entities from the LUIS result.
+            const fromEntities = this.luisRecognizer.getFromEntities(luisResult);
+            const toEntities = this.luisRecognizer.getToEntities(luisResult);
+
+            // Show a warning for Origin and Destination if we can't resolve them.
+            await this.showWarningForUnsupportedCities(stepContext.context, fromEntities, toEntities);
+
+            // Initialize BookingDetails with any entities we may have found in the response.
+            bookingDetails.destination = toEntities.airport;
+            bookingDetails.origin = fromEntities.airport;
+            bookingDetails.travelDate = this.luisRecognizer.getTravelDate(luisResult);
+            console.log('LUIS extracted these booking details:', JSON.stringify(bookingDetails));
+
+            // Run the BookingDialog passing in whatever details we have from the LUIS call, it will fill out the remainder.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+
+        case 'GetWeather':
+            // We haven't implemented the GetWeatherDialog so we just display a TODO message.
+            const getWeatherMessageText = 'TODO: get weather flow here';
+            await stepContext.context.sendActivity(getWeatherMessageText, getWeatherMessageText, InputHints.IgnoringInput);
+            break;
+
+        default:
+            // Catch all for unhandled intents
+            const didntUnderstandMessageText = `Sorry, I didn't get that. Please try asking in a different way (intent was ${ LuisRecognizer.topIntent(luisResult) })`;
+            await stepContext.context.sendActivity(didntUnderstandMessageText, didntUnderstandMessageText, InputHints.IgnoringInput);
+        }
+
+        return await stepContext.next();
+    }
+
+    /**
+     * Shows a warning if the requested From or To cities are recognized as entities but they are not in the Airport entity list.
+     * In some cases LUIS will recognize the From and To composite entities as a valid cities but the From and To Airport values
+     * will be empty if those entity values can't be mapped to a canonical item in the Airport.
+     */
+    private async showWarningForUnsupportedCities(context, fromEntities, toEntities) {
+        const unsupportedCities = [];
+        if (fromEntities.from && !fromEntities.airport) {
+            unsupportedCities.push(fromEntities.from);
+        }
+
+        if (toEntities.to && !toEntities.airport) {
+            unsupportedCities.push(toEntities.to);
+        }
+
+        if (unsupportedCities.length) {
+            const messageText = `Sorry but the following airports are not supported: ${ unsupportedCities.join(', ') }`;
+            await context.sendActivity(messageText, messageText, InputHints.IgnoringInput);
+        }
+    }
+
+    /**
+     * This is the final step in the main waterfall dialog.
+     * It wraps up the sample "book a flight" interaction with a simple confirmation.
+     */
+    private async finalStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
+        // If the child dialog ("bookingDialog") was cancelled or the user failed to confirm, the Result here will be null.
+        if (stepContext.result) {
+            const result = stepContext.result as BookingDetails;
+            // Now we have all the booking details.
+
+            // This is where calls to the booking AOU service or database would go.
+
+            // If the call to the booking service was successful tell the user.
+            const timeProperty = new TimexProperty(result.travelDate);
+            const travelDateMsg = timeProperty.toNaturalLanguage(new Date(Date.now()));
+            const msg = `I have you booked to ${ result.destination } from ${ result.origin } on ${ travelDateMsg }.`;
+            await stepContext.context.sendActivity(msg);
+        }
+
+        // Restart the main dialog waterfall with a different message the second time around
+        return await stepContext.replaceDialog(this.initialDialogId, { restartMsg: 'What else can I do for you?' });
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.js
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// index.js is used to setup and configure your bot
+
+// Import required packages
+const path = require('path');
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
+const restify = require('restify');
+
+// Import required bot services.
+// See https://aka.ms/bot-services to learn more about the different parts of a bot.
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    InputHints,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
+
+const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer');
+
+// This bot's main dialog.
+const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
+const { MainDialog } = require('./dialogs/mainDialog');
+
+// the bot's booking dialog
+const { BookingDialog } = require('./dialogs/bookingDialog');
+const BOOKING_DIALOG = 'bookingDialog';
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+// Catch-all for errors.
+const onTurnErrorHandler = async (context, error) => {
+    // This check writes out errors to console log .vs. app insights.
+    // NOTE: In production environment, you should consider logging this to Azure
+    //       application insights.
+    console.error(`\n [onTurnError] unhandled error: ${ error }`);
+
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+        'OnTurnError Trace',
+        `${ error }`,
+        'https://www.botframework.com/schemas/error',
+        'TurnError'
+    );
+
+    // Send a message to the user
+    let onTurnErrorMessage = 'The bot encountered an error or bug.';
+    await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+    onTurnErrorMessage = 'To continue to run this bot, please fix the bot source code.';
+    await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+    // Clear out state
+    await conversationState.delete(context);
+};
+
+// Set the onTurnError for the singleton CloudAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
+// Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
+// A bot requires a state store to persist the dialog and user state between messages.
+
+// For local development, in-memory storage is used.
+// CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
+// is restarted, anything stored in memory will be gone.
+const memoryStorage = new MemoryStorage();
+const conversationState = new ConversationState(memoryStorage);
+const userState = new UserState(memoryStorage);
+
+// If configured, pass in the FlightBookingRecognizer.  (Defining it externally allows it to be mocked for tests)
+const { LuisAppId, LuisAPIKey, LuisAPIHostName } = process.env;
+const luisConfig = { applicationId: LuisAppId, endpointKey: LuisAPIKey, endpoint: `https://${ LuisAPIHostName }` };
+
+const luisRecognizer = new FlightBookingRecognizer(luisConfig);
+
+// Create the main dialog.
+const bookingDialog = new BookingDialog(BOOKING_DIALOG);
+const dialog = new MainDialog(luisRecognizer, bookingDialog);
+const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
+
+// Create HTTP server
+const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
+server.listen(process.env.port || process.env.PORT || 3978, function() {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
+    console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
+});
+
+// Listen for incoming activities and route them to your bot main dialog.
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', async (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    await streamingAdapter.process(req, socket, head, (context) => bot.run(context));
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.ts
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { config } from 'dotenv';
+import * as path from 'path';
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '..', '.env');
+config({ path: ENV_FILE });
+
+import * as restify from 'restify';
+
+import { INodeSocket } from 'botframework-streaming';
+
+// Import required bot services.
+// See https://aka.ms/bot-services to learn more about the different parts of a bot.
+import { 
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    MemoryStorage,
+    UserState
+} from 'botbuilder';
+import { LuisApplication } from 'botbuilder-ai';
+
+// The bot and its main dialog.
+import { DialogAndWelcomeBot } from './bots/dialogAndWelcomeBot';
+import { MainDialog } from './dialogs/mainDialog';
+
+// The bot's booking dialog
+import { BookingDialog } from './dialogs/bookingDialog';
+const BOOKING_DIALOG = 'bookingDialog';
+
+// The helper-class recognizer that calls LUIS
+import { FlightBookingRecognizer } from './dialogs/flightBookingRecognizer';
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+// Catch-all for errors.
+const onTurnErrorHandler = async (context, error) => {
+    // This check writes out errors to console log .vs. app insights.
+    // NOTE: In production environment, you should consider logging this to Azure
+    //       application insights.
+    console.error(`\n [onTurnError] unhandled error: ${ error }`);
+
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+        'OnTurnError Trace',
+        `${ error }`,
+        'https://www.botframework.com/schemas/error',
+        'TurnError'
+    );
+
+    // Send a message to the user
+    await context.sendActivity('The bot encountered an error or bug.');
+    await context.sendActivity('To continue to run this bot, please fix the bot source code.');
+    // Clear out state
+    await conversationState.delete(context);
+};
+
+// Set the onTurnError for the singleton CloudAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
+// Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
+// A bot requires a state store to persist the dialog and user state between messages.
+let conversationState: ConversationState;
+let userState: UserState;
+
+// For local development, in-memory storage is used.
+// CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
+// is restarted, anything stored in memory will be gone.
+const memoryStorage = new MemoryStorage();
+conversationState = new ConversationState(memoryStorage);
+userState = new UserState(memoryStorage);
+
+// If configured, pass in the FlightBookingRecognizer. (Defining it externally allows it to be mocked for tests)
+let luisRecognizer;
+const { LuisAppId, LuisAPIKey, LuisAPIHostName } = process.env;
+const luisConfig: LuisApplication = { applicationId: LuisAppId, endpointKey: LuisAPIKey, endpoint: `https://${ LuisAPIHostName }` };
+
+luisRecognizer = new FlightBookingRecognizer(luisConfig);
+
+// Create the main dialog.
+const bookingDialog = new BookingDialog(BOOKING_DIALOG);
+const dialog = new MainDialog(luisRecognizer, bookingDialog);
+const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
+
+// Create HTTP server
+const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
+server.listen(process.env.port || process.env.PORT || 3978, () => {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
+    console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
+});
+
+// Listen for incoming activities and route them to your bot main dialog.
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', async (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => bot.run(context));
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -1,0 +1,38 @@
+{
+    "name": "<%= botname %>",
+    "version": "1.0.0",
+    "description": "<%= botDescription %>",
+    "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
+    "license": "MIT",
+    "main": "<%= npmMain %>",
+    "scripts": {
+        "start": "node ./index.js",
+        "watch": "nodemon ./index.js",
+        "lint": "eslint .",
+        "test": "nyc mocha tests/**/*.test.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com"
+    },
+    "dependencies": {
+        "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-testing": "~4.15.0",
+        "dotenv": "^8.2.0",
+        "restify": "^8.5.1"
+    },
+    "devDependencies": {
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^4.0.1",
+        "mocha": "^7.1.2",
+        "nodemon": "^2.0.4",
+        "nyc": "^15.0.1"
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -1,0 +1,59 @@
+{
+    "name": "<%= botname %>",
+    "version": "1.0.0",
+    "description": "<%= botDescription %>",
+    "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
+    "license": "MIT",
+    "main": "<%= npmMain %>",
+    "scripts": {
+        "build": "tsc --build",
+        "lint": "tslint -c tslint.json 'src/**/*.ts'",
+        "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
+        "start": "tsc --build && node ./lib/index.js",
+        "test": "tsc --build && nyc mocha lib/tests/**/*.test.js",
+        "watch": "nodemon --watch ./src -e ts --exec \"npm run start\""
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com"
+    },
+    "nyc": {
+        "extension": [
+          ".ts",
+          ".tsx"
+        ],
+        "exclude": [
+          "**/.eslintrc.js",
+          "**/*.d.ts",
+          "**/*.test.*",
+          "**/tests",
+          "**/coverage",
+          "**/deploymentScripts",
+          "**/src/index.ts"
+        ],
+        "reporter": [
+          "text"
+        ],
+        "all": true
+    },
+    "dependencies": {
+      "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
+      "botbuilder": "~4.15.0",
+      "botbuilder-ai": "~4.15.0",
+      "botbuilder-dialogs": "~4.15.0",
+      "botbuilder-testing": "~4.15.0",
+      "dotenv": "^8.2.0",
+      "replace": "~1.2.0",
+      "restify": "~8.5.1"
+},
+  "devDependencies": {
+      "@types/mocha": "^7.0.2",
+      "@types/restify": "8.4.2",
+      "mocha": "^7.1.2",
+      "nodemon": "^2.0.4",
+      "nyc": "^15.0.1",
+      "ts-node": "^8.10.1",
+      "tslint": "^6.1.2",
+      "typescript": "^3.9.2"
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -1,0 +1,37 @@
+{
+    "name": "<%= botname %>",
+    "version": "1.0.0",
+    "description": "<%= botDescription %>",
+    "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
+    "license": "MIT",
+    "main": "<%= npmMain %>",
+    "scripts": {
+        "start": "node ./index.js",
+        "watch": "nodemon ./index.js",
+        "lint": "eslint .",
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com"
+    },
+    "dependencies": {
+        "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "dotenv": "~8.2.0",
+        "restify": "~8.5.1"
+    },
+    "devDependencies": {
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^4.0.1",
+        "mocha": "^7.1.2",
+        "nodemon": "^2.0.4",
+        "nyc": "^15.0.1"
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -1,0 +1,39 @@
+{
+    "name": "<%= botname %>",
+    "version": "1.0.0",
+    "description": "<%= botDescription %>",
+    "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
+    "license": "MIT",
+    "main": "<%= npmMain %>",
+    "scripts": {
+        "build": "tsc --build",
+        "lint": "tslint -c tslint.json 'src/**/*.ts'",
+        "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
+        "start": "tsc --build && node ./lib/index.js",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "watch": "nodemon --watch ./src -e ts --exec \"npm run start\""
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com"
+    },
+    "dependencies": {
+        "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "dotenv": "~8.2.0",
+        "replace": "~1.2.0",
+        "restify": "~8.5.1"
+    },
+    "devDependencies": {
+        "@types/mocha": "^7.0.2",
+        "@types/restify": "8.4.2",
+        "mocha": "^7.1.2",
+        "nodemon": "^2.0.4",
+        "nyc": "^15.0.1",
+        "ts-node": "^8.10.1",
+        "tslint": "^6.1.2",
+        "typescript": "^3.9.2"
+    }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/resources/welcomeCard.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/resources/welcomeCard.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.0",
+  "body": [
+    {
+      "type": "Image",
+      "url": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU",
+      "size": "stretch"
+    },
+    {
+      "type": "TextBlock",
+      "spacing": "medium",
+      "size": "default",
+      "weight": "bolder",
+      "text": "Welcome to Bot Framework!",
+      "wrap": true,
+      "maxLines": 0
+    },
+    {
+      "type": "TextBlock",
+      "size": "default",
+      "isSubtle": true,
+      "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
+      "wrap": true,
+      "maxLines": 0
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.OpenUrl",
+      "title": "Get an overview",
+      "url": "https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0"
+    },
+    {
+      "type": "Action.OpenUrl",
+      "title": "Ask a question",
+      "url": "https://stackoverflow.com/questions/tagged/botframework"
+    },
+    {
+      "type": "Action.OpenUrl",
+      "title": "Learn how to deploy",
+      "url": "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0"
+    }
+  ]
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "rootDirs": ["./src", "./resources"],
+    "sourceMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/.tsbuildinfo"
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tslint.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tslint.json
@@ -1,0 +1,18 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "interface-name" : [true, "never-prefix"],
+        "max-line-length": [false],
+        "no-console": [false, "log", "error"],
+        "no-var-requires": false,
+        "quotemark": [true, "single"],
+        "one-variable-per-declaration": false,
+        "curly": [true, "ignore-same-line"],
+        "trailing-comma": [true, {"multiline": "never", "singleline": "never"}]
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
Addresses # 3997

## Description
This PR adds the generator-botbuilder's **Core bot** from the [BotBuider-Samples](https://github.com/microsoft/BotBuilder-Samples/tree/main/generators/generator-botbuilder) repository.

### Detailed Changes
- Added **Core bot** templates for JS and TS versions.

## Testing
These images show the _generator-botbuilder_ working for the Core bot.
![image](https://user-images.githubusercontent.com/44245136/145427037-ef0e09e1-2e6a-473f-907b-c41e11a5195a.png)

