### PR TITLE
port: [#4006] Add TelemetryLoggerConstants for adaptive. (#6029)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -2283,6 +2283,26 @@ export interface SwitchConditionConfiguration extends DialogConfiguration {
 }
 
 // @public
+export class TelemetryLoggerConstants {
+    static readonly CompleteEvent: string;
+    static readonly CrossTrainedRecognizerSetResultEvent: string;
+    static readonly DialogActionEvent: string;
+    static readonly DialogCancelEvent: string;
+    static readonly DialogStartEvent: string;
+    static readonly GeneratorResultEvent: string;
+    static readonly InputDialogResultEvent: string;
+    static readonly LogActionResultEvent: string;
+    static readonly MultiLanguageRecognizerResultEvent: string;
+    static readonly OAuthInputResultEvent: string;
+    static readonly RecognizerSetResultEvent: string;
+    static readonly RegexRecognizerResultEvent: string;
+    static readonly SendActivityResultEvent: string;
+    static readonly TriggerEvent: string;
+    static readonly UpdateActivityResultEvent: string;
+    static readonly ValueRecognizerResultEvent: string;
+}
+
+// @public
 export class TelemetryTrackEventAction<O extends object = {}> extends Dialog implements TelemetryTrackEventActionConfiguration {
     // (undocumented)
     static $kind: string;

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
@@ -18,6 +18,7 @@ import {
 } from 'botbuilder-dialogs';
 import { ActionContext } from '../actionContext';
 import { DialogListConverter } from '../converters';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 const OFFSET_KEY = 'this.offset';
 
@@ -265,7 +266,7 @@ export class ActionScope<O extends object = {}>
             Kind: `Microsoft.${actionName}`,
             ActionId: `Microsoft.${action.id}`,
         };
-        this.telemetryClient.trackEvent({ name: 'AdaptiveDialogAction', properties: properties });
+        this.telemetryClient.trackEvent({ name: TelemetryLoggerConstants.DialogActionEvent, properties: properties });
 
         return await dc.beginDialog(action.id);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -11,6 +11,7 @@ import { ActivityTemplateConverter } from '../converters';
 import { AdaptiveEvents } from '../adaptiveEvents';
 import { BoolProperty, StringProperty, TemplateInterfaceProperty } from '../properties';
 import { skillClientKey, skillConversationIdFactoryKey } from '../skillExtensions';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     BoolExpression,
@@ -203,7 +204,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
             const activity = await this.activity.bind(dc, dcState);
 
             this.telemetryClient.trackEvent({
-                name: 'GeneratorResult',
+                name: TelemetryLoggerConstants.GeneratorResultEvent,
                 properties: {
                     template: this.activity,
                     result: activity || '',

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/logAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/logAction.ts
@@ -9,6 +9,7 @@ import { Activity, ActivityTypes } from 'botbuilder';
 import { BoolProperty, StringProperty } from '../properties';
 import { TextTemplate } from '../templates';
 import { TextTemplateConverter } from '../converters/textTemplateConverter';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     BoolExpression,
@@ -111,10 +112,11 @@ export class LogAction<O extends object = {}> extends Dialog<O> implements LogAc
 
         const msg = await this.text.bind(dc, dc.state);
         this.telemetryClient.trackEvent({
-            name: 'GeneratorResult',
+            name: TelemetryLoggerConstants.GeneratorResultEvent,
             properties: {
                 template: this.text,
                 result: msg || '',
+                context: TelemetryLoggerConstants.LogActionResultEvent,
             },
         });
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
@@ -10,6 +10,7 @@ import { ActivityTemplate, StaticActivityTemplate } from '../templates';
 import { ActivityTemplateConverter } from '../converters';
 import { BoolExpression, BoolExpressionConverter } from 'adaptive-expressions';
 import { BoolProperty, TemplateInterfaceProperty } from '../properties';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     Converter,
@@ -101,10 +102,11 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
         const activityResult = await this.activity.bind(dc, data);
 
         this.telemetryClient.trackEvent({
-            name: 'GeneratorResult',
+            name: TelemetryLoggerConstants.GeneratorResultEvent,
             properties: {
                 template: this.activity,
                 result: activityResult || '',
+                context: TelemetryLoggerConstants.SendActivityResultEvent,
             },
         });
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
@@ -9,6 +9,7 @@ import { Activity, StringUtils } from 'botbuilder';
 import { ActivityTemplate, StaticActivityTemplate } from '../templates';
 import { ActivityTemplateConverter } from '../converters';
 import { BoolProperty, StringProperty, TemplateInterfaceProperty } from '../properties';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     StringExpression,
@@ -118,10 +119,11 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
         const activityResult = await this.activity.bind(dc, data);
 
         this.telemetryClient.trackEvent({
-            name: 'GeneratorResult',
+            name: TelemetryLoggerConstants.GeneratorResultEvent,
             properties: {
                 template: this.activity,
                 result: activityResult || '',
+                context: TelemetryLoggerConstants.UpdateActivityResultEvent,
             },
         });
 

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -56,6 +56,7 @@ import { ValueRecognizer } from './recognizers/valueRecognizer';
 import { SchemaHelper } from './schemaHelper';
 import { FirstSelector, MostSpecificSelector } from './selectors';
 import { TriggerSelector } from './triggerSelector';
+import { TelemetryLoggerConstants } from './telemetryLoggerConstants';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isDialogDependencies(val: any): val is DialogDependencies {
@@ -301,9 +302,10 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         const properties: { [key: string]: string } = {
             DialogId: this.id,
             Kind: 'Microsoft.AdaptiveDialog',
+            context: TelemetryLoggerConstants.DialogStartEvent,
         };
         this.telemetryClient.trackEvent({
-            name: 'AdaptiveDialogStart',
+            name: TelemetryLoggerConstants.GeneratorResultEvent,
             properties: properties,
         });
         telemetryTrackDialogView(this.telemetryClient, this.id);
@@ -347,13 +349,13 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         };
         if (reason === DialogReason.cancelCalled) {
             this.telemetryClient.trackEvent({
-                name: 'AdaptiveDialogCancel',
-                properties: properties,
+                name: TelemetryLoggerConstants.GeneratorResultEvent,
+                properties: { ...properties, context: TelemetryLoggerConstants.DialogCancelEvent },
             });
         } else if (reason === DialogReason.endCalled) {
             this.telemetryClient.trackEvent({
-                name: 'AdaptiveDialogComplete',
-                properties: properties,
+                name: TelemetryLoggerConstants.GeneratorResultEvent,
+                properties: { ...properties, context: TelemetryLoggerConstants.CompleteEvent },
             });
         }
         await super.endDialog(turnContext, instance, reason);
@@ -667,9 +669,10 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                 Expression: evt.getExpression().toString(),
                 Kind: `Microsoft.${evt.constructor.name}`,
                 ConditionId: evt.id,
+                context: TelemetryLoggerConstants.TriggerEvent,
             };
             this.telemetryClient.trackEvent({
-                name: 'AdaptiveDialogTrigger',
+                name: TelemetryLoggerConstants.GeneratorResultEvent,
                 properties: properties,
             });
 

--- a/libraries/botbuilder-dialogs-adaptive/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/index.ts
@@ -29,6 +29,7 @@ export * from './schemaHelper';
 export * from './selectors';
 export * from './skillExtensions';
 export * from './telemetryExtensions';
+export * from './telemetryLoggerConstants';
 export * from './templates';
 export * from './triggerSelector';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
@@ -11,6 +11,7 @@ import { ActivityTypes, Activity, InputHints, MessageFactory } from 'botbuilder'
 import { AdaptiveEvents } from '../adaptiveEvents';
 import { AttachmentInput } from './attachmentInput';
 import { BoolProperty, IntProperty, StringProperty, TemplateInterfaceProperty, UnknownProperty } from '../properties';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     BoolExpression,
@@ -255,10 +256,11 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
                 if (this.defaultValueResponse) {
                     const response = await this.defaultValueResponse.bind(dc, dc.state);
                     this.telemetryClient.trackEvent({
-                        name: 'GeneratorResult',
+                        name: TelemetryLoggerConstants.GeneratorResultEvent,
                         properties: {
                             template: this.defaultValueResponse,
                             result: response || '',
+                            context: TelemetryLoggerConstants.InputDialogResultEvent,
                         },
                     });
 
@@ -372,10 +374,11 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
         }
 
         this.telemetryClient.trackEvent({
-            name: 'GeneratorResult',
+            name: TelemetryLoggerConstants.GeneratorResultEvent,
             properties: {
                 template: template,
                 result: msg,
+                context: TelemetryLoggerConstants.InputDialogResultEvent,
             },
         });
 

--- a/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
@@ -8,6 +8,7 @@
 import { InputDialog, InputDialogConfiguration, InputState } from './inputDialog';
 import { IntProperty, StringProperty } from '../properties';
 import { TextTemplate } from '../templates';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 import {
     ConversationState,
@@ -274,9 +275,10 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
                         const properties = {
                             template: JSON.stringify(this.defaultValueResponse),
                             result: response ? JSON.stringify(response) : '',
+                            context: TelemetryLoggerConstants.OAuthInputResultEvent,
                         };
                         this.telemetryClient.trackEvent({
-                            name: 'GeneratorResult',
+                            name: TelemetryLoggerConstants.GeneratorResultEvent,
                             properties,
                         });
                         await dc.context.sendActivity(response);

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -11,6 +11,7 @@ import { Activity, RecognizerResult, getTopScoringIntent } from 'botbuilder';
 import { Converter, ConverterFactory, DialogContext, Recognizer, RecognizerConfiguration } from 'botbuilder-dialogs';
 import { RecognizerListConverter } from '../converters';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 /**
  * Standard cross trained intent name prefix.
@@ -84,7 +85,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
         const result = this.processResults(results);
         this.trackRecognizerResult(
             dialogContext,
-            'CrossTrainedRecognizerSetResult',
+            TelemetryLoggerConstants.CrossTrainedRecognizerSetResultEvent,
             this.fillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext),
             telemetryMetrics
         );

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
@@ -12,6 +12,7 @@ import { LanguagePolicy, LanguagePolicyConverter } from '../languagePolicy';
 import { MultiLanguageRecognizerConverter } from '../converters';
 import { languagePolicyKey } from '../languageGeneratorExtensions';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 export interface MultiLanguageRecognizerConfiguration extends RecognizerConfiguration {
     languagePolicy?: Record<string, string[]> | LanguagePolicy;
@@ -78,7 +79,7 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
                 );
                 this.trackRecognizerResult(
                     dialogContext,
-                    'MultiLanguageRecognizerResult',
+                    TelemetryLoggerConstants.MultiLanguageRecognizerResultEvent,
                     this.fillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext),
                     telemetryMetrics
                 );
@@ -93,7 +94,7 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
         };
         this.trackRecognizerResult(
             dialogContext,
-            'MultiLanguagesRecognizerResult',
+            TelemetryLoggerConstants.MultiLanguageRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
             telemetryMetrics
         );

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
@@ -10,6 +10,7 @@ import { Activity, RecognizerResult, getTopScoringIntent } from 'botbuilder';
 import { Converter, ConverterFactory, DialogContext, Recognizer, RecognizerConfiguration } from 'botbuilder-dialogs';
 import { RecognizerListConverter } from '../converters';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 export interface RecognizerSetConfiguration extends RecognizerConfiguration {
     recognizers?: string[] | Recognizer[];
@@ -50,7 +51,7 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
 
         this.trackRecognizerResult(
             dialogContext,
-            'RecognizerSetResult',
+            TelemetryLoggerConstants.RecognizerSetResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
             telemetryMetrics
         );

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -12,6 +12,7 @@ import { IntentPattern } from './intentPattern';
 import { EntityRecognizer, TextEntity, EntityRecognizerSet } from './entityRecognizers';
 import { RecognizerSetConfiguration } from './recognizerSet';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 type IntentPatternInput = {
     intent: string;
@@ -165,7 +166,7 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
         );
         this.trackRecognizerResult(
             dialogContext,
-            'RegexRecognizerResult',
+            TelemetryLoggerConstants.RegexRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
             telemetryMetrics
         );

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
@@ -9,6 +9,7 @@
 import { Activity, ActivityTypes, RecognizerResult } from 'botbuilder';
 import { DialogContext } from 'botbuilder-dialogs';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
+import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 export class ValueRecognizer extends AdaptiveRecognizer {
     public async recognize(
@@ -40,7 +41,7 @@ export class ValueRecognizer extends AdaptiveRecognizer {
         }
         this.trackRecognizerResult(
             dialogContext,
-            'ValueRecognizerResult',
+            TelemetryLoggerConstants.ValueRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
             telemetryMetrics
         );

--- a/libraries/botbuilder-dialogs-adaptive/src/telemetryLoggerConstants.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/telemetryLoggerConstants.ts
@@ -1,0 +1,92 @@
+/**
+ * @module botbuilder-dialogs-adaptive
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Defines names of common adaptive dialog events for use with a [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient) object.
+ */
+export class TelemetryLoggerConstants {
+    /**
+     * The generic name of the event when an binding completes. When this event is logged, the context property will contain a more descriptive constant.
+     */
+    public static readonly GeneratorResultEvent: string = 'GeneratorResult';
+
+    /**
+     * The name of the event when an adaptive dialog trigger occurs.
+     */
+    public static readonly TriggerEvent: string = 'AdaptiveDialogTrigger';
+
+    /**
+     * The name of the event when an adaptive dialog complete occurs.
+     */
+    public static readonly CompleteEvent: string = 'AdaptiveDialogComplete';
+
+    /**
+     * The name of the event when an adaptive dialog cancel occurs.
+     */
+    public static readonly DialogCancelEvent: string = 'AdaptiveDialogCancel';
+
+    /**
+     * The name of the event when an adaptive dialog start occurs.
+     */
+    public static readonly DialogStartEvent: string = 'AdaptiveDialogStart';
+
+    /**
+     * The name of the event when an adaptive dialog action occurs.
+     */
+    public static readonly DialogActionEvent: string = 'AdaptiveDialogAction';
+
+    /**
+     * The name of the event when a Log Action result occurs.
+     */
+    public static readonly LogActionResultEvent: string = 'LogActionResult';
+
+    /**
+     * The name of the event when a Sent Activity result occurs.
+     */
+    public static readonly SendActivityResultEvent: string = 'SendActivityResult';
+
+    /**
+     * The name of the event when an Update Activity result occurs.
+     */
+    public static readonly UpdateActivityResultEvent: string = 'UpdateActivityResult';
+
+    /**
+     * The name of the event when an Input result occurs.
+     */
+    public static readonly InputDialogResultEvent: string = 'InputDialogResult';
+
+    /**
+     * The name of the event when an OAuth Input result occurs.
+     */
+    public static readonly OAuthInputResultEvent: string = 'OAuthInputResult';
+
+    /**
+     * The name of the event when a cross trained recognizer set result occurs.
+     */
+    public static readonly CrossTrainedRecognizerSetResultEvent: string = 'CrossTrainedRecognizerSetResult';
+
+    /**
+     * The name of the event when a multi language recognizer result occurs.
+     */
+    public static readonly MultiLanguageRecognizerResultEvent: string = 'MultiLanguageRecognizerResult';
+
+    /**
+     * The name of the event when a recognizer set result occurs.
+     */
+    public static readonly RecognizerSetResultEvent: string = 'RecognizerSetResult';
+
+    /**
+     * The name of the event when a regex recognizer result occurs.
+     */
+    public static readonly RegexRecognizerResultEvent: string = 'RegexRecognizerResult';
+
+    /**
+     * The name of the event when a value recognizer result occurs.
+     */
+    public static readonly ValueRecognizerResultEvent: string = 'ValueRecognizerResult';
+}

--- a/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
@@ -14,7 +14,7 @@ const {
 } = require('botbuilder');
 const { BoolExpression, StringExpression } = require('adaptive-expressions');
 const { DialogManager, DialogTurnStatus, DialogEvents, DialogSet } = require('botbuilder-dialogs');
-const { BeginSkill, SkillExtensions, StaticActivityTemplate } = require('../lib');
+const { BeginSkill, SkillExtensions, StaticActivityTemplate, TelemetryLoggerConstants } = require('../lib');
 
 
 class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
@@ -118,7 +118,7 @@ describe('BeginSkill', function () {
             strictEqual(turnResult.status, DialogTurnStatus.waiting);
 
             // assert telemetry result
-            strictEqual(telemetryName, 'GeneratorResult');
+            strictEqual(telemetryName, TelemetryLoggerConstants.GeneratorResultEvent);
             strictEqual(telemetryProperties.result.text, 'test');
             strictEqual(telemetryProperties.template.activity.text, 'test');
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
@@ -8,7 +8,7 @@ const {
     InputHints,
 } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { InputDialog, StaticActivityTemplate } = require('../lib')
+const { InputDialog, StaticActivityTemplate, TelemetryLoggerConstants } = require('../lib')
 
 
 describe('InputDialog', function () {
@@ -42,7 +42,7 @@ describe('InputDialog', function () {
             await dialog.promptUser(dc, undefined);
 
             // assert telemetry result
-            strictEqual(telemetryName, 'GeneratorResult');
+            strictEqual(telemetryName, TelemetryLoggerConstants.GeneratorResultEvent);
             strictEqual(telemetryProperties.result.text, 'test');
             strictEqual(telemetryProperties.template.activity.text, 'test');
             strictEqual(telemetryProperties.template.activity.inputHint, InputHints.AcceptingInput);

--- a/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
@@ -7,7 +7,7 @@ const {
     MessageFactory,
 } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { LogAction, StaticActivityTemplate } = require('../lib')
+const { LogAction, StaticActivityTemplate, TelemetryLoggerConstants } = require('../lib')
 
 
 describe('LogAction', function () {
@@ -41,7 +41,7 @@ describe('LogAction', function () {
             await dialog.beginDialog(dc);
 
             // assert telemetry result
-            strictEqual(telemetryName, 'GeneratorResult');
+            strictEqual(telemetryName, TelemetryLoggerConstants.GeneratorResultEvent);
             strictEqual(telemetryProperties.result.text, 'test');
             strictEqual(telemetryProperties.template.activity.text, 'test');
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
@@ -7,7 +7,7 @@ const {
     MessageFactory,
 } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { SendActivity } = require('../lib')
+const { SendActivity, TelemetryLoggerConstants } = require('../lib')
 
 
 describe('SendActivity', function () {
@@ -40,7 +40,7 @@ describe('SendActivity', function () {
             await dialog.beginDialog(dc);
 
             // assert telemetry result
-            strictEqual(telemetryName, 'GeneratorResult');
+            strictEqual(telemetryName, TelemetryLoggerConstants.GeneratorResultEvent);
             strictEqual(telemetryProperties.result.text, 'test');
             strictEqual(telemetryProperties.template.activity.text, 'test');
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
@@ -8,7 +8,7 @@ const {
     MessageFactory,
 } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { UpdateActivity } = require('../lib')
+const { UpdateActivity, TelemetryLoggerConstants } = require('../lib')
 
 
 describe('UpdateActivity', function () {
@@ -43,7 +43,7 @@ describe('UpdateActivity', function () {
             await dialog.beginDialog(dc);
 
             // assert telemetry result
-            strictEqual(telemetryName, 'GeneratorResult');
+            strictEqual(telemetryName, TelemetryLoggerConstants.GeneratorResultEvent);
             strictEqual(telemetryProperties.result.text, 'test');
             strictEqual(telemetryProperties.template.activity.text, 'test');
 


### PR DESCRIPTION
Fixes # 4006

## Description
This PR adds the `TelemetryLoggerConstants` class and updates all the hard-coded string references to use the property that corresponds. These changes are ported from `DotNet`.

## Specific Changes
- Adds the `TelemetryLoggerConstants` class.
- Updates all the hard-coded strings to use each specific property declared in the `TelemetryLoggerConstants` class, including unit tests.
- Updated the `beginSkill` to use the constant that corresponds with no addition of a new context property, since this case does not exist in DotNet's port.

## Testing
The following images show an overview of the project building correctly to execute the tests successfully.
![imagen](https://user-images.githubusercontent.com/62260472/147666369-aed4fe8a-b683-46d4-975a-952e37b42dd6.png)