### PR TITLE
fix: [#3756] Ensure SDK packages and their dependencies support next Node.js LTS (16.x)

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/test-repoutils.yml
+++ b/.github/workflows/test-repoutils.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-repoutils.yml
+++ b/.github/workflows/test-repoutils.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/test-schemas.yml
+++ b/.github/workflows/test-schemas.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node 16.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/test-schemas.yml
+++ b/.github/workflows/test-schemas.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node 14.x
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: 14.x
 
       - name: yarn cache dir
         id: yarn-cache-dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
         run: yarn test:github
 
       - name: coveralls
-        if: matrix.node-version == '14.x'
+        if: matrix.node-version == '16.x'
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -68,7 +68,10 @@ describe('ComponentDialog', function () {
         const adapter = new TestAdapter(async (turnContext) => {
             const dc = await dialogs.createContext(turnContext);
             await assert.rejects(async () => await dc.beginDialog('composite'), {
-                message: `Cannot read property 'status' of undefined`,
+                message:
+                    process.versions.node.split('.')[0] >= 16
+                        ? "Cannot read properties of undefined (reading 'status')"
+                        : "Cannot read property 'status' of undefined",
             });
         });
         await adapter.send('Hi').startTest();

--- a/libraries/botbuilder-dialogs/tests/dialogSet.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialogSet.test.js
@@ -15,7 +15,10 @@ describe('DialogSet', function () {
     it('should throw on createContext(undefined)', async function () {
         const dialogSet = new DialogSet(dialogState);
         await assert.rejects(async () => await dialogSet.createContext(undefined), {
-            message: "Cannot read property 'turnState' of undefined",
+            message:
+                process.versions.node.split('.')[0] >= 16
+                    ? "Cannot read properties of undefined (reading 'turnState')"
+                    : "Cannot read property 'turnState' of undefined",
         });
     });
 

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -261,11 +261,20 @@ describe('TeamsActivityHandler', function () {
             await adapter
                 .send(activity)
                 .assertReply((activity) => {
-                    assert.strictEqual(
-                        activity.value.message,
-                        "Cannot read property 'activity' of null",
-                        'should have thrown an error.'
-                    );
+                    if (process.versions.node.split('.')[0] >= 16){
+                        assert.strictEqual(
+                            activity.value.message,
+                            "Cannot read properties of null (reading 'activity')",
+                            'should have thrown an error.'
+                        );
+                    }
+                    else{
+                        assert.strictEqual(
+                            activity.value.message,
+                            "Cannot read property 'activity' of null",
+                            'should have thrown an error.'
+                        );
+                    }
                 })
                 .startTest();
         });


### PR DESCRIPTION
Fixes # 3756

## Description
This PR updates the CI checks to use Nodejs 16 and three failing tests to support the new node error messages.

### Detailed Changes
- Updated the following GitHub workflows to use Nodejs 16:
   - `depcheck`
   - `lint`
   - `test-compat`
   - `test-consumer`
   - `test-repoutils`
- Added Nodejs 16 to the test matrix in the `tests` GitHub workflow.
- Updated the following unit tests that were asserting an error message that changed in the new version of Node.
   - componentDialog.test
   - dialogSet.test
   - teamsActivityHandler.test

## Testing
