### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs library

### DIFF
--- a/libraries/botbuilder-dialogs/.eslintrc.json
+++ b/libraries/botbuilder-dialogs/.eslintrc.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../.eslintrc.json",
     "plugins": ["only-warn"],
-    "ignorePatterns": ["vendor/"]
+    "ignorePatterns": ["vendor/"],
+    "env": {
+        "node": true
+      }
 }

--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -30,9 +30,9 @@ export class ActivityPrompt extends Dialog {
     beginDialog(dc: DialogContext, options: PromptOptions): Promise<DialogTurnResult>;
     continueDialog(dc: DialogContext): Promise<DialogTurnResult>;
     protected onPrompt(context: TurnContext, state: object, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>>;
+    protected onRecognize(context: TurnContext, _state: object, _options: PromptOptions): Promise<PromptRecognizerResult<Activity>>;
     repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
-    resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
+    resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult>;
     }
 
 // @public
@@ -56,7 +56,7 @@ export class AtPathResolver extends AliasPathResolver {
 export class AttachmentPrompt extends Prompt<Attachment[]> {
     constructor(dialogId: string, validator?: PromptValidator<Attachment[]>);
     protected onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<Attachment[]>>;
+    protected onRecognize(context: TurnContext, _state: any, _options: PromptOptions): Promise<PromptRecognizerResult<Attachment[]>>;
 }
 
 // @public
@@ -67,11 +67,11 @@ export interface BeginSkillDialogOptions {
 // @public
 export class BotStateMemoryScope extends MemoryScope {
     constructor(name: string);
-    delete(dc: DialogContext): Promise<void>;
+    delete(_dc: DialogContext): Promise<void>;
     getMemory(dc: DialogContext): object;
     load(dc: DialogContext, force?: boolean): Promise<void>;
     saveChanges(dc: DialogContext, force?: boolean): Promise<void>;
-    setMemory(dc: DialogContext, memory: object): void;
+    setMemory(dc: DialogContext, _memory: object): void;
     // (undocumented)
     protected stateKey: string;
 }
@@ -131,10 +131,10 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     protected initialDialogId: string;
     protected onBeginDialog(innerDC: DialogContext, options?: O): Promise<DialogTurnResult>;
     protected onContinueDialog(innerDC: DialogContext): Promise<DialogTurnResult>;
-    protected onEndDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void>;
-    protected onRepromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
+    protected onEndDialog(_context: TurnContext, _instance: DialogInstance, _reason: DialogReason): Promise<void>;
+    protected onRepromptDialog(_context: TurnContext, _instance: DialogInstance): Promise<void>;
     repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
-    resumeDialog(outerDC: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
+    resumeDialog(outerDC: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult>;
 }
 
 // @public
@@ -164,7 +164,7 @@ export class ConfirmPrompt extends Prompt<boolean> {
     confirmChoices: (string | Choice)[] | undefined;
     defaultLocale: string | undefined;
     protected onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<boolean>>;
+    protected onRecognize(context: TurnContext, _state: any, _options: PromptOptions): Promise<PromptRecognizerResult<boolean>>;
     style: ListStyle;
 }
 
@@ -191,7 +191,7 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
     constructor(dialogId: string, validator?: PromptValidator<DateTimeResolution[]>, defaultLocale?: string);
     defaultLocale: string | undefined;
     protected onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<DateTimeResolution[]>>;
+    protected onRecognize(context: TurnContext, _state: any, _options: PromptOptions): Promise<PromptRecognizerResult<DateTimeResolution[]>>;
 }
 
 // @public
@@ -202,14 +202,14 @@ export interface DateTimeResolution {
 }
 
 // @public
-export function defaultTokenizer(text: string, locale?: string): Token[];
+export function defaultTokenizer(text: string, _locale?: string): Token[];
 
 // @public
 export abstract class Dialog<O extends object = {}> extends Configurable {
     constructor(dialogId?: string);
     abstract beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
     continueDialog(dc: DialogContext): Promise<DialogTurnResult>;
-    endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void>;
+    endDialog(_context: TurnContext, _instance: DialogInstance, _reason: DialogReason): Promise<void>;
     static EndOfTurn: DialogTurnResult;
     getVersion(): string;
     get id(): string;
@@ -217,9 +217,9 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
     set id(value: string);
     protected onComputeId(): string;
     onDialogEvent(dc: DialogContext, e: DialogEvent): Promise<boolean>;
-    protected onPostBubbleEvent(dc: DialogContext, e: DialogEvent): Promise<boolean>;
-    protected onPreBubbleEvent(dc: DialogContext, e: DialogEvent): Promise<boolean>;
-    repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
+    protected onPostBubbleEvent(_dc: DialogContext, _e: DialogEvent): Promise<boolean>;
+    protected onPreBubbleEvent(_dc: DialogContext, _e: DialogEvent): Promise<boolean>;
+    repromptDialog(_context: TurnContext, _instance: DialogInstance): Promise<void>;
     resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
     get telemetryClient(): BotTelemetryClient;
     // Warning: (ae-setter-with-docs) The doc comment for the property "telemetryClient" must appear on the getter, not the setter.
@@ -257,12 +257,15 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
 export class DialogContext {
     constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
     constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
+    // (undocumented)
     get activeDialog(): DialogInstance | undefined;
     beginDialog(dialogId: string, options?: object): Promise<DialogTurnResult>;
     cancelAllDialogs(cancelParents?: boolean, eventName?: string, eventValue?: any): Promise<DialogTurnResult>;
+    // (undocumented)
     get child(): DialogContext | undefined;
     context: TurnContext;
     continueDialog(): Promise<DialogTurnResult>;
+    // (undocumented)
     get dialogManager(): DialogManager;
     dialogs: DialogSet;
     emitEvent(name: string, value?: any, bubble?: boolean, fromLeaf?: boolean): Promise<boolean>;
@@ -394,7 +397,7 @@ export enum DialogReason {
     replaceCalled = "replaceCalled"
 }
 
-// @public (undocumented)
+// @public
 export class DialogsBotComponent extends BotComponent {
     // (undocumented)
     configureServices(services: ServiceCollection, configuration: Configuration): void;
@@ -543,18 +546,18 @@ export enum ListStyle {
 }
 
 // @public (undocumented)
-export function maxActionTitleLength(channelId: string): number;
+export function maxActionTitleLength(_channelId: string): number;
 
 // @public
 export abstract class MemoryScope {
     constructor(name: string, includeInSnapshot?: boolean);
-    delete(dc: DialogContext): Promise<void>;
+    delete(_dc: DialogContext): Promise<void>;
     abstract getMemory(dc: DialogContext): object;
     readonly includeInSnapshot: boolean;
-    load(dc: DialogContext): Promise<void>;
+    load(_dc: DialogContext): Promise<void>;
     readonly name: string;
-    saveChanges(dc: DialogContext): Promise<void>;
-    setMemory(dc: DialogContext, memory: object): void;
+    saveChanges(_dc: DialogContext): Promise<void>;
+    setMemory(_dc: DialogContext, _memory: object): void;
 }
 
 // @public
@@ -571,7 +574,7 @@ export class NumberPrompt extends Prompt<number> {
     constructor(dialogId: string, validator?: PromptValidator<number>, defaultLocale?: string);
     defaultLocale?: string;
     protected onPrompt(context: TurnContext, state: unknown, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: unknown, options: PromptOptions): Promise<PromptRecognizerResult<number>>;
+    protected onRecognize(context: TurnContext, _state: unknown, _options: PromptOptions): Promise<PromptRecognizerResult<number>>;
 }
 
 // @public
@@ -615,7 +618,7 @@ export abstract class Prompt<T> extends Dialog {
     protected abstract onPrompt(context: TurnContext, state: object, options: PromptOptions, isRetry: boolean): Promise<void>;
     protected abstract onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<T>>;
     repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
-    resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
+    resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult>;
     }
 
 // @public (undocumented)
@@ -686,9 +689,9 @@ export function recognizeChoices(utterance: string, choices: (string | Choice)[]
 // @public
 export class Recognizer extends Configurable implements RecognizerConfiguration {
     protected createChooseIntentResult(recognizerResults: Record<string, RecognizerResult>): RecognizerResult;
-    protected fillRecognizerResultTelemetryProperties(recognizerResult: RecognizerResult, telemetryProperties: Record<string, string>, dialogContext?: DialogContext): Record<string, string>;
+    protected fillRecognizerResultTelemetryProperties(recognizerResult: RecognizerResult, telemetryProperties: Record<string, string>, _dialogContext?: DialogContext): Record<string, string>;
     id: string;
-    recognize(dialogContext: DialogContext, activity: Partial<Activity>, telemetryProperties?: Record<string, string>, telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
+    recognize(_dialogContext: DialogContext, _activity: Partial<Activity>, _telemetryProperties?: Record<string, string>, _telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
     // (undocumented)
     protected stringifyAdditionalPropertiesOfRecognizerResult(recognizerResult: RecognizerResult): string;
     telemetryClient: BotTelemetryClient;
@@ -736,9 +739,9 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     // (undocumented)
     protected dialogOptions: SkillDialogOptions;
     endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void>;
-    protected onValidateActivity(activity: Activity): boolean;
+    protected onValidateActivity(_activity: Activity): boolean;
     repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void>;
-    resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
+    resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult>;
     }
 
 // @public (undocumented)
@@ -774,9 +777,9 @@ export interface TemplateInterface<T, D = Record<string, unknown>> {
 // @public
 export class TextPrompt extends Prompt<string> {
     constructor(dialogId?: string, validator?: PromptValidator<string>);
-    protected onPreBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean>;
+    protected onPreBubbleEvent(_dc: DialogContext, _event: DialogEvent): Promise<boolean>;
     protected onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void>;
-    protected onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<string>>;
+    protected onRecognize(context: TurnContext, _state: any, _options: PromptOptions): Promise<PromptRecognizerResult<string>>;
 }
 
 // @public
@@ -863,11 +866,16 @@ export type WaterfallStep<O extends object = {}> = (step: WaterfallStepContext<O
 // @public
 export class WaterfallStepContext<O extends object = {}> extends DialogContext {
     constructor(dc: DialogContext, info: WaterfallStepInfo<O>);
+    // (undocumented)
     get index(): number;
     next(result?: any): Promise<DialogTurnResult>;
+    // (undocumented)
     get options(): O;
+    // (undocumented)
     get reason(): DialogReason;
+    // (undocumented)
     get result(): any;
+    // (undocumented)
     get values(): object;
 }
 

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -36,6 +36,7 @@
     "botframework-connector": "4.1.6",
     "globalize": "^1.4.2",
     "lodash": "^4.17.21",
+    "uuid": "^8.3.2",
     "zod": "~1.11.17"
   },
   "devDependencies": {
@@ -47,7 +48,7 @@
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-dialogs --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-dialogs .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Dialogs\" --readme none",
     "build:rollup": "yarn clean && yarn build && api-extractor run --verbose --local",
     "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",
-    "depcheck": "depcheck --config ../../.depcheckrc",
+    "depcheck": "depcheck --config ../../.depcheckrc --ignores uuid,sinon",
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "npm-run-all build test:mocha",

--- a/libraries/botbuilder-dialogs/src/choices/channel.ts
+++ b/libraries/botbuilder-dialogs/src/choices/channel.ts
@@ -73,9 +73,9 @@ export function hasMessageFeed(_channelId: string): boolean {
 
 /**
  * @private
- * @param channelId id of a channel
+ * @param _channelId id of a channel
  */
-export function maxActionTitleLength(channelId: string): number {
+export function maxActionTitleLength(_channelId: string): number {
     return 20;
 }
 

--- a/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
+++ b/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
@@ -89,6 +89,7 @@ export class ChoiceFactory {
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to speak for the message.
      * @param options (Optional) formatting options to use when rendering as a list.
+     * @returns A choice list.
      */
     public static forChannel(
         channelOrContext: string | TurnContext,
@@ -134,10 +135,9 @@ export class ChoiceFactory {
         }
     }
 
-
     /**
      * Creates a message [Activity](xref:botframework-schema.Activity) that includes a [Choice](xref:botbuilder-dialogs.Choice) list that have been added as `HeroCard`'s.
-     * 
+     *
      * @param choices Optional. The [Choice](xref:botbuilder-dialogs.Choice) list to add.
      * @param text Optional. Text of the message.
      * @param speak Optional. SSML text to be spoken by the bot on a speech-enabled channel.
@@ -172,6 +172,7 @@ export class ChoiceFactory {
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to speak for the message.
      * @param options (Optional) formatting options to tweak rendering of list.
+     * @returns An activity with choices as an inline list.
      */
     public static inline(
         choices: (string | Choice)[],
@@ -222,6 +223,7 @@ export class ChoiceFactory {
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to speak for the message.
      * @param options (Optional) formatting options to tweak rendering of list.
+     * @returns An activity with choices as a numbered list.
      */
     public static list(
         choices: (string | Choice)[],
@@ -263,6 +265,7 @@ export class ChoiceFactory {
      * @param choices List of choices to add.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to speak for the message.
+     * @returns An activity with choices as suggested actions
      */
     public static suggestedAction(choices: (string | Choice)[], text?: string, speak?: string): Partial<Activity> {
         // Map choices to actions
@@ -291,6 +294,7 @@ export class ChoiceFactory {
      * const choices = ChoiceFactory.toChoices(['red', 'green', 'blue']);
      * ```
      * @param choices List of choices to add.
+     * @returns A list of choices.
      */
     public static toChoices(choices: (string | Choice)[] | undefined): Choice[] {
         return (choices || [])

--- a/libraries/botbuilder-dialogs/src/choices/findChoices.ts
+++ b/libraries/botbuilder-dialogs/src/choices/findChoices.ts
@@ -130,6 +130,7 @@ export interface FoundChoice {
  * @param utterance The text or user utterance to search over. For an incoming 'message' activity you can simply use `context.activity.text`.
  * @param choices List of choices to search over.
  * @param options (Optional) options used to tweak the search that's performed.
+ * @returns The choice found
  */
 export function findChoices(
     utterance: string,

--- a/libraries/botbuilder-dialogs/src/choices/findValues.ts
+++ b/libraries/botbuilder-dialogs/src/choices/findValues.ts
@@ -78,9 +78,11 @@ export interface SortedValue {
  * functions like `findChoices()` and `recognizeChoices()` are layered above this function.  In most
  * cases its easier to just call one of the higher level functions instead but this function contains
  * the fuzzy search algorithm that drives choice recognition.
+ *
  * @param utterance The text or user utterance to search over.
  * @param values List of values to search over.
  * @param options (Optional) options used to tweak the search that's performed.
+ * @returns The results sorted by position in the utterance.
  */
 // tslint:disable-next-line:max-func-body-length
 export function findValues(
@@ -233,7 +235,7 @@ export function findValues(
     const usedTokens: { [index: number]: boolean } = {};
     matches.forEach((match: ModelResult<FoundValue>) => {
         // Apply filters
-        let add = !foundIndexes.hasOwnProperty(match.resolution.index);
+        let add = !Object.prototype.hasOwnProperty.call(foundIndexes, match.resolution.index);
         for (let i: number = match.start; i <= match.end; i++) {
             if (usedTokens[i]) {
                 add = false;

--- a/libraries/botbuilder-dialogs/src/choices/recognizeChoices.ts
+++ b/libraries/botbuilder-dialogs/src/choices/recognizeChoices.ts
@@ -40,6 +40,7 @@ import { ModelResult } from './modelResult';
  * @param utterance The text or user utterance to search over. For an incoming 'message' activity you can simply use `context.activity.text`.
  * @param choices List of choices to search over.
  * @param options (Optional) options used to tweak the search that's performed.
+ * @returns The found choice.
  */
 export function recognizeChoices(
     utterance: string,
@@ -63,7 +64,7 @@ export function recognizeChoices(
                     },
                 });
             }
-        } catch (e) {
+        } catch {
             // noop
             // TODO: Should this log an error or do something?
         }

--- a/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
+++ b/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
@@ -60,11 +60,11 @@ export type TokenizerFunction = (text: string, locale?: string) => Token[];
  * const stemmer = require('stemmer');
  *
  * function customTokenizer(text, locale) {
- * const tokens = defaultTokenizer(text, locale);
- * tokens.forEach((t) => {
- * t.normalized = stemmer(t.normalized);
- * });
- * return tokens;
+ *     const tokens = defaultTokenizer(text, locale);
+ *     tokens.forEach((t) => {
+ *         t.normalized = stemmer(t.normalized);
+ *     });
+ *     return tokens;
  * }
  *
  * const choices = ['red', 'green', 'blue'];

--- a/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
+++ b/libraries/botbuilder-dialogs/src/choices/tokenizer.ts
@@ -49,8 +49,10 @@ export type TokenizerFunction = (text: string, locale?: string) => Token[];
 /**
  * Simple tokenizer that breaks on spaces and punctuation.
  *
- * @remarks
- * The only normalization done is to lowercase the tokens. Developers can wrap this tokenizer with
+ * @param text The input text.
+ * @param _locale (Optional) The Locale.
+ * @returns A list of tokens
+ * @remarks The only normalization done is to lowercase the tokens. Developers can wrap this tokenizer with
  * their own function to perform additional normalization like [stemming](https://github.com/words/stemmer).
  *
  * ```JavaScript
@@ -58,11 +60,11 @@ export type TokenizerFunction = (text: string, locale?: string) => Token[];
  * const stemmer = require('stemmer');
  *
  * function customTokenizer(text, locale) {
- *     const tokens = defaultTokenizer(text, locale);
- *     tokens.forEach((t) => {
- *         t.normalized = stemmer(t.normalized);
- *     });
- *     return tokens;
+ * const tokens = defaultTokenizer(text, locale);
+ * tokens.forEach((t) => {
+ * t.normalized = stemmer(t.normalized);
+ * });
+ * return tokens;
  * }
  *
  * const choices = ['red', 'green', 'blue'];
@@ -70,7 +72,7 @@ export type TokenizerFunction = (text: string, locale?: string) => Token[];
  * const results = recognizeChoices(utterance, choices, { tokenizer: customTokenizer });
  * ```
  */
-export function defaultTokenizer(text: string, locale?: string): Token[] {
+export function defaultTokenizer(text: string, _locale?: string): Token[] {
     const tokens: Token[] = [];
     let token: Token | undefined;
     function appendToken(end: number): void {

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -7,7 +7,7 @@
  */
 import { telemetryTrackDialogView, TurnContext } from 'botbuilder-core';
 import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from './dialog';
-import { DialogContext, DialogState } from './dialogContext';
+import { DialogContext } from './dialogContext';
 import { DialogContainer } from './dialogContainer';
 
 const PERSISTED_DIALOG_STATE = 'dialogs';
@@ -83,11 +83,12 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * Dialog.BeginDialogAsync(DialogContext, object, CancellationToken) method
      * of the component dialog's initial dialog, as defined by InitialDialogId.
      * Override this method in a derived class to implement interrupt logic.
+     *
      * @param outerDC The parent [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional, initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
-     * If the task is successful, the result indicates whether the dialog is still 
+     * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
      */
     public async beginDialog(outerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
@@ -120,6 +121,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * Called when the dialog is _continued_, where it is the active dialog and the
      * user replies with a new [Activity](xref:botframework-schema.Activity).
      * If this method is *not* overridden, the dialog automatically ends when the user replies.
+     *
      * @param outerDC The parent [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
@@ -147,13 +149,13 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
     /**
      * Called when a child dialog on the parent's dialog stack completed this turn, returning
      * control to this dialog component.
-     * @param outerDc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param reason Reason why the dialog resumed.
-     * @param result Optional, value returned from the dialog that was called. The type
+     *
+     * @param outerDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param _reason Reason why the dialog resumed.
+     * @param _result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A Promise representing the asynchronous operation.
-     * @remarks
-     * If the task is successful, the result indicates whether this dialog is still
+     * @remarks If the task is successful, the result indicates whether this dialog is still
      * active after this dialog turn has been processed.
      * Generally, the child dialog was started with a call to
      * beginDialog(DialogContext, object) in the parent's
@@ -162,7 +164,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * If this method is *not* overridden, the dialog automatically calls its
      * RepromptDialog(ITurnContext, DialogInstance) when the user replies.
      */
-    public async resumeDialog(outerDC: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+    public async resumeDialog(outerDC: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult> {
         await this.checkForVersionChange(outerDC);
 
         // Containers are typically leaf nodes on the stack but the dev is free to push other dialogs
@@ -177,6 +179,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the dialog should re-prompt the user for input.
+     *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information for this dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -192,6 +195,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is ending.
+     *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information associated with the instance of this component
      * [Dialog](xref:botbuilder-dialogs.Dialog) on its parent's dialog stack.
@@ -213,7 +217,9 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Adds a child [Dialog](xref:botbuilder-dialogs.Dialog) or prompt to the components internal [DialogSet](xref:botbuilder-dialogs.DialogSet).
+     *
      * @param dialog The child [Dialog](xref:botbuilder-dialogs.Dialog) or prompt to add.
+     * @returns The dialog object with the last dialog added.
      * @remarks
      * The [Dialog.id](xref:botbuilder-dialogs.Dialog.id) of the first child added to the component will be assigned to the initialDialogId property.
      */
@@ -228,7 +234,9 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
 
     /**
      * Creates the inner dialog context
+     *
      * @param outerDC the outer dialog context
+     * @returns A dialog context.
      */
     public createChildContext(outerDC: DialogContext): DialogContext {
         return this.createInnerDC(outerDC, outerDC.activeDialog);
@@ -243,6 +251,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * [initialDialogId](#initialdialogid).
      * @param innerDC Dialog context for the components internal `DialogSet`.
      * @param options (Optional) options that were passed to the component by its parent.
+     * @returns A promise representing the asynchronous operation.
      */
     protected onBeginDialog(innerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
         return innerDC.beginDialog(this.initialDialogId, options);
@@ -255,6 +264,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * SHOULD be overridden by components that wish to perform custom interruption logic. The
      * default implementation calls `innerDC.continueDialog()`.
      * @param innerDC Dialog context for the components internal `DialogSet`.
+     * @returns A promise representing the asynchronous operation.
      */
     protected onContinueDialog(innerDC: DialogContext): Promise<DialogTurnResult> {
         return innerDC.continueDialog();
@@ -266,11 +276,12 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * @remarks
      * If the `reason` code is equal to `DialogReason.cancelCalled`, then any active child dialogs
      * will be cancelled before this method is called.
-     * @param context Context for the current turn of conversation.
-     * @param instance The components instance data within its parents dialog stack.
-     * @param reason The reason the component is ending.
+     * @param _context Context for the current turn of conversation.
+     * @param _instance The components instance data within its parents dialog stack.
+     * @param _reason The reason the component is ending.
+     * @returns A promise representing the asynchronous operation.
      */
-    protected onEndDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
+    protected onEndDialog(_context: TurnContext, _instance: DialogInstance, _reason: DialogReason): Promise<void> {
         return Promise.resolve();
     }
 
@@ -279,10 +290,11 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      *
      * @remarks
      * The active child dialog will have already been asked to reprompt before this method is called.
-     * @param context Context for the current turn of conversation.
-     * @param instance The instance of the current dialog.
+     * @param _context Context for the current turn of conversation.
+     * @param _instance The instance of the current dialog.
+     * @returns A promise representing the asynchronous operation.
      */
-    protected onRepromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
+    protected onRepromptDialog(_context: TurnContext, _instance: DialogInstance): Promise<void> {
         return Promise.resolve();
     }
 
@@ -295,6 +307,7 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
      * from the last active child dialog.
      * @param outerDC Dialog context for the parents `DialogSet`.
      * @param result Result returned by the last active child dialog. Can be a value of `undefined`.
+     * @returns A promise representing the asynchronous operation.
      */
     protected endComponent(outerDC: DialogContext, result: any): Promise<DialogTurnResult> {
         return outerDC.endDialog(result);

--- a/libraries/botbuilder-dialogs/src/configurable.ts
+++ b/libraries/botbuilder-dialogs/src/configurable.ts
@@ -14,7 +14,9 @@ import { Converter, ConverterFactory } from './converter';
 export abstract class Configurable {
     /**
      * Fluent method for configuring the object.
+     *
      * @param config Configuration settings to apply.
+     * @returns The configuration with the settings applied.
      */
     public configure(config: Record<string, unknown>): this {
         for (const key in config) {
@@ -46,6 +48,10 @@ export abstract class Configurable {
         return this;
     }
 
+    /**
+     * @param _property The property.
+     * @returns The converter.
+     */
     public getConverter(_property: string): Converter | ConverterFactory {
         return undefined;
     }

--- a/libraries/botbuilder-dialogs/src/dialog.ts
+++ b/libraries/botbuilder-dialogs/src/dialog.ts
@@ -9,7 +9,7 @@ import { Configurable } from './configurable';
 /**
  * Contains state information for an instance of a dialog on the stack.
  *
- * @typeparam T Optional. The type that represents state information for the dialog.
+ * @template T Optional. The type that represents state information for the dialog.
  *
  * @remarks
  * This contains information for a specific instance of a dialog on a dialog stack.
@@ -176,7 +176,7 @@ export interface DialogConfiguration {
  * Represents the result of a dialog context's attempt to begin, continue,
  * or otherwise manipulate one or more dialogs.
  *
- * @typeparam T Optional. The type that represents a result returned by the active dialog when it
+ * @template T Optional. The type that represents a result returned by the active dialog when it
  *      successfully completes.
  *
  * @remarks
@@ -260,6 +260,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      *
      * @remarks
      * This will be automatically generated if not specified.
+     * @returns The id of the dialog
      */
     public get id(): string {
         if (this._id === undefined) {
@@ -277,6 +278,8 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
 
     /**
      * Gets the telemetry client for this dialog.
+     *
+     * @returns The telemetry client.
      */
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
@@ -299,6 +302,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * an error will be thrown resulting in the bots error handler logic being run.
      *
      * Returning an empty string will disable version tracking for the component all together.
+     * @returns The current version.
      */
     public getVersion(): string {
         return this.id;
@@ -330,7 +334,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * When overridden in a derived class, continues the dialog.
      *
      * @param dc The context for the current dialog turn.
-     *
+     * @returns A promise representing the asynchronous operation.
      * @remarks
      * Derived dialogs that support multiple-turn conversations should override this method.
      * By default, this method signals that the dialog is complete and returns.
@@ -356,7 +360,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * @param reason The reason the dialog is resuming. This will typically be
      *      [DialogReason.endCalled](xref:botbuilder-dialogs.DialogReason.endCalled)
      * @param result Optional. The return value, if any, from the dialog that ended.
-     *
+     * @returns A promise representing the asynchronous operation.
      * @remarks
      * Derived dialogs that support multiple-turn conversations should override this method.
      * By default, this method signals that the dialog is complete and returns.
@@ -382,8 +386,8 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
     /**
      * When overridden in a derived class, reprompts the user for input.
      *
-     * @param context The context object for the turn.
-     * @param instance Current state information for this dialog.
+     * @param _context The context object for the turn.
+     * @param _instance Current state information for this dialog.
      *
      * @remarks
      * Derived dialogs that support validation and re-prompt logic should override this method.
@@ -396,16 +400,16 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * - [DialogContext.repromptDialog](xref:botbuilder-dialogs.DialogContext.repromptDialog)
      * - [Prompt](xref:botbuilder-dialogs.Prompt)
      */
-    public async repromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
+    public async repromptDialog(_context: TurnContext, _instance: DialogInstance): Promise<void> {
         // No-op by default
     }
 
     /**
      * When overridden in a derived class, performs clean up for the dialog before it ends.
      *
-     * @param context The context object for the turn.
-     * @param instance Current state information for this dialog.
-     * @param reason The reason the dialog is ending.
+     * @param _context The context object for the turn.
+     * @param _instance Current state information for this dialog.
+     * @param _reason The reason the dialog is ending.
      *
      * @remarks
      * Derived dialogs that need to perform logging or cleanup before ending should override this method.
@@ -419,7 +423,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * - [DialogContext.endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
      * - [DialogContext.replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
      */
-    public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
+    public async endDialog(_context: TurnContext, _instance: DialogInstance, _reason: DialogReason): Promise<void> {
         // No-op by default
     }
 
@@ -454,11 +458,11 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * This is a good place to perform interception of an event as returning `true` will prevent
      * any further bubbling of the event to the dialogs parents and will also prevent any child
      * dialogs from performing their default processing.
-     * @param dc The dialog context for the current turn of conversation.
-     * @param e The event being raised.
+     * @param _dc The dialog context for the current turn of conversation.
+     * @param _e The event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      */
-    protected async onPreBubbleEvent(dc: DialogContext, e: DialogEvent): Promise<boolean> {
+    protected async onPreBubbleEvent(_dc: DialogContext, _e: DialogEvent): Promise<boolean> {
         return false;
     }
 
@@ -468,11 +472,11 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * @remarks
      * This is a good place to perform default processing logic for an event. Returning `true` will
      * prevent any processing of the event by child dialogs.
-     * @param dc The dialog context for the current turn of conversation.
-     * @param e The event being raised.
+     * @param _dc The dialog context for the current turn of conversation.
+     * @param _e The event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      */
-    protected async onPostBubbleEvent(dc: DialogContext, e: DialogEvent): Promise<boolean> {
+    protected async onPostBubbleEvent(_dc: DialogContext, _e: DialogEvent): Promise<boolean> {
         return false;
     }
 
@@ -484,6 +488,6 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * ID's is `<dialog type>(this.hashedLabel('<dialog args>'))`.
      */
     protected onComputeId(): string {
-        throw new Error(`Dialog.onComputeId(): not implemented.`);
+        throw new Error('Dialog.onComputeId(): not implemented.');
     }
 }

--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -22,6 +22,7 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
 
     /**
      * Creates an inner dialog context for the containers active child.
+     *
      * @param dc Parents dialog context.
      * @returns A new dialog context for the active child or `undefined` if there is no active child.
      */
@@ -29,7 +30,9 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
 
     /**
      * Finds a child dialog that was previously added to the container.
+     *
      * @param dialogId ID of the dialog to lookup.
+     * @returns The Dialog if found; otherwise null.
      */
     public findDialog(dialogId: string): Dialog | undefined {
         return this.dialogs.find(dialogId);
@@ -41,6 +44,7 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
      *
      * @param dc The dialog context for the current turn of conversation.
      * @param e The event being raised.
+     * @returns True if the event is handled by the current dialog and bubbling should stop.
      */
     public async onDialogEvent(dc: DialogContext, e: DialogEvent): Promise<boolean> {
         const handled = await super.onDialogEvent(dc, e);
@@ -104,6 +108,8 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
 
     /**
      * Get the current telemetry client.
+     *
+     * @returns The telemetry client.
      */
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -19,6 +19,7 @@ import { DialogContextError } from './dialogContextError';
  *
  * @param dialogContext source dialog context from which enriched error properties are sourced
  * @param promise a promise to await inside a try-catch for error enrichment
+ * @returns A promise representing the asynchronous operation.
  */
 const wrapErrors = async <T>(dialogContext: DialogContext, promise: Promise<T>): Promise<T> => {
     try {
@@ -75,6 +76,7 @@ export interface DialogState {
 export class DialogContext {
     /**
      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     *
      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
@@ -85,6 +87,7 @@ export class DialogContext {
 
     /**
      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     *
      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
      * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
@@ -95,6 +98,7 @@ export class DialogContext {
 
     /**
      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     *
      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
@@ -147,7 +151,7 @@ export class DialogContext {
     public parent: DialogContext | undefined;
 
     /**
-     * Returns dialog context for child if the active dialog is a container.
+     * @returns The dialog context for child if the active dialog is a container.
      */
     public get child(): DialogContext | undefined {
         const instance = this.activeDialog;
@@ -163,7 +167,7 @@ export class DialogContext {
     }
 
     /**
-     * Returns the state information for the dialog on the top of the dialog stack, or `undefined` if
+     * @returns The state information for the dialog on the top of the dialog stack, or `undefined` if
      * the stack is empty.
      */
     public get activeDialog(): DialogInstance | undefined {
@@ -181,9 +185,9 @@ export class DialogContext {
     public services: TurnContextStateCollection = new TurnContextStateCollection();
 
     /**
-     * Returns the current dialog manager instance. This property is obsolete.
+     * @returns The current dialog manager instance. This property is obsolete.
      *
-     * @obsolete This property serves no function.
+     * This property serves no function (obsolete).
      */
     public get dialogManager(): DialogManager {
         return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
@@ -191,6 +195,7 @@ export class DialogContext {
 
     /**
      * Obtain the CultureInfo in DialogContext.
+     *
      * @returns a locale string.
      */
     public getLocale(): string {
@@ -215,7 +220,7 @@ export class DialogContext {
      *
      * @param dialogId ID of the dialog to start.
      * @param options Optional. Arguments to pass into the dialog when it starts.
-     *
+     * @returns A promise that represents the work queued to execute.
      * @remarks
      * If there's already an active dialog on the stack, that dialog will be paused until
      * it is again the top dialog on the stack.
@@ -264,7 +269,7 @@ export class DialogContext {
      * @param cancelParents Optional. If `true` all parent dialogs will be cancelled as well.
      * @param eventName Optional. Name of a custom event to raise as dialogs are cancelled. This defaults to [cancelDialog](xref:botbuilder-dialogs.DialogEvents.cancelDialog).
      * @param eventValue Optional. Value to pass along with custom cancellation event.
-     *
+     * @returns A promise that represents the work queued to execute.
      * @remarks
      * This calls each dialog's [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog) method before
      * removing the dialog from the stack.
@@ -291,7 +296,7 @@ export class DialogContext {
         if (this.stack.length > 0 || this.parent != undefined) {
             // Cancel all local and parent dialogs while checking for interception
             let notify = false;
-            let dc: DialogContext = this;
+            let dc: DialogContext = Object.assign(this);
             while (dc != undefined) {
                 if (dc.stack.length > 0) {
                     // Check to see if the dialog wants to handle the event
@@ -322,7 +327,7 @@ export class DialogContext {
      * Searches for a dialog with a given ID.
      *
      * @param dialogId ID of the dialog to search for.
-     *
+     * @returns The dialog with that id.
      * @remarks
      * If the dialog to start is not found in the [DialogSet](xref:botbuilder-dialogs.DialogSet) associated
      * with this dialog context, it attempts to find the dialog in its parent dialog context.
@@ -341,6 +346,7 @@ export class DialogContext {
 
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
+     *
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
      *      the activity to send as the initial prompt, or
@@ -363,6 +369,7 @@ export class DialogContext {
 
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
+     *
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
      * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
@@ -385,11 +392,13 @@ export class DialogContext {
 
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
+     *
      * @param dialogId ID of the prompt dialog to start.
      * @param promptOrOptions The text of the initial prompt to send the user,
      * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
      * @param choices Optional. Array of choices for the user to choose from,
      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * @returns A promise that represents the work queued to execute.
      * @remarks This helper method formats the object to use as the `options` parameter, and then calls
      * beginDialog to start the specified prompt dialog.
      *
@@ -423,6 +432,7 @@ export class DialogContext {
      * Continues execution of the active dialog, if there is one, by passing this dialog context to its
      * [Dialog.continueDialog](xref:botbuilder-dialogs.Dialog.continueDialog) method.
      *
+     * @returns A promise that represents the work queued to execute.
      * @remarks
      * After the call completes, you can check the turn context's [responded](xref:botbuilder-core.TurnContext.responded)
      * property to determine if the dialog sent a reply to the user.
@@ -478,6 +488,7 @@ export class DialogContext {
      *      on the stack, or if this was the last dialog on the stack, a parent dialog context or
      *      the bot's turn handler.
      *
+     * @returns A promise that represents the work queued to execute.
      * @remarks
      * The _parent_ dialog is the next dialog on the dialog stack, if there is one. This method
      * calls the parent's [Dialog.resumeDialog](xref:botbuilder-dialogs.Dialog.resumeDialog) method,
@@ -531,6 +542,7 @@ export class DialogContext {
      *
      * @param dialogId ID of the dialog to start.
      * @param options Optional. Arguments to pass into the new dialog when it starts.
+     * @returns A promise that represents the work queued to execute.
      *
      * @remarks
      * This is particularly useful for creating a loop or redirecting to another dialog.
@@ -588,6 +600,7 @@ export class DialogContext {
 
     /**
      * Searches for a dialog with a given ID.
+     *
      * @remarks
      * Emits a named event for the current dialog, or someone who started it, to handle.
      * @param name Name of the event to raise.
@@ -605,14 +618,15 @@ export class DialogContext {
         };
 
         // Find starting dialog
-        let dc: DialogContext = this;
+        let dc: DialogContext = Object.assign(this);
         if (fromLeaf) {
-            while (true) {
+            let searching = true;
+            while (searching) {
                 const childDc = dc.child;
                 if (childDc != undefined) {
                     dc = childDc;
                 } else {
-                    break;
+                    searching = false;
                 }
             }
         }

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -55,7 +55,8 @@ export async function runDialog(
     }
 
     const dialogSet = new DialogSet(accessor);
-    dialogSet.telemetryClient = context.turnState.get<BotTelemetryClient>(BotTelemetryClientKey) ?? dialog.telemetryClient;
+    dialogSet.telemetryClient =
+        context.turnState.get<BotTelemetryClient>(BotTelemetryClientKey) ?? dialog.telemetryClient;
 
     dialogSet.add(dialog);
 
@@ -64,6 +65,13 @@ export async function runDialog(
     await internalRun(context, dialog.id, dialogContext);
 }
 
+/**
+ * @param context The turn context.
+ * @param dialogId The dialog id.
+ * @param dialogContext The dialog context.
+ * @param dialogStateManagerConfiguration (optional) The dialog state manager configuration.
+ * @returns The dialogs turn result
+ */
 export async function internalRun(
     context: TurnContext,
     dialogId: string,
@@ -174,8 +182,9 @@ async function innerRun(
 /**
  * Helper to determine if we should send an EoC to the parent or not.
  *
- * @param context
- * @param turnResult
+ * @param context The turn context.
+ * @param turnResult The turn result.
+ * @returns True if send an EoC is needed, otherwise, false.
  */
 export function shouldSendEndOfConversationToParent(context: TurnContext, turnResult: DialogTurnResult): boolean {
     if (!(turnResult.status == DialogTurnStatus.complete || turnResult.status == DialogTurnStatus.cancelled)) {
@@ -241,7 +250,8 @@ export function isFromParentToSkill(context: TurnContext): boolean {
 const sendStateSnapshotTrace = async (dialogContext: DialogContext): Promise<void> => {
     const adapter = dialogContext.context.adapter;
     const claimIdentity = dialogContext.context.turnState.get<ClaimsIdentity>(adapter.BotIdentityKey);
-    const traceLabel = claimIdentity && SkillValidation.isSkillClaim(claimIdentity.claims) ? 'Skill State' : 'Bot State';
+    const traceLabel =
+        claimIdentity && SkillValidation.isSkillClaim(claimIdentity.claims) ? 'Skill State' : 'Bot State';
 
     // Send trace of memory
     const snapshot = getActiveDialogContext(dialogContext).state.getMemorySnapshot();

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -94,6 +94,8 @@ export class DialogManager extends Configurable {
 
     /**
      * Values that will be copied to the `TurnContext.turnState` at the beginning of each turn.
+     *
+     * @returns The initial turn state.
      */
     public get initialTurnState(): TurnContextStateCollection {
         return this._initialTurnState;
@@ -157,7 +159,7 @@ export class DialogManager extends Configurable {
     public async onTurn(context: TurnContext): Promise<DialogManagerResult> {
         // Ensure properly configured
         if (!this._rootDialogId) {
-            throw new Error(`DialogManager.onTurn: the bot's 'rootDialog' has not been configured.`);
+            throw new Error("DialogManager.onTurn: the bot's 'rootDialog' has not been configured.");
         }
 
         // Copy initial turn state to context
@@ -174,7 +176,7 @@ export class DialogManager extends Configurable {
         }
 
         if (!this.conversationState) {
-            throw new Error(`DialogManager.onTurn: the bot's 'conversationState' has not been configured.`);
+            throw new Error("DialogManager.onTurn: the bot's 'conversationState' has not been configured.");
         }
         botStateSet.add(this.conversationState);
 

--- a/libraries/botbuilder-dialogs/src/dialogSet.ts
+++ b/libraries/botbuilder-dialogs/src/dialogSet.ts
@@ -97,6 +97,7 @@ export class DialogSet {
      *
      * @remarks
      * This hash is persisted to state storage and used to detect changes to a dialog set.
+     * @returns The version as string.
      */
     public getVersion(): string {
         if (!this._version) {
@@ -123,17 +124,18 @@ export class DialogSet {
      * of "duplicate2".
      * @param dialog The dialog or prompt to add.
      * If a telemetryClient is present on the dialog set, it will be added to each dialog.
+     * @returns The dialog set after the operation is complete.
      */
     public add<T extends Dialog>(dialog: T): this {
         if (!(dialog instanceof Dialog)) {
-            throw new Error(`DialogSet.add(): Invalid dialog being added.`);
+            throw new Error('DialogSet.add(): Invalid dialog being added.');
         }
 
         // Ensure new version hash is computed
         this._version = undefined;
 
         // Ensure dialogs ID is unique.
-        if (this.dialogs.hasOwnProperty(dialog.id)) {
+        if (Object.prototype.hasOwnProperty.call(this.dialogs, dialog.id)) {
             // If we are trying to add the same exact instance, it's not a name collision.
             // No operation required since the instance is already in the dialog set.
             if (this.dialogs[dialog.id] === dialog) {
@@ -143,11 +145,12 @@ export class DialogSet {
             // If we are adding a new dialog with a conflicting name, add a suffix to avoid
             // dialog name collisions.
             let nextSuffix = 2;
-            while (true) {
+            let searching = true;
+            while (searching) {
                 const suffixId = dialog.id + nextSuffix.toString();
-                if (!this.dialogs.hasOwnProperty(suffixId)) {
+                if (!Object.prototype.hasOwnProperty.call(this.dialogs, suffixId)) {
                     dialog.id = suffixId;
-                    break;
+                    searching = false;
                 } else {
                     nextSuffix++;
                 }
@@ -174,12 +177,14 @@ export class DialogSet {
 
     /**
      * Creates a dialog context which can be used to work with the dialogs in the set.
+     *
      * @param context Context for the current turn of conversation with the user.
+     * @returns The dialog context
      */
     public async createContext(context: TurnContext): Promise<DialogContext> {
         if (!this.dialogState) {
             throw new Error(
-                `DialogSet.createContext(): the dialog set was not bound to a stateProperty when constructed.`
+                'DialogSet.createContext(): the dialog set was not bound to a stateProperty when constructed.'
             );
         }
         const state: DialogState = await this.dialogState.get(context, { dialogStack: [] } as DialogState);
@@ -197,13 +202,16 @@ export class DialogSet {
      * const dialog = dialogs.find('greeting');
      * ```
      * @param dialogId ID of the dialog or prompt to lookup.
+     * @returns The dialog if found; otherwise undefined.
      */
     public find(dialogId: string): Dialog | undefined {
-        return this.dialogs.hasOwnProperty(dialogId) ? this.dialogs[dialogId] : undefined;
+        return Object.prototype.hasOwnProperty.call(this.dialogs, dialogId) ? this.dialogs[dialogId] : undefined;
     }
 
     /**
      * Set the telemetry client for this dialog set and apply it to all current dialogs.
+     *
+     * @returns The telemetry client.
      */
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;

--- a/libraries/botbuilder-dialogs/src/dialogsBotComponent.ts
+++ b/libraries/botbuilder-dialogs/src/dialogsBotComponent.ts
@@ -28,7 +28,14 @@ import {
 
 const InitialSettings = z.record(z.unknown());
 
+/**
+ * Defines dialogs bot component.
+ */
 export class DialogsBotComponent extends BotComponent {
+    /**
+     * @param services Runtime service collection.
+     * @param configuration A [Configuration](xref:botbuilder-dialogs-adaptive-runtime-core.Configuration) instance.
+     */
     configureServices(services: ServiceCollection, configuration: Configuration): void {
         services.composeFactory<MemoryScope[]>('memoryScopes', (memoryScopes) => {
             const rootConfiguration = configuration.get();

--- a/libraries/botbuilder-dialogs/src/dialogsComponentRegistration.ts
+++ b/libraries/botbuilder-dialogs/src/dialogsComponentRegistration.ts
@@ -22,6 +22,9 @@ export class DialogsComponentRegistration
         pathResolvers: [],
     });
 
+    /**
+     * Configures the services.
+     */
     constructor() {
         super();
 

--- a/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
+++ b/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts
@@ -99,7 +99,6 @@ export class DialogStateManager {
      *
      * @remarks
      * This always returns a CLONE of the memory, any modifications to the result will not affect memory.
-     * @param T The value type to return.
      * @param pathExpression Path expression to use.
      * @param defaultValue (Optional) default value to use if the path isn't found. May be a function that returns the default value to use.
      * @returns The found value or undefined if not found and no `defaultValue` specified.
@@ -130,6 +129,7 @@ export class DialogStateManager {
 
     /**
      * Set memory to value.
+     *
      * @param pathExpression Path to memory.
      * @param value Value to set.
      */
@@ -138,7 +138,7 @@ export class DialogStateManager {
         const tpath = this.transformPath(pathExpression);
         const segments = this.parsePath(tpath);
         if (segments.length < 1) {
-            throw new Error(`DialogStateManager.setValue: path wasn't specified.`);
+            throw new Error("DialogStateManager.setValue: path wasn't specified.");
         }
 
         // Track changes
@@ -196,7 +196,8 @@ export class DialogStateManager {
 
     /**
      * Delete property from memory
-     * @param path The leaf property to remove.
+     *
+     * @param pathExpression The leaf property to remove.
      */
     public deleteValue(pathExpression: string): void {
         // Get path segments
@@ -260,6 +261,8 @@ export class DialogStateManager {
 
     /**
      * Deletes all of the backing memory for a given scope.
+     *
+     * @param name The name of the scope.
      */
     public async deleteScopesMemory(name: string): Promise<void> {
         name = name.toLowerCase();
@@ -397,6 +400,7 @@ export class DialogStateManager {
 
     /**
      * Transform the path using the registered path transformers.
+     *
      * @param pathExpression The path to transform.
      * @returns The transformed path.
      */
@@ -412,6 +416,7 @@ export class DialogStateManager {
 
     /**
      * Gets all memory scopes suitable for logging.
+     *
      * @returns Object which represents all memory scopes.
      */
     public getMemorySnapshot(): object {
@@ -427,6 +432,7 @@ export class DialogStateManager {
 
     /**
      * Track when specific paths are changed.
+     *
      * @param paths Paths to track.
      * @returns Normalized paths to pass to [anyPathChanged()](#anypathchanged).
      */
@@ -450,6 +456,7 @@ export class DialogStateManager {
 
     /**
      * Check to see if any path has changed since watermark.
+     *
      * @param counter Time counter to compare to.
      * @param paths Paths from [trackPaths()](#trackpaths) to check.
      * @returns True if any path has changed since counter.
@@ -609,6 +616,7 @@ export class DialogStateManager {
 
     /**
      * Gets the version number.
+     *
      * @returns A string with the version number.
      */
     public version(): string {

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/aliasPathResolver.ts
@@ -17,6 +17,7 @@ export class AliasPathResolver implements PathResolver {
 
     /**
      * Initializes a new instance of the [AliasPathResolver](xref:botbuilder-dialogs.AliasPathResolver) class.
+     *
      * @param alias Alias name.
      * @param prefix Prefix name.
      * @param postfix Postfix name.
@@ -29,6 +30,7 @@ export class AliasPathResolver implements PathResolver {
 
     /**
      * Transforms the path.
+     *
      * @param path Path to inspect.
      * @returns The transformed path.
      */

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/atPathResolver.ts
@@ -23,6 +23,7 @@ export class AtPathResolver extends AliasPathResolver {
 
     /**
      * Transforms the path.
+     *
      * @param path Path to inspect.
      * @returns The transformed path.
      */

--- a/libraries/botbuilder-dialogs/src/memory/pathResolvers/pathResolver.ts
+++ b/libraries/botbuilder-dialogs/src/memory/pathResolvers/pathResolver.ts
@@ -9,6 +9,7 @@
 export interface PathResolver {
     /**
      * Transform the path
+     *
      * @param path Path to inspect.
      * @returns Transformed path
      */

--- a/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/botStateMemoryScope.ts
@@ -17,6 +17,7 @@ export class BotStateMemoryScope extends MemoryScope {
 
     /**
      * Initializes a new instance of the [BotStateMemoryScope](xref:adaptive-expressions.BotStateMemoryScope) class.
+     *
      * @param name name of the property.
      */
     public constructor(name: string) {
@@ -25,7 +26,9 @@ export class BotStateMemoryScope extends MemoryScope {
 
     /**
      * Get the backing memory for this scope.
-     * @param dc current dialog context
+     *
+     * @param dc current dialog context.
+     * @returns The context for the current turn.
      */
     public getMemory(dc: DialogContext): object {
         const botState: BotState = dc.context.turnState.get(this.stateKey);
@@ -38,19 +41,21 @@ export class BotStateMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
+     *
      * @param dc current dialog context
-     * @param memory memory
+     * @param _memory memory
      */
-    public setMemory(dc: DialogContext, memory: object): void {
+    public setMemory(dc: DialogContext, _memory: object): void {
         const botState = dc.context.turnState.get(this.stateKey);
         if (!botState) {
             throw new Error(`${this.stateKey} is not available.`);
         }
-        throw new Error(`You cannot replace the root BotState object.`);
+        throw new Error('You cannot replace the root BotState object.');
     }
 
     /**
      * Populates the state cache for this [BotState](xref:botbuilder-core.BotState) from the storage layer.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param force Optional, `true` to overwrite any existing state cache;
      * or `false` to load state from storage only if the cache doesn't already exist.
@@ -65,6 +70,7 @@ export class BotStateMemoryScope extends MemoryScope {
 
     /**
      * Writes the state cache for this [BotState](xref:botbuilder-core.BotState) to the storage layer.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param force Optional, `true` to save the state cache to storage;
      * or `false` to save state to storage only if a property in the cache has changed.
@@ -79,10 +85,11 @@ export class BotStateMemoryScope extends MemoryScope {
 
     /**
      * Deletes any state in storage and the cache for this [BotState](xref:botbuilder-core.BotState).
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
+     *
+     * @param _dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns A Promise that represents the work queued to execute.
      */
-    public async delete(dc: DialogContext): Promise<void> {
+    public async delete(_dc: DialogContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/classMemoryScope.ts
@@ -16,6 +16,7 @@ import { Dialog } from '../../dialog';
 export class ClassMemoryScope extends MemoryScope {
     /**
      * Initializes a new instance of the [ClassMemoryScope](xref:botbuilder-dialogs.ClassMemoryScope) class.
+     *
      * @param name Name of the scope class.
      */
     public constructor(name = ScopePath.class) {
@@ -24,6 +25,7 @@ export class ClassMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
@@ -36,7 +38,7 @@ export class ClassMemoryScope extends MemoryScope {
                 const clone: object = {};
                 for (const key in dialog) {
                     const prop = dialog[key];
-                    if (dialog.hasOwnProperty(key) && typeof prop != 'function') {
+                    if (Object.prototype.hasOwnProperty.call(dialog, key) && typeof prop != 'function') {
                         if (isExpression(prop)) {
                             const { value, error } = prop.tryGetValue(dc.state);
                             if (!error) {
@@ -57,7 +59,9 @@ export class ClassMemoryScope extends MemoryScope {
 
     /**
      * Override to find the dialog instance referenced by the scope.
+     *
      * @param dc Current dialog context.
+     * @returns The dialog instance referenced.
      */
     protected onFindDialog(dc: DialogContext): Dialog {
         return dc.findDialog(dc.activeDialog.id);

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogClassMemoryScope.ts
@@ -25,7 +25,7 @@ export class DialogClassMemoryScope extends ClassMemoryScope {
     /**
      * @protected
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
-     * @retuns The current [Dialog](xref:botbuilder-dialogs.Dialog).
+     * @returns The current [Dialog](xref:botbuilder-dialogs.Dialog).
      */
     protected onFindDialog(dc: DialogContext): Dialog {
         // Is the active dialog a container?

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogContextMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogContextMemoryScope.ts
@@ -23,6 +23,7 @@ export class DialogContextMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
+     *
      * @param dc The `DialogContext` object for this turn.
      * @returns Memory for the scope.
      */

--- a/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/dialogMemoryScope.ts
@@ -23,6 +23,7 @@ export class DialogMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
@@ -41,12 +42,13 @@ export class DialogMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
-            throw new Error(`DialogMemoryScope.setMemory: undefined memory object passed in.`);
+            throw new Error('DialogMemoryScope.setMemory: undefined memory object passed in.');
         }
 
         // If active dialog is a container dialog then "dialog" binds to it.
@@ -59,7 +61,7 @@ export class DialogMemoryScope extends MemoryScope {
 
         // If there's no active dialog then throw an error.
         if (!parent.activeDialog) {
-            throw new Error(`DialogMemoryScope.setMemory: no active dialog found.`);
+            throw new Error('DialogMemoryScope.setMemory: no active dialog found.');
         }
 
         parent.activeDialog.state = memory;

--- a/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/memoryScope.ts
@@ -13,6 +13,7 @@ import { DialogContext } from '../../dialogContext';
 export abstract class MemoryScope {
     /**
      * Initializes a new instance of the [MemoryScope](xref:botbuilder-dialogs.MemoryScope) class.
+     *
      * @param name Name of the scope.
      * @param includeInSnapshot Boolean value indicating whether this memory
      * should be included in snapshot. Default value is true.
@@ -34,41 +35,46 @@ export abstract class MemoryScope {
 
     /**
      * Get the backing memory for this scope
+     *
      * @param dc Current dialog context.
-     * @returns memory for the scope
+     * @returns Memory for the scope.
      */
     public abstract getMemory(dc: DialogContext): object;
 
     /**
      * Changes the backing object for the memory scope.
-     * @param dc Current dialog context
-     * @param memory memory to assign
+     *
+     * @param _dc Current dialog context.
+     * @param _memory Memory to assign.
      */
-    public setMemory(dc: DialogContext, memory: object): void {
+    public setMemory(_dc: DialogContext, _memory: object): void {
         throw new Error(`MemoryScope.setMemory: The '${this.name}' memory scope is read-only.`);
     }
 
     /**
      * Loads a scopes backing memory at the start of a turn.
-     * @param dc Current dialog context.
+     *
+     * @param _dc Current dialog context.
      */
-    public async load(dc: DialogContext): Promise<void> {
+    public async load(_dc: DialogContext): Promise<void> {
         // No initialization by default.
     }
 
     /**
      * Saves a scopes backing memory at the end of a turn.
-     * @param dc Current dialog context.
+     *
+     * @param _dc Current dialog context.
      */
-    public async saveChanges(dc: DialogContext): Promise<void> {
+    public async saveChanges(_dc: DialogContext): Promise<void> {
         // No initialization by default.
     }
 
     /**
      * Deletes the backing memory for a scope.
-     * @param dc Current dialog context.
+     *
+     * @param _dc Current dialog context.
      */
-    public async delete(dc: DialogContext): Promise<void> {
+    public async delete(_dc: DialogContext): Promise<void> {
         throw new Error(`MemoryScope.delete: The '${this.name}' memory scope can't be deleted.`);
     }
 }

--- a/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/settingsMemoryScope.ts
@@ -87,6 +87,9 @@ export class SettingsMemoryScope extends MemoryScope {
         return settings;
     }
 
+    /**
+     * @param dc The dialog context.
+     */
     public async load(dc: DialogContext): Promise<void> {
         if (this.initialSettings) {
             // filter initialSettings

--- a/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/thisMemoryScope.ts
@@ -22,6 +22,7 @@ export class ThisMemoryScope extends MemoryScope {
 
     /**
      * Gets the backing memory for this scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @returns The memory for the scope.
      */
@@ -31,16 +32,17 @@ export class ThisMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
-            throw new Error(`ThisMemoryScope.setMemory: undefined memory object passed in.`);
+            throw new Error('ThisMemoryScope.setMemory: undefined memory object passed in.');
         }
 
         if (!dc.activeDialog) {
-            throw new Error(`ThisMemoryScope.setMemory: no active dialog found.`);
+            throw new Error('ThisMemoryScope.setMemory: no active dialog found.');
         }
 
         dc.activeDialog.state = memory;

--- a/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
+++ b/libraries/botbuilder-dialogs/src/memory/scopes/turnMemoryScope.ts
@@ -27,6 +27,7 @@ export class TurnMemoryScope extends MemoryScope {
 
     /**
      * Get the backing memory for this scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for this turn.
      * @returns The memory for the scope.
      */
@@ -42,12 +43,13 @@ export class TurnMemoryScope extends MemoryScope {
 
     /**
      * Changes the backing object for the memory scope.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for this turn.
      * @param memory Memory object to set for the scope.
      */
     public setMemory(dc: DialogContext, memory: object): void {
         if (memory == undefined) {
-            throw new Error(`TurnMemoryScope.setMemory: undefined memory object passed in.`);
+            throw new Error('TurnMemoryScope.setMemory: undefined memory object passed in.');
         }
 
         dc.context.turnState.set(TURN_STATE, memory);

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -21,6 +21,7 @@ import { PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt
 export class ActivityPrompt extends Dialog {
     /**
      * Creates a new ActivityPrompt instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator Validator that will be called each time a new activity is received.
      */
@@ -30,12 +31,13 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
      * turn of the conversation.
      * @param options [PromptOptions](xref:botbuilder-dialogs.PromptOptions), additional
      * information to pass to the prompt being started.
      * @returns A `Promise` representing the asynchronous operation.
-     * @remarks 
+     * @remarks
      * If the promise is successful, the result indicates whether the prompt is still
      * active after the turn has been processed by the prompt.
      */
@@ -62,6 +64,7 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
      * turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
@@ -110,15 +113,16 @@ export class ActivityPrompt extends Dialog {
     /**
      * Called when a prompt dialog resumes being the active dialog on the dialog stack, such as
      * when the previous active dialog on the stack completes.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn
      * of the conversation.
-     * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), an enum indicating why
+     * @param _reason [DialogReason](xref:botbuilder-dialogs.DialogReason), an enum indicating why
      * the dialog resumed.
-     * @param result Optional. Value returned from the previous dialog on the stack.
+     * @param _result Optional. Value returned from the previous dialog on the stack.
      * The type of the value returned is dependent on the previous dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+    public async resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult> {
         // Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
         // on top of the stack which will result in the prompt receiving an unexpected call to
         // resumeDialog() when the pushed on dialog ends.
@@ -131,6 +135,7 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog has been requested to re-prompt the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), the instance
@@ -141,9 +146,10 @@ export class ActivityPrompt extends Dialog {
         const state: ActivityPromptState = instance.state as ActivityPromptState;
         await this.onPrompt(context, state.state, state.options, false);
     }
-  
+
     /**
      * When overridden in a derived class, prompts the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
@@ -167,17 +173,18 @@ export class ActivityPrompt extends Dialog {
 
     /**
      * When overridden in a derived class, attempts to recognize the incoming [Activity](xref:botframework-schema.Activity).
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
      * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: object,
-        options: PromptOptions
+        _state: object,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<Activity>> {
         return { succeeded: true, value: context.activity };
     }

--- a/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
@@ -17,6 +17,7 @@ import { Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from '
 export class AttachmentPrompt extends Prompt<Attachment[]> {
     /**
      * Creates a new `AttachmentPrompt` instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
      */
@@ -26,6 +27,7 @@ export class AttachmentPrompt extends Prompt<Attachment[]> {
 
     /**
      * Prompts the user for input.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
      * @param options A prompt options object constructed from the options initially provided
@@ -49,16 +51,17 @@ export class AttachmentPrompt extends Prompt<Attachment[]> {
 
     /**
      * Attempts to recognize the user's input.
+     *
      * @param context Context for the current turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A prompt options object constructed from the options initially provided
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A prompt options object constructed from the options initially provided
      * in the call to Prompt.
      * @returns A Promise representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: any,
-        options: PromptOptions
+        _state: any,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<Attachment[]>> {
         const value: Attachment[] = context.activity.attachments;
 

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -55,6 +55,7 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     /**
      * Creates a new `ChoicePrompt` instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt. If the validator replies with a message no additional retry prompt will be sent.
      * @param defaultLocale (Optional) locale to use if `dc.context.activity.locale` not specified. Defaults to a value of `en-us`.
@@ -89,6 +90,7 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     /**
      * Prompts the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
@@ -127,7 +129,8 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     /**
      * Attempts to recognize the user's input.
-     * @param context [TurnContext](xref:botbuilder-core.TurnContext) context for the current 
+     *
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext) context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
      * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -56,9 +56,11 @@ export class ConfirmPrompt extends Prompt<boolean> {
 
     /**
      * Creates a new ConfirmPrompt instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
      * @param defaultLocale (Optional) locale to use if `TurnContext.activity.locale` is not specified. Defaults to a value of `en-us`.
+     * @param choiceDefaults (Optional) set to empty if not specified. The choice defaults.
      */
     public constructor(
         dialogId: string,
@@ -91,6 +93,7 @@ export class ConfirmPrompt extends Prompt<boolean> {
 
     /**
      * Prompts the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
@@ -124,17 +127,18 @@ export class ConfirmPrompt extends Prompt<boolean> {
 
     /**
      * Attempts to recognize the user's input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
      * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: any,
-        options: PromptOptions
+        _state: any,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<boolean>> {
         const result: PromptRecognizerResult<boolean> = { succeeded: false };
         const activity = context.activity;

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -45,6 +45,7 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
 
     /**
      * Creates a new DateTimePrompt instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
      * @param defaultLocale (Optional) locale to use if `TurnContext.activity.locale` is not specified. Defaults to a value of `en-us`.
@@ -56,6 +57,7 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
 
     /**
      * Prompts the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
@@ -80,17 +82,18 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
 
     /**
      * Attempts to recognize the user's input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
      * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: any,
-        options: PromptOptions
+        _state: any,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<DateTimeResolution[]>> {
         const result: PromptRecognizerResult<DateTimeResolution[]> = { succeeded: false };
         const activity: Activity = context.activity;

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -28,6 +28,7 @@ export class NumberPrompt extends Prompt<number> {
 
     /**
      * Creates a new NumberPrompt instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
      * @param defaultLocale (Optional) locale to use if `TurnContext.activity.locale` is not specified. Defaults to a value of `en-us`.
@@ -39,7 +40,8 @@ export class NumberPrompt extends Prompt<number> {
 
     /**
      * Prompts the user for input.
-     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current 
+     *
+     * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
      * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
@@ -63,17 +65,18 @@ export class NumberPrompt extends Prompt<number> {
 
     /**
      * Attempts to recognize the user's input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
      * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: unknown,
-        options: PromptOptions
+        _state: unknown,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<number>> {
         const result: PromptRecognizerResult<number> = { succeeded: false };
         const activity = context.activity;
@@ -96,7 +99,7 @@ export class NumberPrompt extends Prompt<number> {
             let numberParser: (value: string) => number;
             try {
                 numberParser = parser.numberParser();
-            } catch (err) {
+            } catch {
                 numberParser = Globalize(this.getCultureFormattedForGlobalize(defaultLocale)).numberParser();
             }
 

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -157,6 +157,7 @@ export class OAuthPrompt extends Dialog {
     private readonly PersistedCaller: string = 'botbuilder-dialogs.caller';
     /**
      * Creates a new OAuthPrompt instance.
+     *
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param settings Settings used to configure the prompt.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
@@ -213,6 +214,7 @@ export class OAuthPrompt extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn
      * of the conversation.
      * @returns A `Promise` representing the asynchronous operation.
@@ -279,8 +281,10 @@ export class OAuthPrompt extends Dialog {
 
     /**
      * Attempts to retrieve the stored token for the current user.
+     *
      * @param context Context reference the user that's being looked up.
      * @param code (Optional) login code received from the user.
+     * @returns The token for the current user, or an exception if it fails.
      */
     public async getUserToken(context: TurnContext, code?: string): Promise<TokenResponse | undefined> {
         return UserTokenAccess.getUserToken(context, this.settings, code);
@@ -300,6 +304,7 @@ export class OAuthPrompt extends Dialog {
      * await prompt.signOutUser(context);
      * ```
      * @param context Context referencing the user that's being signed out.
+     * @returns A promise representing the asynchronous operation.
      */
     public async signOutUser(context: TurnContext): Promise<void> {
         return UserTokenAccess.signOutUser(context, this.settings);
@@ -585,7 +590,7 @@ export class OAuthPrompt extends Dialog {
      * @private
      */
     private static isTokenExchangeRequest(obj: unknown): obj is TokenExchangeInvokeRequest {
-        if (obj.hasOwnProperty('token')) {
+        if (Object.prototype.hasOwnProperty.call(obj, 'token')) {
             return true;
         }
         return false;

--- a/libraries/botbuilder-dialogs/src/prompts/prompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/prompt.ts
@@ -79,6 +79,7 @@ export interface PromptOptions {
 
 /**
  * Result returned by a prompts recognizer function.
+ *
  * @param T Type of value being recognized.
  */
 export interface PromptRecognizerResult<T> {
@@ -116,6 +117,7 @@ export type PromptValidator<T> = (prompt: PromptValidatorContext<T>) => Promise<
 
 /**
  * Contextual information passed to a custom `PromptValidator`.
+ *
  * @param T Type of recognizer result being validated.
  */
 export interface PromptValidatorContext<T> {
@@ -162,11 +164,13 @@ export interface PromptValidatorContext<T> {
 
 /**
  * Base class for all prompts.
+ *
  * @param T Type of value being returned by the prompts recognizer function.
  */
 export abstract class Prompt<T> extends Dialog {
     /**
      * Creates a new Prompt instance.
+     *
      * @param dialogId Unique ID of the prompt within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) custom validator used to provide additional validation and re-prompting logic for the prompt.
      */
@@ -176,6 +180,7 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
      * turn of the conversation.
      * @param options Optional. [PromptOptions](xref:botbuilder-dialogs.PromptOptions),
@@ -208,6 +213,7 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog is the active dialog and the user replied with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
      * @remarks
@@ -267,6 +273,7 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called before an event is bubbled to its parent.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param event [DialogEvent](xref:botbuilder-dialogs.DialogEvent), the event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
@@ -293,16 +300,17 @@ export abstract class Prompt<T> extends Dialog {
     /**
      * Called when a prompt dialog resumes being the active dialog on the dialog stack, such as
      * when the previous active dialog on the stack completes.
+     *
      * @param dc The DialogContext for the current turn of the conversation.
-     * @param reason An enum indicating why the dialog resumed.
-     * @param result Optional, value returned from the previous dialog on the stack.
+     * @param _reason An enum indicating why the dialog resumed.
+     * @param _result Optional, value returned from the previous dialog on the stack.
      * The type of the value returned is dependent on the previous dialog.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
      */
-    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+    public async resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult> {
         // Prompts are typically leaf nodes on the stack but the dev is free to push other dialogs
         // on top of the stack which will result in the prompt receiving an unexpected call to
         // resumeDialog() when the pushed on dialog ends.
@@ -315,6 +323,7 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called when a prompt dialog has been requested to re-prompt the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), the instance
@@ -328,6 +337,7 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Called anytime the derived class should send the user a prompt.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param state Additional state being persisted for the prompt.
      * @param options Options that the prompt was started with in the call to `DialogContext.prompt()`.
@@ -358,11 +368,13 @@ export abstract class Prompt<T> extends Dialog {
 
     /**
      * Helper function to compose an output activity containing a set of choices.
+     *
      * @param prompt The prompt to append the users choices to.
      * @param channelId ID of the channel the prompt is being sent to.
      * @param choices List of choices to append.
      * @param style Configured style for the list of choices.
      * @param options (Optional) options to configure the underlying ChoiceFactory call.
+     * @returns The output activity containing the set of choices.
      */
     protected appendChoices(
         prompt: string | Partial<Activity>,

--- a/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
@@ -3,36 +3,42 @@ import { Culture } from '@microsoft/recognizers-text-suite';
 export interface PromptCultureModel {
     /**
      * Culture Model's Locale.
+     *
      * @example
      * "en-US"
      */
     locale: string;
     /**
      * Culture Model's InlineSeparator.
+     *
      * @example
      * ", "
      */
     separator: string;
     /**
      * Culture Model's InlineOr.
+     *
      * @example
      * " or "
      */
     inlineOr: string;
     /**
      * Culture Model's InlineOrMore.
+     *
      * @example
      * ", or "
      */
     inlineOrMore: string;
     /**
      * Equivalent of "Yes" in Culture Model's Language.
+     *
      * @example
      * "Yes"
      */
     yesInLanguage: string;
     /**
      * Equivalent of "No" in Culture Model's Language.
+     *
      * @example
      * "No"
      */
@@ -133,6 +139,7 @@ export class PromptCultureModels {
 
     /**
      * Use Recognizers-Text to normalize various potential Locale strings to a standard.
+     *
      * @remarks This is mostly a copy/paste from https://github.com/microsoft/Recognizers-Text/blob/master/JavaScript/packages/recognizers-text/src/culture.ts#L39
      *          This doesn't directly use Recognizers-Text's MapToNearestLanguage because if they add language support before we do, it will break our prompts.
      * @param cultureCode Represents locale. Examples: "en-US, en-us, EN".

--- a/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
@@ -19,6 +19,7 @@ import { DialogEvent } from '../dialog';
 export class TextPrompt extends Prompt<string> {
     /**
      * Creates a new TextPrompt instance.
+     *
      * @param dialogId (Optional) unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
      * @param validator (Optional) validator that will be called each time the user responds to the prompt.
      */
@@ -28,6 +29,7 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Prompts the user for input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
      * @param state Contains state for the current instance of the prompt on the dialog stack.
@@ -52,17 +54,18 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Attempts to recognize the user's input.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext), context for the current
      * turn of conversation with the user.
-     * @param state Contains state for the current instance of the prompt on the dialog stack.
-     * @param options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
+     * @param _state Contains state for the current instance of the prompt on the dialog stack.
+     * @param _options A [PromptOptions](xref:botbuilder-dialogs.PromptOptions) object constructed
      * from the options initially provided in the call to Prompt.
      * @returns A `Promise` representing the asynchronous operation.
      */
     protected async onRecognize(
         context: TurnContext,
-        state: any,
-        options: PromptOptions
+        _state: any,
+        _options: PromptOptions
     ): Promise<PromptRecognizerResult<string>> {
         const value: string = context.activity.text;
 
@@ -71,16 +74,17 @@ export class TextPrompt extends Prompt<string> {
 
     /**
      * Called before an event is bubbled to its parent.
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
+     *
+     * @param _dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current
      * turn of conversation.
-     * @param event [DialogEvent](xref:botbuilder-dialogs.DialogEvent), the event being raised.
+     * @param _event [DialogEvent](xref:botbuilder-dialogs.DialogEvent), the event being raised.
      * @returns Whether the event is handled by the current dialog and further processing should stop.
      * @remarks
      * This is a good place to perform interception of an event as returning `true` will prevent
      * any further bubbling of the event to the dialogs parents and will also prevent any child
      * dialogs from performing their default processing.
      */
-    protected async onPreBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean> {
+    protected async onPreBubbleEvent(_dc: DialogContext, _event: DialogEvent): Promise<boolean> {
         return false;
     }
 }

--- a/libraries/botbuilder-dialogs/src/recognizer.ts
+++ b/libraries/botbuilder-dialogs/src/recognizer.ts
@@ -13,7 +13,7 @@ import {
     NullTelemetryClient,
     RecognizerResult,
 } from 'botbuilder-core';
-import { omit } from 'lodash';
+import omit = require('lodash/omit');
 import { Configurable } from './configurable';
 import { DialogContext } from './dialogContext';
 import { DialogTurnStateConstants } from './dialogTurnStateConstants';
@@ -41,17 +41,16 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
     /**
      * To recognize intents and entities in a users utterance.
      *
-     * @param {DialogContext} dialogContext Dialog Context.
-     * @param {Partial<Activity>} activity Activity.
-     * @param {Record<string, string>} telemetryProperties Additional properties to be logged to telemetry with event.
-     * @param {Record<string, number>} telemetryMetrics Additional metrics to be logged to telemetry with event.
-     * @returns {Promise<RecognizerResult>} Recognized result.
+     * @param {DialogContext} _dialogContext Dialog Context.
+     * @param {Partial<Activity>} _activity Activity.
+     * @param {Record<string, string>} _telemetryProperties Additional properties to be logged to telemetry with event.
+     * @param {Record<string, number>} _telemetryMetrics Additional metrics to be logged to telemetry with event.
      */
     public recognize(
-        dialogContext: DialogContext,
-        activity: Partial<Activity>,
-        telemetryProperties?: Record<string, string>,
-        telemetryMetrics?: Record<string, number>
+        _dialogContext: DialogContext,
+        _activity: Partial<Activity>,
+        _telemetryProperties?: Record<string, string>,
+        _telemetryMetrics?: Record<string, number>
     ): Promise<RecognizerResult> {
         throw new Error('Please implement recognize function.');
     }
@@ -101,16 +100,16 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
 
     /**
      * Uses the RecognizerResult to create a list of properties to be included when tracking the result in telemetry.
-     * 
+     *
      * @param {RecognizerResult} recognizerResult Recognizer Result.
      * @param {Record<string, string>} telemetryProperties A list of properties to append or override the properties created using the RecognizerResult.
-     * @param {DialogContext} dialogContext Dialog Context.
+     * @param {DialogContext} _dialogContext Dialog Context.
      * @returns {Record<string, string>} A collection of properties that can be included when calling the TrackEvent method on the TelemetryClient.
      */
     protected fillRecognizerResultTelemetryProperties(
         recognizerResult: RecognizerResult,
         telemetryProperties: Record<string, string>,
-        dialogContext?: DialogContext
+        _dialogContext?: DialogContext
     ): Record<string, string> {
         const { intent, score } = getTopScoringIntent(recognizerResult);
         const intents = Object.entries(recognizerResult.intents);
@@ -161,8 +160,9 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
         telemetryMetrics?: Record<string, number>
     ): void {
         if (this.telemetryClient instanceof NullTelemetryClient) {
-            const turnStateTelemetryClient = dialogContext.context.turnState.get<BotTelemetryClient>(DialogTurnStateConstants.telemetryClient)
-                ?? dialogContext.context.turnState.get<BotTelemetryClient>(BotTelemetryClientKey);
+            const turnStateTelemetryClient =
+                dialogContext.context.turnState.get<BotTelemetryClient>(DialogTurnStateConstants.telemetryClient) ??
+                dialogContext.context.turnState.get<BotTelemetryClient>(BotTelemetryClientKey);
             this.telemetryClient = turnStateTelemetryClient ?? this.telemetryClient;
         }
 

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -33,6 +33,7 @@ import { TurnPath } from './memory/turnPath';
 
 /**
  * A specialized Dialog that can wrap remote calls to a skill.
+ *
  * @remarks
  * The options parameter in beginDialog must be a BeginSkillDialogOptions instance
  * with the initial parameters for the dialog.
@@ -51,8 +52,8 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
      * The options parameter in `beginDialog()` must be a `SkillDialogArgs` object with the initial parameters
      * for the dialog.
      *
-     * @param dialogOptions
-     * @param dialogId
+     * @param dialogOptions The dialog options.
+     * @param dialogId The dialog id.
      */
     public constructor(dialogOptions: SkillDialogOptions, dialogId?: string) {
         super(dialogId);
@@ -64,6 +65,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Initial information to pass to the dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -101,6 +103,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
     /**
      * Called when the skill dialog is _continued_, where it is the active dialog and the
      * user replies with a new [Activity](xref:botframework-schema.Activity).
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
@@ -144,6 +147,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog is ending.
+     *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information associated with the instance of this dialog on the dialog stack.
      * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog ended.
@@ -172,6 +176,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when the skill dialog should re-prompt the user for input.
+     *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param instance State information for this dialog.
      * @returns A Promise representing the asynchronous operation.
@@ -192,13 +197,14 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
 
     /**
      * Called when a child skill dialog completed its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the conversation.
-     * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
-     * @param result Optional, value returned from the dialog that was called. The type
+     * @param _reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
+     * @param _result Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A Promise representing the asynchronous operation.
      */
-    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+    public async resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult> {
         await this.repromptDialog(dc.context, dc.activeDialog);
         return Dialog.EndOfTurn;
     }
@@ -210,9 +216,10 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
      * Override this method to implement a custom validator for the activity being sent during the continueDialog.
      * This method can be used to ignore activities of a certain type if needed.
      * If this method returns false, the dialog will end the turn without processing the activity.
-     * @param activity The Activity for the current turn of conversation.
+     * @param _activity The Activity for the current turn of conversation.
+     * @returns True if activity is valid.
      */
-    protected onValidateActivity(activity: Activity): boolean {
+    protected onValidateActivity(_activity: Activity): boolean {
         return true;
     }
 
@@ -234,7 +241,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
         }
 
         if (!options.activity) {
-            throw new TypeError(`"activity" is undefined or null in options.`);
+            throw new TypeError('"activity" is undefined or null in options.');
         }
 
         return options;
@@ -358,7 +365,7 @@ export class SkillDialog extends Dialog<Partial<BeginSkillDialogOptions>> {
                             result.token
                         );
                     }
-                } catch (err) {
+                } catch {
                     // Failures in token exchange are not fatal. They simply mean that the user needs to be shown the skill's OAuthCard.
                     return false;
                 }

--- a/libraries/botbuilder-dialogs/src/template.ts
+++ b/libraries/botbuilder-dialogs/src/template.ts
@@ -14,6 +14,7 @@ import { DialogContext } from './dialogContext';
 export interface TemplateInterface<T, D = Record<string, unknown>> {
     /**
      * Given the turn context bind to the data to create the object
+     *
      * @param dialogContext DialogContext.
      * @param data Data to bind to.
      * @returns Instance of T.

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -19,6 +19,7 @@ import { WaterfallStepContext } from './waterfallStepContext';
  * ```TypeScript
  * type WaterfallStep<O extends object = {}> = (step: WaterfallStepContext<O>) => Promise<DialogTurnResult>;
  * ```
+ *
  * @param O (Optional) type of dialog options passed into the step.
  * @param WaterfallStep.step Contextual information for the current step being executed.
  */
@@ -91,12 +92,13 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Gets the dialog version, composed of the ID and number of steps.
+     *
      * @returns Dialog version, composed of the ID and number of steps.
      */
     public getVersion(): string {
         // Simply return the id + number of steps to help detect when new steps have
         // been added to a given waterfall.
-        return `${ this.id }:${ this.steps.length }`;
+        return `${this.id}:${this.steps.length}`;
     }
 
     /**
@@ -136,6 +138,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
      * helloDialog.addStep(this.helloWorldStep.bind(this));
      * ```
      * @param step Asynchronous step function to call.
+     * @returns The waterfall with a new step.
      */
     public addStep(step: WaterfallStep<O>): this {
         this.steps.push(step);
@@ -145,6 +148,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional, initial information to pass to the [Dialog](xref:botbuilder-dialogs.Dialog).
      * @returns A Promise representing the asynchronous operation.
@@ -177,6 +181,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
     /**
      * Called when the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) is _continued_, where it is the active dialog and the
      * user replies with a new [Activity](xref:botframework-schema.Activity).
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A Promise representing the asynchronous operation.
      * @remarks
@@ -196,6 +201,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when a child [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog) completed its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the conversation.
      * @param reason [Reason](xref:botbuilder-dialogs.DialogReason) why the dialog resumed.
      * @param result Optional, value returned from the dialog that was called. The type
@@ -224,6 +230,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
      * }
      * ```
      * @param step Context object for the waterfall step to execute.
+     * @returns A promise representing the asynchronous operation.
      */
     protected async onStep(step: WaterfallStepContext<O>): Promise<DialogTurnResult> {
         // Log Waterfall Step event.
@@ -242,6 +249,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Executes a step of the [WaterfallDialog](xref:botbuilder-dialogs.WaterfallDialog).
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param index The index of the current waterfall step to execute.
      * @param reason The [Reason](xref:botbuilder-dialogs.DialogReason) the waterfall step is being executed.
@@ -320,6 +328,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
 
     /**
      * Identifies the step name by its position index.
+     *
      * @param index Step position
      * @returns A string that identifies the step name.
      */

--- a/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
@@ -40,6 +40,7 @@ export interface WaterfallStepInfo<O extends object> {
 
     /**
      * Called to skip to the next waterfall step.
+     *
      * @param result (Optional) result to pass to the next step.
      */
     onNext(result?: any): Promise<DialogTurnResult>;
@@ -47,6 +48,7 @@ export interface WaterfallStepInfo<O extends object> {
 
 /**
  * Context object passed in to a `WaterfallStep`.
+ *
  * @param O (Optional) type of options passed to the steps waterfall dialog in the call to `DialogContext.beginDialog()`.
  */
 export class WaterfallStepContext<O extends object = {}> extends DialogContext {
@@ -54,6 +56,7 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
 
     /**
      * Creates a new WaterfallStepContext instance.
+     *
      * @param dc The dialog context for the current turn of conversation.
      * @param info Values to initialize the step context with.
      */
@@ -64,14 +67,14 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
     }
 
     /**
-     * The index of the current waterfall step being executed.
+     * @returns The index of the current waterfall step being executed.
      */
     public get index(): number {
         return this._info.index;
     }
 
     /**
-     * Any options passed to the steps waterfall dialog when it was started with
+     * @returns Any options passed to the steps waterfall dialog when it was started with
      * `DialogContext.beginDialog()`.
      */
     public get options(): O {
@@ -79,21 +82,21 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
     }
 
     /**
-     * The reason the waterfall step is being executed.
+     * @returns The reason the waterfall step is being executed.
      */
     public get reason(): DialogReason {
         return this._info.reason;
     }
 
     /**
-     * Results returned by a dialog or prompt that was called in the previous waterfall step.
+     * @returns Results returned by a dialog or prompt that was called in the previous waterfall step.
      */
     public get result(): any {
         return this._info.result;
     }
 
     /**
-     * A dictionary of values which will be persisted across all waterfall steps.
+     * @returns A dictionary of values which will be persisted across all waterfall steps.
      */
     public get values(): object {
         return this._info.values;
@@ -108,6 +111,7 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
      * return await step.skip();
      * ```
      * @param result (Optional) result to pass to the next step.
+     * @returns The next waterfall step.
      */
     public async next(result?: any): Promise<DialogTurnResult> {
         return await this._info.onNext(result);


### PR DESCRIPTION
Addresses # 2745
#minor

## Description
When reviewing the [botbuilder-js](https://github.com/microsoft/botbuilder-js) project it was found that eslint is showing several warnings for the botbuilder-dialogs library. 

## Specific Changes
  - Added node environment to eslint configuration for the library
  - Replaced strings quotes with the correct one depending of the case
  - Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
  - Adjusted formatting
  - Limited importing scopes
  - Added missing jsdocs documentation for parameters and returns for functions
  - Removed unused variables
  - Added "uuid" to project dependencies

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149357490-7fa68422-fb78-4f94-b774-cdeed5f22b12.png)
