### PR TITLE
fix: [#4007] Bot framework V4. Unable to use ⭐ emoji in suggested actions

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
+++ b/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
@@ -121,17 +121,19 @@ export function defaultTokenizer(text: string, locale?: string): Token[] {
 
 /**
  * @private
+ * Exclude unicode ranges containing punctuation characters and symbols.
  * @param codePoint number of character
  */
 function isBreakingChar(codePoint: number): boolean {
     return (
-        isBetween(codePoint, 0x0000, 0x002f) ||
-        isBetween(codePoint, 0x003a, 0x0040) ||
-        isBetween(codePoint, 0x005b, 0x0060) ||
-        isBetween(codePoint, 0x007b, 0x00bf) ||
-        isBetween(codePoint, 0x02b9, 0x036f) ||
-        isBetween(codePoint, 0x2000, 0x2bff) ||
-        isBetween(codePoint, 0x2e00, 0x2e7f)
+        (isBetween(codePoint, 0x0000, 0x002f) ||
+            isBetween(codePoint, 0x003a, 0x0040) ||
+            isBetween(codePoint, 0x005b, 0x0060) ||
+            isBetween(codePoint, 0x007b, 0x00bf) ||
+            isBetween(codePoint, 0x02b9, 0x036f) ||
+            isBetween(codePoint, 0x2000, 0x2bff) ||
+            isBetween(codePoint, 0x2e00, 0x2e7f)) &&
+        codePoint != 0x2b50
     );
 }
 

--- a/libraries/botbuilder-dialogs/tests/choices_tokenizer.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_tokenizer.test.js
@@ -59,11 +59,12 @@ describe('defaultTokenizer()', function () {
     });
 
     it('should break on emojis.', function () {
-        const tokens = defaultTokenizer(`food 💥👍😀`);
-        assert(tokens.length === 4);
+        const tokens = defaultTokenizer(`food 💥👍😀⭐`);
+        assert(tokens.length === 5);
         assertToken(tokens[0], 0, 3, 'food');
         assertToken(tokens[1], 5, 6, '💥');
         assertToken(tokens[2], 7, 8, '👍');
         assertToken(tokens[3], 9, 10, '😀');
+        assertToken(tokens[4], 11, 11, '⭐');
     });
 });


### PR DESCRIPTION
Fixes # 4007

## Description
This PR adds an exception in the [isBreakingChar](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-dialogs/src/choices/tokenizer.ts#L126) function of choices prompt to skip the ⭐ emoji as part of the excluded Unicode ranges.

## Specific Changes
- Added an extra condition in `isBreakingChar` function to skip the star emoji. Also, added a comment explaining what this function does.
- Updated a unit test in `choices_tokenizer.test` to cover this case.

## Testing
These images show the star choice being ignored, and after the fix, being properly recognized.
![image](https://user-images.githubusercontent.com/44245136/146563035-8df9c045-3e7f-4395-a327-c043522190cb.png)
