### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-azure library

### DIFF
--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -33,13 +33,14 @@
     "azure-storage": "2.10.2",
     "botbuilder": "4.1.6",
     "documentdb": "1.14.5",
+    "lodash": "^4.17.20",
     "semaphore": "^1.1.0"
   },
   "devDependencies": {
     "@types/semaphore": "^1.1.0",
     "fs-extra": "^7.0.1",
-    "node-fetch": "^2.6.1",
-    "nock": "^11.9.1"
+    "nock": "^11.9.1",
+    "node-fetch": "^2.6.1"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -144,7 +144,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      *
      * @param channelId Channel Id.
      * @param continuationToken ContinuationToken token to page through results.
-     * @returns A promise representation of [PagedResult<TranscriptInfo>](xref:botbuilder-core.PagedResult<T>)
+     * @returns A promise representation of [PagedResult<TranscriptInfo>](xref:botbuilder-core.PagedResult)
      */
     async listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>> {
         if (!channelId) {

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -97,6 +97,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * @param conversationId Conversation Id.
      * @param continuationToken Continuation token to page through results.
      * @param startDate Earliest time to include.
+     * @returns The PagedResult of activities.
      */
     async getTranscriptActivities(
         channelId: string,
@@ -143,6 +144,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      *
      * @param channelId Channel Id.
      * @param continuationToken ContinuationToken token to page through results.
+     * @returns A promise representation of [PagedResult<TranscriptInfo>](xref:botbuilder-core.PagedResult<T>)
      */
     async listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>> {
         if (!channelId) {
@@ -391,6 +393,8 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
 
     /**
      * Delay Container creation if it does not exist.
+     *
+     * @returns A promise representing the asynchronous operation.
      */
     private ensureContainerExists(): Promise<azure.BlobService.ContainerResult> {
         const key: string = this.settings.containerName;
@@ -431,6 +435,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
             },
         }) as BlobServiceAsync;
 
+        // eslint-disable-next-line @typescript-eslint/ban-types
         function denodeify<T>(thisArg: any, fn: Function): (...args: any[]) => Promise<T> {
             return (...args: any[]): Promise<T> => {
                 return new Promise<T>((resolve: any, reject: any): void => {

--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -204,6 +204,7 @@ export class BlobStorage implements Storage {
      * Store a new entity in the configured blob container.
      *
      * @param changes The changes to write to storage.
+     * @returns A promise representing the asynchronous operation.
      */
     write(changes: StoreItems): Promise<void> {
         if (!changes) {
@@ -268,6 +269,7 @@ export class BlobStorage implements Storage {
      * Delete entity blobs from the configured container.
      *
      * @param keys An array of entity keys.
+     * @returns A promise representing the asynchronous operation.
      */
     delete(keys: string[]): Promise<void> {
         if (!keys) {
@@ -296,6 +298,7 @@ export class BlobStorage implements Storage {
      * Get a blob name validated representation of an entity to be used as a key.
      *
      * @param key The key used to identify the entity.
+     * @returns An appropriately escaped version of the key.
      */
     private sanitizeKey(key: string): string {
         if (!key || key.length < 1) {
@@ -326,6 +329,8 @@ export class BlobStorage implements Storage {
 
     /**
      * Delay Container creation if it does not exist.
+     *
+     * @returns A promise representing the asynchronous operation.
      */
     private ensureContainerExists(): Promise<azure.BlobService.ContainerResult> {
         const key: string = this.settings.containerName;
@@ -373,6 +378,7 @@ export class BlobStorage implements Storage {
      * @private
      * Turn a cb based azure method into a Promisified one.
      */
+    // eslint-disable-next-line @typescript-eslint/ban-types
     private denodeify<T>(thisArg: any, fn: Function): (...args: any[]) => Promise<T> {
         return (...args: any[]): Promise<T> => {
             return new Promise<T>((resolve: any, reject: any): void => {

--- a/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import crypto = require('crypto');
+import * as crypto from 'crypto';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CosmosDbKeyEscape {

--- a/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
@@ -5,8 +5,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-const crypto = require('crypto');
+import crypto = require('crypto');
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CosmosDbKeyEscape {
     // Older libraries had a max key length of 255.
     // The limit is now 1023. In this library, 255 remains the default for backwards compat.
@@ -32,6 +33,7 @@ export namespace CosmosDbKeyEscape {
      * @param keySuffix The string to add a the end of all RowKeys.
      * @param compatibilityMode True if keys should be truncated in order to support previous CosmosDb
      * max key length of 255.  This behavior can be overridden by setting cosmosDbPartitionedStorageOptions.compatibilityMode to false.
+     * @returns An escaped key that can be used safely with CosmosDB.
      */
     export function escapeKey(key: string, keySuffix?: string, compatibilityMode?: boolean): string {
         if (!key) {
@@ -56,20 +58,28 @@ export namespace CosmosDbKeyEscape {
         );
 
         return truncateKey(`${sanitizedKey}${keySuffix || ''}`, compatibilityMode);
-    }
 
-    function truncateKey(key: string, truncateKeysForCompatibility?: boolean): string {
-        if (truncateKeysForCompatibility === false) {
+        /**
+         * Truncates the key if it exceeds the max key length to have backwards compatibility with older libraries.
+         *
+         * @param key The key to be truncated.
+         * @param truncateKeysForCompatibility True if keys should be truncated in order to support previous CosmosDb
+         * max key length of 255. False to override this behavior using the longer limit.
+         * @returns The resulting key.
+         */
+        function truncateKey(key: string, truncateKeysForCompatibility?: boolean): string {
+            if (truncateKeysForCompatibility === false) {
+                return key;
+            }
+
+            if (key.length > maxKeyLength) {
+                const hash = crypto.createHash('sha256');
+                hash.update(key);
+                // combine truncated key with hash of self for extra uniqueness
+                const hex = hash.digest('hex');
+                key = key.substr(0, maxKeyLength - hex.length) + hex;
+            }
             return key;
         }
-
-        if (key.length > maxKeyLength) {
-            const hash = crypto.createHash('sha256');
-            hash.update(key);
-            // combine truncated key with hash of self for extra uniqueness
-            const hex = hash.digest('hex');
-            key = key.substr(0, maxKeyLength - hex.length) + hex;
-        }
-        return key;
     }
 }

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -357,7 +357,7 @@ export class CosmosDbPartitionedStorage implements Storage {
                     this.compatibilityModePartitionKey = true;
                 }
                 return container;
-            } catch (err) {
+            } catch {
                 createIfNotExists = true;
             }
         }

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -180,7 +180,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      */
     async read(keys: string[]): Promise<StoreItems> {
         if (!keys) {
-            throw new ReferenceError(`Keys are required when reading.`);
+            throw new ReferenceError('Keys are required when reading.');
         } else if (keys.length === 0) {
             return {};
         }
@@ -239,7 +239,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      */
     async write(changes: StoreItems): Promise<void> {
         if (!changes) {
-            throw new ReferenceError(`Changes are required when writing.`);
+            throw new ReferenceError('Changes are required when writing.');
         } else if (changes.length === 0) {
             return;
         }

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -15,7 +15,8 @@ import { Storage, StoreItems } from 'botbuilder';
 const _semaphore: semaphore.Semaphore = semaphore(1);
 
 // @types/documentdb does not have DocumentBase definition
-const DocumentBase: any = require('documentdb').DocumentBase; // tslint:disable-line no-require-imports no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const DocumentBase: any = require('documentdb').DocumentBase;
 
 /**
  * Additional settings for configuring an instance of `CosmosDbStorage`.
@@ -223,6 +224,7 @@ export class CosmosDbStorage implements Storage {
      * Write storage items to storage.
      *
      * @param changes Items to write to storage, indexed by key.
+     * @returns A promise representing the asynchronous operation.
      */
     write(changes: StoreItems): Promise<void> {
         if (!changes || Object.keys(changes).length === 0) {
@@ -284,6 +286,7 @@ export class CosmosDbStorage implements Storage {
      * Delete storage items from storage.
      *
      * @param keys Keys of the items to remove from the store.
+     * @returns A promise representing the asynchronous operation.
      */
     delete(keys: string[]): Promise<void> {
         if (!keys || keys.length === 0) {
@@ -324,9 +327,12 @@ export class CosmosDbStorage implements Storage {
 
     /**
      * Delayed Database and Collection creation if they do not exist.
+     *
+     * @returns A promise representing the asynchronous operation.
      */
     private ensureCollectionExists(): Promise<string> {
         if (!this.collectionExists) {
+            // eslint-disable-next-line @typescript-eslint/ban-types
             this.collectionExists = new Promise((resolve: Function): void => {
                 _semaphore.take(() => {
                     const result: Promise<string> = this.collectionExists

--- a/libraries/botbuilder-azure/src/doOnce.ts
+++ b/libraries/botbuilder-azure/src/doOnce.ts
@@ -19,6 +19,7 @@ export class DoOnce<T> {
      *
      * @param key Key of the task.
      * @param fn Function to perform.
+     * @returns A promise representing the asynchronous operation.
      */
     waitFor(key: string, fn: () => Promise<T>): Promise<T> {
         if (!this.task[key]) {

--- a/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
+++ b/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
@@ -204,7 +204,7 @@ function createActivity(conversationId, ts) {
         id: 1,
         text: 'testMessage',
         channelId: 'test',
-        from: { id: `User1` },
+        from: { id: 'User1' },
         conversation: { id: conversationId },
         recipient: { id: 'Bot1', name: '2' },
         serviceUrl: 'http://foo.com/api/messages',

--- a/libraries/botbuilder-azure/tests/blobStorage.test.js
+++ b/libraries/botbuilder-azure/tests/blobStorage.test.js
@@ -22,8 +22,8 @@ const reset = (done) => {
     nock.cleanAll();
     nock.enableNetConnect();
     if (mode !== MockMode.lockdown) {
-        let settings = getSettings();
-        let client = azure.createBlobService(settings.storageAccountOrConnectionString, settings.storageAccessKey);
+        const settings = getSettings();
+        const client = azure.createBlobService(settings.storageAccountOrConnectionString, settings.storageAccessKey);
         client.deleteContainerIfExists(settings.containerName, (err, result) => done());
     } else {
         done();

--- a/libraries/botbuilder-azure/tests/blobStorage.test.js
+++ b/libraries/botbuilder-azure/tests/blobStorage.test.js
@@ -5,6 +5,7 @@ const azure = require('azure-storage');
 const { MockMode, usingNock } = require('./mockHelper.js');
 const nock = require('nock');
 const fs = require('fs');
+const flow = require('lodash/fp/flow');
 
 /**
  * @param mode controls the nock mode used for the tests. Available options found in ./mockHelper.js.
@@ -24,7 +25,7 @@ const reset = (done) => {
     if (mode !== MockMode.lockdown) {
         const settings = getSettings();
         const client = azure.createBlobService(settings.storageAccountOrConnectionString, settings.storageAccessKey);
-        client.deleteContainerIfExists(settings.containerName, (err, result) => done());
+        client.deleteContainerIfExists(settings.containerName, (_err, _result) => done());
     } else {
         done();
     }
@@ -59,8 +60,10 @@ describe('BlobStorage - Constructor', function () {
 });
 
 describe('BlobStorage - Base Storage Tests', function () {
-    before('cleanup', reset);
-    before('check emulator', checkEmulator);
+    before(
+        'cleanup',
+        flow(() => reset, checkEmulator)
+    );
     after('cleanup', reset);
 
     it('return empty object when reading unknown key', async function () {
@@ -68,7 +71,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('throws when reading null keys', async function () {
@@ -76,7 +79,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('throws when writing null keys', async function () {
@@ -84,7 +87,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when writing no items', async function () {
@@ -92,7 +95,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('create an object', async function () {
@@ -100,7 +103,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('handle crazy keys', async function () {
@@ -108,7 +111,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('update an object', async function () {
@@ -116,7 +119,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('delete an object', async function () {
@@ -124,7 +127,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when deleting an unknown object', async function () {
@@ -132,7 +135,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('performs batch operations', async function () {
@@ -140,7 +143,7 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('proceeds through a waterfall dialog', async function () {
@@ -148,6 +151,6 @@ describe('BlobStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 });

--- a/libraries/botbuilder-azure/tests/cosmosDbKeyEscape.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbKeyEscape.test.js
@@ -27,53 +27,53 @@ describe('CosmosDbKeyEscape', function () {
     });
 
     it('should not change a valid key', function () {
-        let validKey = 'Abc12345';
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey(validKey);
+        const validKey = 'Abc12345';
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey(validKey);
         assert.equal(validKey, sanitizedKey, `${validKey} should be equal to ${sanitizedKey}`);
     });
 
     it("should escape illegal characters - case with '?'", function () {
         // Ascii code of "?" is "3f"
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey('?test?');
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey('?test?');
         assert.equal(sanitizedKey, '*3ftest*3f');
     });
 
     it("should escape illegal characters - case with '/'", function () {
         // Ascii code of "/" is "2f"
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey('/test/');
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey('/test/');
         assert.equal(sanitizedKey, '*2ftest*2f');
     });
 
     it("should escape illegal characters - case with '\\'", function () {
         // Ascii code of "\" is "5c"
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey('\\test\\');
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey('\\test\\');
         assert.equal(sanitizedKey, '*5ctest*5c');
     });
 
     it("should escape illegal characters - case with '#'", function () {
         // Ascii code of "#" is "23"
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey('#test#');
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey('#test#');
         assert.equal(sanitizedKey, '*23test*23');
     });
 
     it("should escape illegal characters - case with '*'", function () {
         // Ascii code of "*" is "2a".
-        let sanitizedKey = CosmosDbKeyEscape.escapeKey('*test*');
+        const sanitizedKey = CosmosDbKeyEscape.escapeKey('*test*');
         assert.equal(sanitizedKey, '*2atest*2a');
     });
 
     it('should escape illegal characters - compound key', function () {
         // Check a compound key
-        let compoundSanitizedKey = CosmosDbKeyEscape.escapeKey('?#/');
+        const compoundSanitizedKey = CosmosDbKeyEscape.escapeKey('?#/');
         assert.equal(compoundSanitizedKey, '*3f*23*2f');
     });
 
     it('should handle possible collisions', function () {
-        let validKey1 = '*2atest*2a';
-        let validKey2 = '*test*';
+        const validKey1 = '*2atest*2a';
+        const validKey2 = '*test*';
 
-        let escaped1 = CosmosDbKeyEscape.escapeKey(validKey1);
-        let escaped2 = CosmosDbKeyEscape.escapeKey(validKey2);
+        const escaped1 = CosmosDbKeyEscape.escapeKey(validKey1);
+        const escaped2 = CosmosDbKeyEscape.escapeKey(validKey2);
 
         assert.notEqual(escaped1, escaped2, `${escaped1} should be different that ${escaped2}`);
     });
@@ -81,41 +81,41 @@ describe('CosmosDbKeyEscape', function () {
     it('should truncate longer keys', function () {
         // create an extra long key
         // limit is 255
-        let longKey = new Array(300).join('x');
-        let fixed = CosmosDbKeyEscape.escapeKey(longKey);
+        const longKey = new Array(300).join('x');
+        const fixed = CosmosDbKeyEscape.escapeKey(longKey);
 
         assert(fixed.length <= 255, 'long key was not properly truncated');
     });
 
     it('should not truncate short key', function () {
         // create a short key
-        let shortKey = new Array(16).join('x');
-        let fixed2 = CosmosDbKeyEscape.escapeKey(shortKey);
+        const shortKey = new Array(16).join('x');
+        const fixed2 = CosmosDbKeyEscape.escapeKey(shortKey);
 
         assert(fixed2.length === 15, 'short key was truncated improperly');
     });
 
     it('should create sufficiently different truncated keys of similar origin', function () {
         // create 2 very similar extra long key where the difference will definitely be trimmed off by truncate function
-        let longKey = new Array(300).join('x') + '1';
-        let longKey2 = new Array(300).join('x') + '2';
+        const longKey = new Array(300).join('x') + '1';
+        const longKey2 = new Array(300).join('x') + '2';
 
-        let fixed = CosmosDbKeyEscape.escapeKey(longKey);
-        let fixed2 = CosmosDbKeyEscape.escapeKey(longKey2);
+        const fixed = CosmosDbKeyEscape.escapeKey(longKey);
+        const fixed2 = CosmosDbKeyEscape.escapeKey(longKey2);
 
         assert(fixed.length !== fixed2, 'key truncation failed to create unique key');
     });
 
     it('should properly truncate keys with special chars', function () {
         // create a short key
-        let longKey = new Array(300).join('*');
-        let fixed = CosmosDbKeyEscape.escapeKey(longKey);
+        const longKey = new Array(300).join('*');
+        const fixed = CosmosDbKeyEscape.escapeKey(longKey);
 
         assert(fixed.length <= 255, 'long key with special char was truncated improperly');
 
         // create a short key
-        let shortKey = new Array(16).join('#');
-        let fixed2 = CosmosDbKeyEscape.escapeKey(shortKey);
+        const shortKey = new Array(16).join('#');
+        const fixed2 = CosmosDbKeyEscape.escapeKey(shortKey);
 
         assert(fixed2.length <= 255, 'short key with special char was truncated improperly');
     });

--- a/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
@@ -79,7 +79,7 @@ const cleanup = async () => {
     const settings = getSettings();
 
     if (canConnectToEmulator) {
-        let client = new CosmosClient({
+        const client = new CosmosClient({
             endpoint: settings.cosmosDbEndpoint,
             key: settings.authKey,
             agent: new https.Agent({ rejectUnauthorized: false }),
@@ -95,7 +95,7 @@ const prep = async () => {
     nock.cleanAll();
     await checkEmulator();
 
-    let settings = getSettings();
+    const settings = getSettings();
 
     if (mode !== MockMode.lockdown) {
         nock.enableNetConnect();
@@ -104,7 +104,7 @@ const prep = async () => {
     }
 
     if (canConnectToEmulator) {
-        let client = new CosmosClient({
+        const client = new CosmosClient({
             endpoint: settings.cosmosDbEndpoint,
             key: settings.authKey,
             agent: new https.Agent({ rejectUnauthorized: false }),
@@ -125,14 +125,14 @@ const options = {
 };
 
 describe('CosmosDbPartitionedStorage - Constructor Tests', function () {
-    it('throws when provided with null options', () => {
+    it('throws when provided with null options', function () {
         assert.throws(
             () => new CosmosDbPartitionedStorage(null),
             ReferenceError('CosmosDbPartitionedStorageOptions is required.')
         );
     });
 
-    it('throws when no endpoint provided', () => {
+    it('throws when no endpoint provided', function () {
         const noEndpoint = getSettings();
         noEndpoint.cosmosDbEndpoint = null;
         assert.throws(
@@ -141,7 +141,7 @@ describe('CosmosDbPartitionedStorage - Constructor Tests', function () {
         );
     });
 
-    it('throws when no authKey provided', () => {
+    it('throws when no authKey provided', function () {
         const noAuthKey = getSettings();
         noAuthKey.authKey = null;
         assert.throws(
@@ -150,7 +150,7 @@ describe('CosmosDbPartitionedStorage - Constructor Tests', function () {
         );
     });
 
-    it('throws when no databaseId provided', () => {
+    it('throws when no databaseId provided', function () {
         const noDatabaseId = getSettings();
         noDatabaseId.databaseId = null;
         assert.throws(
@@ -159,7 +159,7 @@ describe('CosmosDbPartitionedStorage - Constructor Tests', function () {
         );
     });
 
-    it('throws when no containerId provided', () => {
+    it('throws when no containerId provided', function () {
         const noContainerId = getSettings();
         noContainerId.containerId = null;
         assert.throws(
@@ -305,7 +305,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
 
         // cosmosDbPartitionedStorage requires the user creates the db,
         // so we need to create it for the test
-        let dbCreateClient = new CosmosClient({
+        const dbCreateClient = new CosmosClient({
             endpoint: settingsWithNewDb.cosmosDbEndpoint,
             key: settingsWithNewDb.authKey,
             agent: new https.Agent({ rejectUnauthorized: false }),

--- a/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
@@ -55,7 +55,7 @@ const checkEmulator = async () => {
                 });
                 await fetch(emulatorEndpoint, { agent });
                 canConnectToEmulator = true;
-            } catch (err) {
+            } catch {
                 canConnectToEmulator = false;
             }
         }
@@ -86,7 +86,9 @@ const cleanup = async () => {
         });
         try {
             await client.database(settings.databaseId).delete();
-        } catch (err) {}
+        } catch {
+            //This throws if the db is already deleted.
+        }
     }
 };
 
@@ -114,7 +116,9 @@ const prep = async () => {
         // so leaving this here should help prevent failures if the tests change in the future
         try {
             await client.databases.create({ id: settings.databaseId });
-        } catch (err) {}
+        } catch {
+            // This throws if the db is already created.
+        }
     }
 
     storage = new CosmosDbPartitionedStorage(settings);
@@ -191,7 +195,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         assert.strictEqual(client.client.clientContext.connectionPolicy.requestTimeout, 999);
         assert.strictEqual(client.client.clientContext.cosmosClientOptions.userAgentSuffix, 'test');
 
-        return nockDone();
+        nockDone();
     });
 
     it('return empty object when reading unknown key', async function () {
@@ -201,7 +205,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
 
         assert.strictEqual(testRan, true);
 
-        return nockDone();
+        nockDone();
     });
 
     it('throws when reading null keys', async function () {
@@ -210,7 +214,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('throws when writing null keys', async function () {
@@ -219,7 +223,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when writing no items', async function () {
@@ -228,7 +232,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('create an object', async function () {
@@ -237,7 +241,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('handle crazy keys', async function () {
@@ -246,7 +250,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('update an object', async function () {
@@ -255,7 +259,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('delete an object', async function () {
@@ -264,7 +268,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when deleting an unknown object', async function () {
@@ -273,7 +277,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('performs batch operations', async function () {
@@ -282,7 +286,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('proceeds through a waterfall dialog', async function () {
@@ -291,7 +295,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('support using multiple databases', async function () {
@@ -312,7 +316,9 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
         });
         try {
             await dbCreateClient.database(newDb).delete();
-        } catch (err) {}
+        } catch {
+            //This throws if the db is already deleted.
+        }
         await dbCreateClient.databases.create({ id: newDb });
 
         const defaultClient = new CosmosDbPartitionedStorage(defaultSettings);
@@ -327,7 +333,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
 
         await dbCreateClient.database(newDb).delete();
 
-        return nockDone();
+        nockDone();
     });
 
     it('support using multiple containers', async function () {
@@ -350,7 +356,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
                 await newClient.client.database(settingsWithNewContainer.databaseId).container(newContainer).read()
         );
 
-        return nockDone();
+        nockDone();
     });
 
     it('is aware of nesting limit', async function () {
@@ -382,7 +388,7 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
             assert.strictEqual(err.message.includes('recursion'), true);
         }
 
-        return nockDone();
+        nockDone();
     });
 
     it('is aware of nesting limit with dialogs', async function () {
@@ -434,6 +440,6 @@ describe('CosmosDbPartitionedStorage - Base Storage Tests', function () {
             assert.strictEqual(err.message.includes('dialogs'), true);
         }
 
-        return nockDone();
+        nockDone();
     });
 });

--- a/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
@@ -36,8 +36,8 @@ const reset = (done) => {
     nock.cleanAll();
     nock.enableNetConnect();
     if (mode !== MockMode.lockdown) {
-        let settings = getSettings();
-        let client = new DocumentClient(settings.serviceEndpoint, { masterKey: settings.authKey });
+        const settings = getSettings();
+        const client = new DocumentClient(settings.serviceEndpoint, { masterKey: settings.authKey });
         client.deleteDatabase(UriFactory.createDatabaseUri(settings.databaseId), (err, response) => done());
     } else {
         done();
@@ -54,7 +54,7 @@ const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
 const partitionKey = 'ARG';
 
 // item to test the read and delete operations with partitionkey
-let changes = {};
+const changes = {};
 changes['001'] = {
     Location: partitionKey,
     MessageList: ['Hi', 'how are u'],
@@ -70,7 +70,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings endpoint should be thrown - null value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: null,
             authKey: 'testKey',
             databaseId: 'testDataBaseID',
@@ -85,7 +85,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings endpoint should be thrown - empty value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: '',
             authKey: 'testKey',
             databaseId: 'testDataBaseID',
@@ -100,7 +100,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings endpoint should be thrown - white spaces', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: '   ',
             authKey: 'testKey',
             databaseId: 'testDataBaseID',
@@ -115,7 +115,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings authKey should be thrown - null value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: null,
             databaseId: 'testDataBaseID',
@@ -130,7 +130,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings authKey should be thrown - empty value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: '',
             databaseId: 'testDataBaseID',
@@ -145,7 +145,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings authKey should be thrown - white spaces', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: '   ',
             databaseId: 'testDataBaseID',
@@ -160,7 +160,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings databaseId should be thrown - null value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: null,
@@ -175,7 +175,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings databaseId should be thrown - empty value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: '',
@@ -190,7 +190,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings databaseId should be thrown - white spaces', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: '    ',
@@ -205,7 +205,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings collectionId should be thrown - null value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: 'testDataBaseID',
@@ -220,7 +220,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings collectionId should be thrown - empty value', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: 'testDataBaseID',
@@ -235,7 +235,7 @@ describe('CosmosDbStorage - Constructor Tests', function () {
     });
 
     it('missing settings collectionId should be thrown - white spaces', function () {
-        let testSettings = {
+        const testSettings = {
             serviceEndpoint: 'testEndpoint',
             authKey: 'testKey',
             databaseId: 'testDataBaseID',

--- a/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
@@ -5,6 +5,7 @@ const { DocumentClient, UriFactory } = require('documentdb');
 const { MockMode, usingNock } = require('./mockHelper');
 const nock = require('nock');
 const fs = require('fs');
+const flow = require('lodash/fp/flow');
 
 /**
  * @param mode controls the nock mode used for the tests. Available options found in ./mockHelper.js.
@@ -38,7 +39,7 @@ const reset = (done) => {
     if (mode !== MockMode.lockdown) {
         const settings = getSettings();
         const client = new DocumentClient(settings.serviceEndpoint, { masterKey: settings.authKey });
-        client.deleteDatabase(UriFactory.createDatabaseUri(settings.databaseId), (err, response) => done());
+        client.deleteDatabase(UriFactory.createDatabaseUri(settings.databaseId), (_err, _response) => done());
     } else {
         done();
     }
@@ -251,8 +252,10 @@ describe('CosmosDbStorage - Constructor Tests', function () {
 });
 
 describe('CosmosDbStorage - Base Storage Tests', function () {
-    before('cleanup', reset);
-    before('check emulator', checkEmulator);
+    before(
+        'cleanup',
+        flow(() => reset, checkEmulator)
+    );
     after('cleanup', reset);
 
     it('return empty object when reading unknown key', async function () {
@@ -260,7 +263,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('throws when reading null keys', async function () {
@@ -268,7 +271,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('throws when writing null keys', async function () {
@@ -276,7 +279,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when writing no items', async function () {
@@ -284,7 +287,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('create an object', async function () {
@@ -292,7 +295,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('handle crazy keys', async function () {
@@ -300,7 +303,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('update an object', async function () {
@@ -308,7 +311,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('delete an object', async function () {
@@ -316,7 +319,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('does not throw when deleting an unknown object', async function () {
@@ -324,7 +327,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('performs batch operations', async function () {
@@ -332,7 +335,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('proceeds through a waterfall dialog', async function () {
@@ -340,7 +343,7 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
-        return nockDone();
+        nockDone();
     });
 
     it('should call connectionPolicyConfigurator', function () {
@@ -353,8 +356,10 @@ describe('CosmosDbStorage - Base Storage Tests', function () {
 
 // PartitionKeys are deprecated. Tests are here to ensure backwards compatibility of changes
 describe('CosmosDbStorage - PartitionKey Tests', function () {
-    before('cleanup', reset);
-    before('check emulator', checkEmulator);
+    before(
+        'cleanup',
+        flow(() => reset, checkEmulator)
+    );
     after('cleanup', reset);
 
     it('create and read an object with partitionKey', async function () {
@@ -364,7 +369,7 @@ describe('CosmosDbStorage - PartitionKey Tests', function () {
         const result = await storage.read(['001']);
 
         assert.ok(result['001']);
-        return nockDone();
+        nockDone();
     });
 
     it('update an object with partitionKey', async function () {
@@ -382,7 +387,7 @@ describe('CosmosDbStorage - PartitionKey Tests', function () {
         assert.strictEqual(updated.keyUpdate.count, 2);
         assert.notStrictEqual(updated.keyUpdate.eTag, result.keyUpdate.eTag);
 
-        return nockDone();
+        nockDone();
     });
 
     it('delete an object with partitionKey', async function () {
@@ -396,7 +401,7 @@ describe('CosmosDbStorage - PartitionKey Tests', function () {
         result = await storage.read(['001']);
 
         assert.strictEqual(Object.keys(result).length, 0);
-        return nockDone();
+        nockDone();
     });
 });
 


### PR DESCRIPTION
Addresses # 2745
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the [botbuilder-azure](https://github.com/microsoft/botbuilder-js/tree/main/libraries/botbuilder-azure) library.

**_Note: we excluded the `@typescript-eslint/no-explicit-any` and `@typescript-eslint/explicit-module-boundary-types` to tackle those issues as a separated task as they require deeper analysis and testing._**

## Specific Changes
  - Applied the eslint auto-fix with `yarn lint --fix` (quotes, spacing, replaced let with const)
  - Added missing JSDoc documentation in methods.
  - Removed unused variables.
  - Disabled `@typescript-eslint/ban-types` rule to review the use of _object_ along with the _any_ types.
  - Disabled `@typescript-eslint/no-namespace` rule in CosmosDbKeyScape.ts and move the function inside the namespace.
  - Used `lodash/flow` to concatenate functions of duplicated hooks in tests.
  - Removed the `return` clauses from async tests.

## Testing
These images show the current status showing no issues and the tests passing after the changes.

![image](https://user-images.githubusercontent.com/44245136/147755358-6eb5317a-a258-4474-9336-34cf8e38cce4.png)
