### PR TITLE
[#3997] Move Javascript generators from Samples to "generators" - Core Bot's tests

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/tests/README.md
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/README.md
@@ -1,0 +1,58 @@
+﻿
+# <%= botname %> tests
+
+Bot Framework v4 bot tests for `<%= botname %>` bot.
+
+This project uses the [botbuilder-testing](https://www.npmjs.com/package/botbuilder-testing) package and [mocha](https://github.com/mochajs/mocha) to create unit tests for your bot.
+
+This project shows how to:
+
+- Create unit tests for dialogs and bots
+- Create different types of data driven tests using mocha tests
+- Create mock objects for the different dependencies of a dialog (i.e. LUIS recognizers, other dialogs, configuration, etc.)
+- Assert the activities returned by a dialog turn against expected values
+- Assert the results returned by a dialog
+
+## Overview
+
+In this sample, dialogs are unit tested through the `DialogTestClient` class which provides a mechanism for testing them in isolation outside of a bot and without having to deploy your code to a web service.
+
+This class is used to write unit tests for dialogs that test their responses on a turn-by-turn basis. Any dialog built using the botbuilder dialogs library should work.
+
+Here is a simple example on how a test that uses `DialogTestClient` looks like:
+
+```javascript
+const sut = new BookingDialog();
+const testClient = new DialogTestClient('msteams', sut);
+
+let reply = await testClient.sendActivity('hi');
+assert.strictEqual(reply.text, 'Where would you like to travel to?');
+
+reply = await testClient.sendActivity('Seattle');
+assert.strictEqual(reply.text, 'Where are you traveling from?');
+
+reply = await testClient.sendActivity('New York');
+assert.strictEqual(reply.text, 'When would you like to travel?');
+
+reply = await testClient.sendActivity('tomorrow');
+assert.strictEqual(reply.text, 'OK, I will book a flight from Seattle to New York for tomorrow, Is this Correct?');
+
+reply = await testClient.sendActivity('yes');
+assert.strictEqual(reply.text, 'Sure thing, wait while I finalize your reservation...');
+
+reply = testClient.getNextReply();
+assert.strictEqual(reply.text, 'All set, I have booked your flight to Seattle for tomorrow');
+```
+
+The project includes several examples on how to test different bot components:
+
+- [cancelAndHelpDialog.test](dialogs/cancelAndHelpDialog.test.js) shows how to write a simple data driven test for `CancelAndHelpDialog` using a test case array.
+- [bookingDialog.test](dialogs/bookingDialog.test.js) shows how to write a data driven test using a `bookingDialogTestCases` module to generate the test cases.
+- [mainDialog.test](dialogs/mainDialog.test.js) showcases how to use mock objects to mock the dialog's LUIS and `BookingDialog` dependencies to test `MainDialog` in isolation.
+- [dialogAndWelcomeBot.test](bots/dialogAndWelcomeBot.test.js) provides an example on how to write a test for the bot's `ActivityHandler` using `TestAdapter`.
+
+## Further reading
+
+- [How to unit test bots](https://aka.ms/js-unit-test-docs)
+- [Mocha](https://github.com/mochajs/mocha)
+- [Bot Testing](https://github.com/microsoft/botframework-sdk/blob/master/specs/testing/testing.md)

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/bots/dialogAndWelcomeBot.test.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/bots/dialogAndWelcomeBot.test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-env node, mocha */
+const { TestAdapter, ActivityTypes, TurnContext, ConversationState, MemoryStorage, UserState } = require('botbuilder');
+const { DialogSet, DialogTurnStatus, Dialog } = require('botbuilder-dialogs');
+const { DialogAndWelcomeBot } = require('../../bots/dialogAndWelcomeBot');
+const assert = require('assert');
+
+/**
+ * A simple mock for a root dialog that gets invoked by the bot.
+ */
+class MockRootDialog extends Dialog {
+    constructor() {
+        super('mockRootDialog');
+    }
+
+    async beginDialog(dc, options) {
+        await dc.context.sendActivity(`${ this.id } mock invoked`);
+        return await dc.endDialog();
+    }
+
+    async run(turnContext, accessor) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(turnContext);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+}
+
+describe('DialogAndWelcomeBot', () => {
+    const testAdapter = new TestAdapter();
+
+    async function processActivity(activity, bot) {
+        const context = new TurnContext(testAdapter, activity);
+        await bot.run(context);
+    }
+
+    it('Shows welcome card on member added and starts main dialog', async () => {
+        const mockRootDialog = new MockRootDialog();
+        const memoryStorage = new MemoryStorage();
+        const sut = new DialogAndWelcomeBot(new ConversationState(memoryStorage), new UserState(memoryStorage), mockRootDialog, console);
+
+        // Create conversationUpdate activity
+        const conversationUpdateActivity = {
+            type: ActivityTypes.ConversationUpdate,
+            channelId: 'test',
+            conversation: {
+                id: 'someId'
+            },
+            membersAdded: [
+                { id: 'theUser' }
+            ],
+            recipient: { id: 'theBot' }
+        };
+
+        // Send the conversation update activity to the bot.
+        await processActivity(conversationUpdateActivity, sut);
+
+        // Assert we got the welcome card
+        let reply = testAdapter.activityBuffer.shift();
+        assert.strictEqual(reply.attachments.length, 1);
+        assert.strictEqual(reply.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+
+        // Assert that we started the main dialog.
+        reply = testAdapter.activityBuffer.shift();
+        assert.strictEqual(reply.text, 'mockRootDialog mock invoked');
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/bots/dialogAndWelcomeBot.test.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/bots/dialogAndWelcomeBot.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { ActivityTypes, ConversationState, MemoryStorage, TestAdapter, TurnContext, UserState } from 'botbuilder';
+import { Dialog, DialogSet, DialogTurnStatus } from 'botbuilder-dialogs';
+import { DialogAndWelcomeBot } from '../../bots/dialogAndWelcomeBot';
+const assert = require('assert');
+
+/**
+ * A simple mock for a root dialog that gets invoked by the bot.
+ */
+class MockRootDialog extends Dialog {
+    constructor() {
+        super('mockRootDialog');
+    }
+
+    public async beginDialog(dc, options) {
+        await dc.context.sendActivity(`${ this.id } mock invoked`);
+        return await dc.endDialog();
+    }
+
+    public async run(turnContext, accessor) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(turnContext);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+}
+
+describe('DialogAndWelcomeBot', () => {
+    const testAdapter = new TestAdapter(async (context) => undefined);
+
+    async function processActivity(activity, bot) {
+        const context = new TurnContext(testAdapter, activity);
+        await bot.run(context);
+    }
+
+    it('Shows welcome card on member added and starts main dialog', async () => {
+        const mockRootDialog = new MockRootDialog();
+        const memoryStorage = new MemoryStorage();
+        const sut = new DialogAndWelcomeBot(new ConversationState(memoryStorage), new UserState(memoryStorage), mockRootDialog);
+
+        // Create conversationUpdate activity
+        const conversationUpdateActivity = {
+            channelId: 'test',
+            conversation: {
+                id: 'someId'
+            },
+            membersAdded: [
+                { id: 'theUser' }
+            ],
+            recipient: { id: 'theBot' },
+            type: ActivityTypes.ConversationUpdate
+        };
+
+        // Send the conversation update activity to the bot.
+        await processActivity(conversationUpdateActivity, sut);
+
+        // Assert we got the welcome card
+        let reply = testAdapter.activityBuffer.shift();
+        assert.strictEqual(reply.attachments.length, 1);
+        assert.strictEqual(reply.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+
+        // Assert that we started the main dialog.
+        reply = testAdapter.activityBuffer.shift();
+        assert.strictEqual(reply.text, 'mockRootDialog mock invoked');
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/bookingDialog.test.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/bookingDialog.test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-env node, mocha */
+const { DialogTestClient, DialogTestLogger } = require('botbuilder-testing');
+const { BookingDialog } = require('../../dialogs/bookingDialog');
+const assert = require('assert');
+
+describe('BookingDialog', () => {
+    const testCases = require('./testData/bookingDialogTestCases.js');
+    const sut = new BookingDialog('bookingDialog');
+
+    testCases.map(testData => {
+        it(testData.name, async () => {
+            const client = new DialogTestClient('test', sut, testData.initialData, [new DialogTestLogger()]);
+
+            // Execute the test case
+            console.log(`Test Case: ${ testData.name }`);
+            console.log(`Dialog Input ${ JSON.stringify(testData.initialData) }`);
+            for (let i = 0; i < testData.steps.length; i++) {
+                const reply = await client.sendActivity(testData.steps[i][0]);
+                assert.strictEqual((reply ? reply.text : null), testData.steps[i][1], `${ reply ? reply.text : null } != ${ testData.steps[i][1] }`);
+            }
+
+            assert.strictEqual(client.dialogTurnResult.status, testData.expectedStatus, `${ testData.expectedStatus } != ${ client.dialogTurnResult.status }`);
+
+            console.log(`Dialog result: ${ JSON.stringify(client.dialogTurnResult.result) }`);
+            if (testData.expectedResult !== undefined) {
+                // Check dialog results
+                const result = client.dialogTurnResult.result;
+                assert.strictEqual(result.destination, testData.expectedResult.destination);
+                assert.strictEqual(result.origin, testData.expectedResult.origin);
+                assert.strictEqual(result.travelDate, testData.expectedResult.travelDate);
+            } else {
+                assert.strictEqual(client.dialogTurnResult.result, undefined);
+            }
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/bookingDialog.test.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/bookingDialog.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { DialogTestClient, DialogTestLogger } from 'botbuilder-testing';
+import { BookingDialog } from '../../dialogs/bookingDialog';
+const assert = require('assert');
+
+describe('BookingDialog', () => {
+    const testCases = require('./testData/bookingDialogTestCases');
+    const sut = new BookingDialog('bookingDialog');
+
+    testCases.map((testData) => {
+        it(testData.name, async () => {
+            const client = new DialogTestClient('test', sut, testData.initialData, [new DialogTestLogger()]);
+
+            // Execute the test case
+            console.log(`Test Case: ${ testData.name }`);
+            console.log(`Dialog Input ${ JSON.stringify(testData.initialData) }`);
+            for (const step of testData.steps) {
+                const reply = await client.sendActivity(step[0]);
+                assert.strictEqual((reply ? reply.text : null), step[1], `${ reply ? reply.text : null } != ${ step[1] }`);
+            }
+
+            assert.strictEqual(client.dialogTurnResult.status, testData.expectedStatus, `${ testData.expectedStatus } != ${ client.dialogTurnResult.status }`);
+
+            console.log(`Dialog result: ${ JSON.stringify(client.dialogTurnResult.result) }`);
+            if (testData.expectedResult !== undefined) {
+                // Check dialog results
+                const result = client.dialogTurnResult.result;
+                assert.strictEqual(result.destination, testData.expectedResult.destination);
+                assert.strictEqual(result.origin, testData.expectedResult.origin);
+                assert.strictEqual(result.travelDate, testData.expectedResult.travelDate);
+            } else {
+                assert.strictEqual(client.dialogTurnResult.result, undefined);
+            }
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/cancelAndHelpDialog.test.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/cancelAndHelpDialog.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-env node, mocha */
+const { MessageFactory } = require('botbuilder');
+const { DialogTestClient, DialogTestLogger } = require('botbuilder-testing');
+const { TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { CancelAndHelpDialog } = require('../../dialogs/cancelAndHelpDialog');
+const assert = require('assert');
+
+/**
+ * An waterfall dialog derived from CancelAndHelpDialog for testing
+ */
+class TestCancelAndHelpDialog extends CancelAndHelpDialog {
+    constructor() {
+        super('TestCancelAndHelpDialog');
+
+        this.addDialog(new TextPrompt('TextPrompt'))
+            .addDialog(new WaterfallDialog('WaterfallDialog', [
+                this.promptStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = 'WaterfallDialog';
+    }
+
+    async promptStep(stepContext) {
+        return await stepContext.prompt('TextPrompt', { prompt: MessageFactory.text('Hi there') });
+    }
+
+    async finalStep(stepContext) {
+        return await stepContext.endDialog();
+    }
+}
+
+describe('CancelAndHelpDialog', () => {
+    describe('Should be able to cancel', () => {
+        const testCases = ['cancel', 'quit'];
+
+        testCases.map(testData => {
+            it(testData, async () => {
+                const sut = new TestCancelAndHelpDialog();
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'Hi there');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+
+                reply = await client.sendActivity(testData);
+                assert.strictEqual(reply.text, 'Cancelling...');
+                assert.strictEqual(client.dialogTurnResult.status, 'complete');
+            });
+        });
+    });
+
+    describe('Should be able to get help', () => {
+        const testCases = ['help', '?'];
+
+        testCases.map(testData => {
+            it(testData, async () => {
+                const sut = new TestCancelAndHelpDialog();
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'Hi there');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+
+                reply = await client.sendActivity(testData);
+                assert.strictEqual(reply.text, 'Show help here');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+            });
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/cancelAndHelpDialog.test.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/cancelAndHelpDialog.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { MessageFactory } from 'botbuilder';
+import { TextPrompt, WaterfallDialog } from 'botbuilder-dialogs';
+import { DialogTestClient, DialogTestLogger } from 'botbuilder-testing';
+import { CancelAndHelpDialog } from '../../dialogs/cancelAndHelpDialog';
+const assert = require('assert');
+
+/**
+ * An waterfall dialog derived from CancelAndHelpDialog for testing
+ */
+class TestCancelAndHelpDialog extends CancelAndHelpDialog {
+    constructor() {
+        super('TestCancelAndHelpDialog');
+
+        this.addDialog(new TextPrompt('TextPrompt'))
+            .addDialog(new WaterfallDialog('WaterfallDialog', [
+                this.promptStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = 'WaterfallDialog';
+    }
+
+    public async promptStep(stepContext) {
+        return await stepContext.prompt('TextPrompt', { prompt: MessageFactory.text('Hi there') });
+    }
+
+    public async finalStep(stepContext) {
+        return await stepContext.endDialog();
+    }
+}
+
+describe('CancelAndHelpDialog', () => {
+    describe('Should be able to cancel', () => {
+        const testCases = ['cancel', 'quit'];
+
+        testCases.map((testData) => {
+            it(testData, async () => {
+                const sut = new TestCancelAndHelpDialog();
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'Hi there');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+
+                reply = await client.sendActivity(testData);
+                assert.strictEqual(reply.text, 'Cancelling...');
+                assert.strictEqual(client.dialogTurnResult.status, 'complete');
+            });
+        });
+    });
+
+    describe('Should be able to get help', () => {
+        const testCases = ['help', '?'];
+
+        testCases.map((testData) => {
+            it(testData, async () => {
+                const sut = new TestCancelAndHelpDialog();
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'Hi there');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+
+                reply = await client.sendActivity(testData);
+                assert.strictEqual(reply.text, 'Show help here');
+                assert.strictEqual(client.dialogTurnResult.status, 'waiting');
+            });
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/dateResolverDialog.test.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/dateResolverDialog.test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-env node, mocha */
+const { DialogTestClient, DialogTestLogger } = require('botbuilder-testing');
+const { DateResolverDialog } = require('../../dialogs/dateResolverDialog');
+const assert = require('assert');
+
+describe('DateResolverDialog', () => {
+    const testCases = require('./testData/dateResolverTestCases.js');
+    const sut = new DateResolverDialog('dateResolver');
+
+    testCases.map(testData => {
+        it(testData.name, async () => {
+            const client = new DialogTestClient('test', sut, testData.initialData, [new DialogTestLogger()]);
+
+            // Execute the test case
+            console.log(`Test Case: ${ testData.name }`);
+            console.log(`Dialog Input ${ JSON.stringify(testData.initialData) }`);
+            for (let i = 0; i < testData.steps.length; i++) {
+                const reply = await client.sendActivity(testData.steps[i][0]);
+                assert.strictEqual((reply ? reply.text : null), testData.steps[i][1], `${ reply ? reply.text : null } != ${ testData.steps[i][1] }`);
+            }
+            console.log(`Dialog result: ${ client.dialogTurnResult.result }`);
+            assert.strictEqual(client.dialogTurnResult.result, testData.expectedResult, `${ testData.expectedResult } != ${ client.dialogTurnResult.result }`);
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/dateResolverDialog.test.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/dateResolverDialog.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { DialogTestClient, DialogTestLogger } from 'botbuilder-testing';
+import { DateResolverDialog } from '../../dialogs/dateResolverDialog';
+const assert = require('assert');
+
+describe('DateResolverDialog', () => {
+    const testCases = require('./testData/dateResolverTestCases');
+    const sut = new DateResolverDialog('dateResolver');
+
+    testCases.map((testData) => {
+        it(testData.name, async () => {
+            const client = new DialogTestClient('test', sut, testData.initialData, [new DialogTestLogger()]);
+
+            // Execute the test case
+            console.log(`Test Case: ${ testData.name }`);
+            console.log(`Dialog Input ${ JSON.stringify(testData.initialData) }`);
+            for (const step of testData.steps) {
+                const reply = await client.sendActivity(step[0]);
+                assert.strictEqual((reply ? reply.text : null), step[1], `${ reply ? reply.text : null } != ${ step[1] }`);
+            }
+            console.log(`Dialog result: ${ client.dialogTurnResult.result }`);
+            assert.strictEqual(client.dialogTurnResult.result, testData.expectedResult, `${ testData.expectedResult } != ${ client.dialogTurnResult.result }`);
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/mainDialog.test.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/mainDialog.test.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-env node, mocha */
+const { TextPrompt } = require('botbuilder-dialogs');
+const { DialogTestClient, DialogTestLogger } = require('botbuilder-testing');
+const { FlightBookingRecognizer } = require('../../dialogs/flightBookingRecognizer');
+const { MainDialog } = require('../../dialogs/mainDialog');
+const { BookingDialog } = require('../../dialogs/bookingDialog');
+const assert = require('assert');
+
+/**
+ * A mock FlightBookingRecognizer for our main dialog tests that takes
+ * a mock luis result and can set as isConfigured === false.
+ */
+class MockFlightBookingRecognizer extends FlightBookingRecognizer {
+    constructor(isConfigured, mockResult) {
+        super(isConfigured);
+        this.isLuisConfigured = isConfigured;
+        this.mockResult = mockResult;
+    }
+
+    async executeLuisQuery(context) {
+        return this.mockResult;
+    }
+
+    get isConfigured() {
+        return (this.isLuisConfigured);
+    }
+}
+
+/**
+ * A simple mock for Booking dialog that just returns a preset booking info for tests.
+ */
+class MockBookingDialog extends BookingDialog {
+    constructor() {
+        super('bookingDialog');
+    }
+
+    async beginDialog(dc, options) {
+        const bookingDetails = {
+            origin: 'New York',
+            destination: 'Seattle',
+            travelDate: '2025-07-08'
+        };
+        await dc.context.sendActivity(`${ this.id } mock invoked`);
+        return await dc.endDialog(bookingDetails);
+    }
+}
+
+/**
+* A specialized mock for BookingDialog that displays a dummy TextPrompt.
+* The dummy prompt is used to prevent the MainDialog waterfall from moving to the next step
+* and assert that the main dialog was called.
+*/
+class MockBookingDialogWithPrompt extends BookingDialog {
+    constructor() {
+        super('bookingDialog');
+    }
+
+    async beginDialog(dc, options) {
+        dc.dialogs.add(new TextPrompt('MockDialog'));
+        return await dc.prompt('MockDialog', { prompt: `${ this.id } mock invoked` });
+    }
+};
+
+describe('MainDialog', () => {
+    it('Shows message if LUIS is not configured and calls BookingDialogDirectly', async () => {
+        const mockRecognizer = new MockFlightBookingRecognizer(false);
+        const mockBookingDialog = new MockBookingDialogWithPrompt();
+        const sut = new MainDialog(mockRecognizer, mockBookingDialog);
+        const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+        const reply = await client.sendActivity('hi');
+        assert.strictEqual(reply.text, 'NOTE: LUIS is not configured. To enable all capabilities, add `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName` to the .env file.', 'Did not warn about missing luis');
+    });
+
+    it('Shows prompt if LUIS is configured', async () => {
+        const mockRecognizer = new MockFlightBookingRecognizer(true);
+        const mockBookingDialog = new MockBookingDialog();
+        const sut = new MainDialog(mockRecognizer, mockBookingDialog);
+        const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+        const reply = await client.sendActivity('hi');
+        assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"', 'Did not show prompt');
+    });
+
+    describe('Invokes tasks based on LUIS intent', () => {
+        // Create array with test case data.
+        const testCases = [
+            { utterance: 'I want to book a flight', intent: 'BookFlight', invokedDialogResponse: 'bookingDialog mock invoked', taskConfirmationMessage: 'I have you booked to Seattle from New York' },
+            { utterance: 'What\'s the weather like?', intent: 'GetWeather', invokedDialogResponse: 'TODO: get weather flow here', taskConfirmationMessage: undefined },
+            { utterance: 'bananas', intent: 'None', invokedDialogResponse: 'Sorry, I didn\'t get that. Please try asking in a different way (intent was None)', taskConfirmationMessage: undefined }
+        ];
+
+        testCases.map(testData => {
+            it(testData.intent, async () => {
+                // Create LuisResult for the mock recognizer.
+                const mockLuisResult = JSON.parse(`{"intents": {"${ testData.intent }": {"score": 1}}, "entities": {"$instance": {}}}`);
+                const mockRecognizer = new MockFlightBookingRecognizer(true, mockLuisResult);
+                const bookingDialog = new MockBookingDialog();
+                const sut = new MainDialog(mockRecognizer, bookingDialog);
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                console.log(`Test Case: ${ testData.intent }`);
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"');
+
+                reply = await client.sendActivity(testData.utterance);
+                assert.strictEqual(reply.text, testData.invokedDialogResponse);
+
+                // The Booking dialog displays an additional confirmation message, assert that it is what we expect.
+                if (testData.taskConfirmationMessage) {
+                    reply = client.getNextReply();
+                    assert(reply.text.startsWith(testData.taskConfirmationMessage));
+                }
+
+                // Validate that the MainDialog starts over once the task is completed.
+                reply = client.getNextReply();
+                assert.strictEqual(reply.text, 'What else can I do for you?');
+            });
+        });
+    });
+
+    describe('Shows unsupported cities warning', () => {
+        // Create array with test case data.
+        const testCases = [
+            { jsonFile: 'FlightToMadrid.json', expectedMessage: 'Sorry but the following airports are not supported: madrid' },
+            { jsonFile: 'FlightFromMadridToChicago.json', expectedMessage: 'Sorry but the following airports are not supported: madrid, chicago' },
+            { jsonFile: 'FlightFromCdgToJfk.json', expectedMessage: 'Sorry but the following airports are not supported: cdg' },
+            { jsonFile: 'FlightFromParisToNewYork.json', expectedMessage: 'bookingDialog mock invoked' }
+        ];
+
+        testCases.map(testData => {
+            it(testData.jsonFile, async () => {
+                // Create LuisResult for the mock recognizer.
+                const mockLuisResult = require(`./testData/${ testData.jsonFile }`);
+                const mockRecognizer = new MockFlightBookingRecognizer(true, mockLuisResult);
+                const bookingDialog = new MockBookingDialog();
+                const sut = new MainDialog(mockRecognizer, bookingDialog);
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                console.log(`Test Case: ${ mockLuisResult.text }`);
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"');
+
+                reply = await client.sendActivity(mockLuisResult.text);
+                assert.strictEqual(reply.text, testData.expectedMessage);
+            });
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/mainDialog.test.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/mainDialog.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { TextPrompt } from 'botbuilder-dialogs';
+import { DialogTestClient, DialogTestLogger } from 'botbuilder-testing';
+import { BookingDialog } from '../../dialogs/bookingDialog';
+import { FlightBookingRecognizer } from '../../dialogs/flightBookingRecognizer';
+import { MainDialog } from '../../dialogs/mainDialog';
+const assert = require('assert');
+
+// tslint:disable max-classes-per-file
+/**
+ * A mock FlightBookingRecognizer for our main dialog tests that takes
+ * a mock luis result and can set as isConfigured === false.
+ */
+class MockFlightBookingRecognizer extends FlightBookingRecognizer {
+    private isLuisConfigured: boolean;
+    constructor(isConfigured, private mockResult?: any) {
+        super(isConfigured);
+        this.isLuisConfigured = isConfigured;
+        this.mockResult = mockResult;
+    }
+
+    public async executeLuisQuery(context) {
+        return this.mockResult;
+    }
+
+    get isConfigured() {
+        return (this.isLuisConfigured);
+    }
+}
+
+/**
+ * A simple mock for Booking dialog that just returns a preset booking info for tests.
+ */
+class MockBookingDialog extends BookingDialog {
+    constructor() {
+        super('bookingDialog');
+    }
+
+    public async beginDialog(dc, options) {
+        const bookingDetails = {
+            destination: 'Seattle',
+            origin: 'New York',
+            travelDate: '2025-07-08'
+        };
+        await dc.context.sendActivity(`${ this.id } mock invoked`);
+        return await dc.endDialog(bookingDetails);
+    }
+}
+
+/**
+ * A specialized mock for BookingDialog that displays a dummy TextPrompt.
+ * The dummy prompt is used to prevent the MainDialog waterfall from moving to the next step
+ * and assert that the main dialog was called.
+ */
+class MockBookingDialogWithPrompt extends BookingDialog {
+    constructor() {
+        super('bookingDialog');
+    }
+
+    public async beginDialog(dc, options) {
+        dc.dialogs.add(new TextPrompt('MockDialog'));
+        return await dc.prompt('MockDialog', { prompt: `${ this.id } mock invoked` });
+    }
+}
+
+describe('MainDialog', () => {
+    it('Shows message if LUIS is not configured and calls BookingDialogDirectly', async () => {
+        const mockRecognizer = new MockFlightBookingRecognizer(false);
+        const mockBookingDialog = new MockBookingDialogWithPrompt();
+        const sut = new MainDialog(mockRecognizer, mockBookingDialog);
+        const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+        const reply = await client.sendActivity('hi');
+        assert.strictEqual(reply.text, 'NOTE: LUIS is not configured. To enable all capabilities, add `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName` to the .env file.', 'Did not warn about missing luis');
+    });
+
+    it('Shows prompt if LUIS is configured', async () => {
+        const mockRecognizer = new MockFlightBookingRecognizer(true);
+        const mockBookingDialog = new MockBookingDialog();
+        const sut = new MainDialog(mockRecognizer, mockBookingDialog);
+        const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+        const reply = await client.sendActivity('hi');
+        assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"', 'Did not show prompt');
+    });
+
+    describe('Invokes tasks based on LUIS intent', () => {
+        // Create array with test case data.
+        const testCases = [
+            { utterance: 'I want to book a flight', intent: 'BookFlight', invokedDialogResponse: 'bookingDialog mock invoked', taskConfirmationMessage: 'I have you booked to Seattle from New York' },
+            { utterance: `What's the weather like?`, intent: 'GetWeather', invokedDialogResponse: 'TODO: get weather flow here', taskConfirmationMessage: undefined },
+            { utterance: 'bananas', intent: 'None', invokedDialogResponse: `Sorry, I didn't get that. Please try asking in a different way (intent was None)`, taskConfirmationMessage: undefined }
+        ];
+
+        testCases.map((testData) => {
+            it(testData.intent, async () => {
+                // Create LuisResult for the mock recognizer.
+                const mockLuisResult = JSON.parse(`{"intents": {"${ testData.intent }": {"score": 1}}, "entities": {"$instance": {}}}`);
+                const mockRecognizer = new MockFlightBookingRecognizer(true, mockLuisResult);
+                const bookingDialog = new MockBookingDialog();
+                const sut = new MainDialog(mockRecognizer, bookingDialog);
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                console.log(`Test Case: ${ testData.intent }`);
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"');
+
+                reply = await client.sendActivity(testData.utterance);
+                assert.strictEqual(reply.text, testData.invokedDialogResponse);
+
+                // The Booking dialog displays an additional confirmation message, assert that it is what we expect.
+                if (testData.taskConfirmationMessage) {
+                    reply = client.getNextReply();
+                    assert(reply.text.startsWith(testData.taskConfirmationMessage));
+                }
+
+                // Validate that the MainDialog starts over once the task is completed.
+                reply = client.getNextReply();
+                assert.strictEqual(reply.text, 'What else can I do for you?');
+            });
+        });
+    });
+
+    describe('Shows unsupported cities warning', () => {
+        // Create array with test case data.
+        const testCases = [
+            { jsonFile: 'FlightToMadrid.json', expectedMessage: 'Sorry but the following airports are not supported: madrid' },
+            { jsonFile: 'FlightFromMadridToChicago.json', expectedMessage: 'Sorry but the following airports are not supported: madrid, chicago' },
+            { jsonFile: 'FlightFromCdgToJfk.json', expectedMessage: 'Sorry but the following airports are not supported: cdg' },
+            { jsonFile: 'FlightFromParisToNewYork.json', expectedMessage: 'bookingDialog mock invoked' }
+        ];
+
+        testCases.map((testData) => {
+            it(testData.jsonFile, async () => {
+                // Create LuisResult for the mock recognizer.
+                const mockLuisResult = require(`../../../testResources/${ testData.jsonFile }`);
+                const mockRecognizer = new MockFlightBookingRecognizer(true, mockLuisResult);
+                const bookingDialog = new MockBookingDialog();
+                const sut = new MainDialog(mockRecognizer, bookingDialog);
+                const client = new DialogTestClient('test', sut, null, [new DialogTestLogger()]);
+
+                // Execute the test case
+                console.log(`Test Case: ${ mockLuisResult.text }`);
+                let reply = await client.sendActivity('Hi');
+                assert.strictEqual(reply.text, 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"');
+
+                reply = await client.sendActivity(mockLuisResult.text);
+                assert.strictEqual(reply.text, testData.expectedMessage);
+            });
+        });
+    });
+});

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromCdgToJfk.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromCdgToJfk.json
@@ -1,0 +1,103 @@
+{
+  "text": "flight from cdg to jfk",
+  "intents": {
+    "BookFlight": {
+      "score": 0.712058365
+    }
+  },
+  "entities": {
+    "$instance": {
+      "From": [
+        {
+          "startIndex": 12,
+          "endIndex": 15,
+          "score": 0.9553623,
+          "text": "cdg",
+          "type": "From"
+        }
+      ],
+      "To": [
+        {
+          "startIndex": 19,
+          "endIndex": 22,
+          "score": 0.8905674,
+          "text": "jfk",
+          "type": "To"
+        }
+      ]
+    },
+    "From": [ { "$instance": {} } ],
+
+    "To": [
+      {
+        "$instance": {
+          "Airport": [
+            {
+              "startIndex": 19,
+              "endIndex": 22,
+              "text": "jfk",
+              "type": "Airport"
+            }
+          ]
+        },
+        "Airport": [
+          [
+            "New York"
+          ]
+        ]
+      }
+    ]
+  },
+  "luisResult": {
+    "query": "flight from cdg to jfk",
+    "topScoringIntent": {
+      "intent": "BookFlight",
+      "score": 0.712058365
+    },
+    "entities": [
+      {
+        "entity": "cdg",
+        "type": "From",
+        "startIndex": 12,
+        "endIndex": 14,
+        "score": 0.9553623
+      },
+      {
+        "entity": "jfk",
+        "type": "To",
+        "startIndex": 19,
+        "endIndex": 21,
+        "score": 0.8905674
+      },
+      {
+        "entity": "jfk",
+        "type": "Airport",
+        "startIndex": 19,
+        "endIndex": 21,
+        "resolution": {
+          "values": [
+            "New York"
+          ]
+        }
+      }
+    ],
+    "compositeEntities": [
+      {
+        "parentType": "From",
+        "value": "cdg",
+        "children": []
+
+      },
+      {
+        "parentType": "To",
+        "value": "jfk",
+        "children": [
+          {
+            "type": "Airport",
+            "value": "jfk"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromMadridToChicago.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromMadridToChicago.json
@@ -1,0 +1,63 @@
+{
+  "text": "flight from madrid to chicago",
+  "intents": { "BookFlight": { "score": 0.8837919 } },
+  "entities": {
+    "$instance": {
+      "From": [
+        {
+          "startIndex": 12,
+          "endIndex": 18,
+          "score": 0.888236344,
+          "text": "madrid",
+          "type": "From"
+        }
+      ],
+      "To": [
+        {
+          "startIndex": 22,
+          "endIndex": 29,
+          "score": 0.640484631,
+          "text": "chicago",
+          "type": "To"
+        }
+      ]
+    },
+    "From": [ { "$instance": {} } ],
+    "To": [ { "$instance": {} } ]
+  },
+  "luisResult": {
+    "query": "flight from madrid to chicago",
+    "topScoringIntent": {
+      "intent": "BookFlight",
+      "score": 0.8837919
+    },
+    "entities": [
+      {
+        "entity": "madrid",
+        "type": "From",
+        "startIndex": 12,
+        "endIndex": 17,
+        "score": 0.888236344
+      },
+      {
+        "entity": "chicago",
+        "type": "To",
+        "startIndex": 22,
+        "endIndex": 28,
+        "score": 0.640484631
+      }
+    ],
+    "compositeEntities": [
+      {
+        "parentType": "From",
+        "value": "madrid",
+        "children": []
+      },
+      {
+        "parentType": "To",
+        "value": "chicago",
+        "children": []
+      }
+    ]
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromParisToNewYork.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightFromParisToNewYork.json
@@ -1,0 +1,115 @@
+{
+  "text": "flight from paris to new york",
+  "intents": { "BookFlight": { "score": 0.9953049 } },
+  "entities": {
+    "$instance": {
+      "From": [
+        {
+          "startIndex": 12,
+          "endIndex": 17,
+          "score": 0.94712317,
+          "text": "paris",
+          "type": "From"
+        }
+      ],
+      "To": [
+        {
+          "startIndex": 21,
+          "endIndex": 29,
+          "score": 0.8602996,
+          "text": "new york",
+          "type": "To"
+        }
+      ]
+    },
+    "From": [
+      {
+        "$instance": {
+          "Airport": [
+            {
+              "startIndex": 12,
+              "endIndex": 17,
+              "text": "paris",
+              "type": "Airport"
+            }
+          ]
+        },
+        "Airport": [ [ "Paris" ] ]
+      }
+    ],
+    "To": [
+      {
+        "$instance": {
+          "Airport": [
+            {
+              "startIndex": 21,
+              "endIndex": 29,
+              "text": "new york",
+              "type": "Airport"
+            }
+          ]
+        },
+        "Airport": [ [ "New York" ] ]
+      }
+    ]
+  },
+  "luisResult": {
+    "query": "flight from paris to new york",
+    "topScoringIntent": {
+      "intent": "BookFlight",
+      "score": 0.9953049
+    },
+    "entities": [
+      {
+        "entity": "paris",
+        "type": "From",
+        "startIndex": 12,
+        "endIndex": 16,
+        "score": 0.94712317
+      },
+      {
+        "entity": "new york",
+        "type": "To",
+        "startIndex": 21,
+        "endIndex": 28,
+        "score": 0.8602996
+      },
+      {
+        "entity": "paris",
+        "type": "Airport",
+        "startIndex": 12,
+        "endIndex": 16,
+        "resolution": { "values": [ "Paris" ] }
+      },
+      {
+        "entity": "new york",
+        "type": "Airport",
+        "startIndex": 21,
+        "endIndex": 28,
+        "resolution": { "values": [ "New York" ] }
+      }
+    ],
+    "compositeEntities": [
+      {
+        "parentType": "From",
+        "value": "paris",
+        "children": [
+          {
+            "type": "Airport",
+            "value": "paris"
+          }
+        ]
+      },
+      {
+        "parentType": "To",
+        "value": "new york",
+        "children": [
+          {
+            "type": "Airport",
+            "value": "new york"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightToMadrid.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/FlightToMadrid.json
@@ -1,0 +1,41 @@
+{
+  "text": "flight to madrid",
+  "intents": { "BookFlight": { "score": 0.8476145 } },
+  "entities": {
+    "$instance": {
+      "To": [
+        {
+          "startIndex": 10,
+          "endIndex": 16,
+          "score": 0.7892059,
+          "text": "madrid",
+          "type": "To"
+        }
+      ]
+    },
+    "To": [ { "$instance": {} } ]
+  },
+  "luisResult": {
+    "query": "flight to madrid",
+    "topScoringIntent": {
+      "intent": "BookFlight",
+      "score": 0.8476145
+    },
+    "entities": [
+      {
+        "entity": "madrid",
+        "type": "To",
+        "startIndex": 10,
+        "endIndex": 15,
+        "score": 0.7892059
+      }
+    ],
+    "compositeEntities": [
+      {
+        "parentType": "To",
+        "value": "madrid",
+        "children": []
+      }
+    ]
+  }
+}

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/bookingDialogTestCases.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/bookingDialogTestCases.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const now = new Date();
+const today = formatDate(new Date());
+const tomorrow = formatDate(new Date().setDate(now.getDate() + 1));
+
+function formatDate(date) {
+    const d = new Date(date);
+    let month = '' + (d.getMonth() + 1);
+    let day = '' + d.getDate();
+    const year = d.getFullYear();
+
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+
+    return [year, month, day].join('-');
+}
+
+module.exports = [
+    {
+        name: 'Full flow',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ],
+        expectedStatus: 'complete',
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'New York',
+            travelDate: tomorrow
+        }
+    },
+    {
+        name: 'Full flow with \'no\' at confirmation',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['no', null]
+        ],
+        expectedStatus: 'complete',
+        expectedResult: undefined
+    },
+    {
+        name: 'Destination given',
+        initialData: {
+            destination: 'Bahamas'
+        },
+        steps: [
+            ['hi', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Bahamas from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ],
+        expectedStatus: 'complete',
+        expectedResult: {
+            origin: 'New York',
+            destination: 'Bahamas',
+            travelDate: tomorrow
+        }
+    },
+    {
+        name: 'Destination and origin given',
+        initialData: {
+            destination: 'Seattle',
+            origin: 'New York'
+        },
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ],
+        expectedStatus: 'complete',
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'New York',
+            travelDate: tomorrow
+        }
+    },
+    {
+        name: 'All booking details given for today',
+        initialData: {
+            destination: 'Seattle',
+            origin: 'Bahamas',
+            travelDate: today
+        },
+        steps: [
+            ['hi', `Please confirm, I have you traveling to: Seattle from: Bahamas on: ${ today }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ],
+        expectedStatus: 'complete',
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'Bahamas',
+            travelDate: today
+        }
+    },
+    {
+        name: 'Cancel on origin prompt',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['cancel', 'Cancelling...']
+        ],
+        expectedStatus: 'complete',
+        expectedResult: undefined
+    },
+    {
+        name: 'Cancel on destination prompt',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['cancel', 'Cancelling...']
+        ],
+        expectedStatus: 'complete',
+        expectedResult: undefined
+    },
+    {
+        name: 'Cancel on date prompt',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['cancel', 'Cancelling...']
+        ],
+        expectedStatus: 'complete',
+        expectedResult: undefined
+    },
+    {
+        name: 'Cancel on confirm prompt',
+        initialData: {},
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['cancel', 'Cancelling...']
+        ],
+        expectedStatus: 'complete',
+        expectedResult: undefined
+    }
+];

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/bookingDialogTestCases.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/bookingDialogTestCases.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const bookingDialogNow = new Date();
+const bookingDialogToday = formatBookingDialogDate(new Date());
+const bookingDialogTomorrow = formatBookingDialogDate(new Date().setDate(bookingDialogNow.getDate() + 1));
+
+function formatBookingDialogDate(date) {
+    const d = new Date(date);
+    let month = '' + (d.getMonth() + 1);
+    let day = '' + d.getDate();
+    const year = d.getFullYear();
+
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+
+    return [year, month, day].join('-');
+}
+
+module.exports = [
+    {
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'New York',
+            travelDate: bookingDialogTomorrow
+        },
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Full flow',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ bookingDialogTomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ]
+    },
+    {
+        expectedResult: undefined,
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Full flow with \'no\' at confirmation',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ bookingDialogTomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['no', null]
+        ]
+    },
+    {
+        expectedResult: {
+            destination: 'Bahamas',
+            origin: 'New York',
+            travelDate: bookingDialogTomorrow
+        },
+        expectedStatus: 'complete',
+        initialData: {
+            destination: 'Bahamas'
+        },
+        name: 'Destination given',
+        steps: [
+            ['hi', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Bahamas from: New York on: ${ bookingDialogTomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ]
+    },
+    {
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'New York',
+            travelDate: bookingDialogTomorrow
+        },
+        expectedStatus: 'complete',
+        initialData: {
+            destination: 'Seattle',
+            origin: 'New York'
+        },
+        name: 'Destination and origin given',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ bookingDialogTomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ]
+    },
+    {
+        expectedResult: {
+            destination: 'Seattle',
+            origin: 'Bahamas',
+            travelDate:  bookingDialogToday
+        },
+        expectedStatus: 'complete',
+        initialData: {
+            destination: 'Seattle',
+            origin: 'Bahamas',
+            travelDate:  bookingDialogToday
+        },
+        name: 'All booking details given for today',
+        steps: [
+            ['hi', `Please confirm, I have you traveling to: Seattle from: Bahamas on: ${  bookingDialogToday }. Is this correct? (1) Yes or (2) No`],
+            ['yes', null]
+        ]
+    },
+    {
+        expectedResult: undefined,
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Cancel on origin prompt',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['cancel', 'Cancelling...']
+        ]
+    },
+    {
+        expectedResult: undefined,
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Cancel on destination prompt',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['cancel', 'Cancelling...']
+        ]
+    },
+    {
+        expectedResult: undefined,
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Cancel on date prompt',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['cancel', 'Cancelling...']
+        ]
+    },
+    {
+        expectedResult: undefined,
+        expectedStatus: 'complete',
+        initialData: {},
+        name: 'Cancel on confirm prompt',
+        steps: [
+            ['hi', 'To what city would you like to travel?'],
+            ['Seattle', 'From what city will you be travelling?'],
+            ['New York', 'On what date would you like to travel?'],
+            ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ bookingDialogTomorrow }. Is this correct? (1) Yes or (2) No`],
+            ['cancel', 'Cancelling...']
+        ]
+    }
+];

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/dateResolverTestCases.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/dateResolverTestCases.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const now = new Date();
+const tomorrow = formatDate(new Date().setDate(now.getDate() + 1));
+const dayAfterTomorrow = formatDate(new Date().setDate(now.getDate() + 2));
+
+function formatDate(date) {
+    const d = new Date(date);
+    let month = '' + (d.getMonth() + 1);
+    let day = '' + d.getDate();
+    const year = d.getFullYear();
+
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+
+    return [year, month, day].join('-');
+}
+
+module.exports = [
+    {
+        name: 'tomorrow',
+        initialData: null,
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['tomorrow', null]
+        ],
+        expectedResult: tomorrow
+    },
+    {
+        name: 'the day after tomorrow',
+        initialData: null,
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['the day after tomorrow', null]
+        ],
+        expectedResult: dayAfterTomorrow
+    },
+    {
+        name: 'two days from now',
+        initialData: null,
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['two days from now', null]
+        ],
+        expectedResult: dayAfterTomorrow
+    },
+    {
+        name: 'valid input given (tomorrow)',
+        initialData: { date: tomorrow },
+        steps: [
+            ['hi', null]
+        ],
+        expectedResult: tomorrow
+    },
+    {
+        name: 'retry prompt',
+        initialData: {},
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['bananas', 'I\'m sorry, for best results, please enter your travel date including the month, day and year.'],
+            ['tomorrow', null]
+        ],
+        expectedResult: tomorrow
+    },
+    {
+        name: 'fuzzy time',
+        initialData: {},
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['may 5th', 'I\'m sorry, for best results, please enter your travel date including the month, day and year.'],
+            ['may 5th 2055', null]
+        ],
+        expectedResult: '2055-05-05'
+    }
+];

--- a/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/dateResolverTestCases.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/tests/dialogs/testData/dateResolverTestCases.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const now = new Date();
+const tomorrow = formatDate(new Date().setDate(now.getDate() + 1));
+const dayAfterTomorrow = formatDate(new Date().setDate(now.getDate() + 2));
+
+function formatDate(date) {
+    const d = new Date(date);
+    let month = '' + (d.getMonth() + 1);
+    let day = '' + d.getDate();
+    const year = d.getFullYear();
+
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+
+    return [year, month, day].join('-');
+}
+
+module.exports = [
+    {
+        expectedResult: tomorrow,
+        initialData: null,
+        name: 'tomorrow',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['tomorrow', null]
+        ]
+    },
+    {
+        expectedResult: dayAfterTomorrow,
+        initialData: null,
+        name: 'the day after tomorrow',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['the day after tomorrow', null]
+        ]
+    },
+    {
+        expectedResult: dayAfterTomorrow,
+        initialData: null,
+        name: 'two days from now',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['two days from now', null]
+        ]
+    },
+    {
+        expectedResult: tomorrow,
+        initialData: { date: tomorrow },
+        name: 'valid input given (tomorrow)',
+        steps: [
+            ['hi', null]
+        ]
+    },
+    {
+        expectedResult: tomorrow,
+        initialData: {},
+        name: 'retry prompt',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['bananas', 'I\'m sorry, for best results, please enter your travel date including the month, day and year.'],
+            ['tomorrow', null]
+        ]
+    },
+    {
+        expectedResult: '2055-05-05',
+        initialData: {},
+        name: 'fuzzy time',
+        steps: [
+            ['hi', 'On what date would you like to travel?'],
+            ['may 5th', 'I\'m sorry, for best results, please enter your travel date including the month, day and year.'],
+            ['may 5th 2055', null]
+        ]
+    }
+];


### PR DESCRIPTION
Addresses # 3997

## Description
This PR adds the **tests** for the generator-botbuilder's **Core bot** from the [BotBuider-Samples](https://github.com/microsoft/BotBuilder-Samples/tree/main/generators/generator-botbuilder) repository.

### Detailed Changes
- Added **Core bot tests** templates for JS and TS versions.

## Testing
These images show the tests running successfully.
![image](https://user-images.githubusercontent.com/44245136/145430602-66deaf6e-6105-4cd3-9e10-edcb3492b6fd.png)