### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs-adaptive library - tests

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -243,7 +243,7 @@ describe('LGLanguageGenerator', function () {
             const result3 = await lg.generate(await getTurnContext('en-gb', lg), '${test()}', undefined);
             assert.equal(result3, 'english-gb');
         });
-*/
+        */
         it('en, "${test()}", no data', async function () {
             const result4 = await lg.generate(getDialogContext('en', lg), '${test()}', undefined);
             assert.equal(result4, 'english');

--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -3,7 +3,8 @@ const {
     LanguageResourceLoader,
     TemplateEngineLanguageGenerator,
     LanguageGeneratorManager,
-    ResourceMultiLanguageGenerator } = require('../');
+    ResourceMultiLanguageGenerator,
+} = require('../');
 const { ResourceExplorer } = require('botbuilder-dialogs-declarative');
 const assert = require('assert');
 const path = require('path');
@@ -25,180 +26,209 @@ function getDialogContext(locale, generator) {
     return dialogContext;
 }
 
-describe('LGLanguageGenerator', function() {
+describe('LGLanguageGenerator', function () {
     this.timeout(10000);
 
-    it('TestNotFoundTemplate', async function() {
+    it('TestNotFoundTemplate', async function () {
         const lg = new TemplateEngineLanguageGenerator();
-        assert.throws(() => {lg.generate(getDialogContext(), '${tesdfdfsst()}', undefined);}, Error);
+        assert.throws(() => {
+            lg.generate(getDialogContext(), '${tesdfdfsst()}', undefined);
+        }, Error);
     });
 
-    describe('TestMultiLangImport', () => {
+    describe('TestMultiLangImport', function () {
         let lgResourceGroup;
-        this.beforeAll(async function() {
+        this.beforeAll(async function () {
             lgResourceGroup = await LanguageResourceLoader.groupByLocale(resourceExplorer);
         });
 
-        describe('TestLGResourceGroup', async function() {
-            it('assert empty locale', async () => {
+        describe('TestLGResourceGroup', function () {
+            it('assert empty locale', async function () {
                 assert(lgResourceGroup.has(''));
-                var resourceNames = lgResourceGroup.get('').map(u => u.id);
+                const resourceNames = lgResourceGroup.get('').map((u) => u.id);
                 assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg', 'test.lg']));
+                assert.deepStrictEqual(
+                    new Set(resourceNames),
+                    new Set(['a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg', 'root.lg', 'subDialog.lg', 'test.lg'])
+                );
             });
 
-            it('assert en-us locale', async () => {
+            it('assert en-us locale', async function () {
                 assert(lgResourceGroup.has('en-us'));
-                var resourceNames = lgResourceGroup.get('en-us').map(u => u.id);
+                const resourceNames = lgResourceGroup.get('en-us').map((u) => u.id);
                 assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['a.en-US.lg', 'b.en-us.lg', 'test.en-US.lg', 'c.en.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
+                assert.deepStrictEqual(
+                    new Set(resourceNames),
+                    new Set([
+                        'a.en-US.lg',
+                        'b.en-us.lg',
+                        'test.en-US.lg',
+                        'c.en.lg',
+                        'NormalStructuredLG.lg',
+                        'root.lg',
+                        'subDialog.lg',
+                    ])
+                );
             });
 
-            it('assert en locale', async () => {
+            it('assert en locale', async function () {
                 assert(lgResourceGroup.has('en'));
-                var resourceNames = lgResourceGroup.get('en').map(u => u.id);
+                const resourceNames = lgResourceGroup.get('en').map((u) => u.id);
                 assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['c.en.lg', 'test.en.lg', 'a.lg', 'b.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
+                assert.deepStrictEqual(
+                    new Set(resourceNames),
+                    new Set([
+                        'c.en.lg',
+                        'test.en.lg',
+                        'a.lg',
+                        'b.lg',
+                        'NormalStructuredLG.lg',
+                        'root.lg',
+                        'subDialog.lg',
+                    ])
+                );
             });
         });
 
-        describe('Test MultiLang Import with specified locale', async function() {
+        describe('Test MultiLang Import with specified locale', function () {
             let generator;
-            this.beforeAll(async function() {
+            this.beforeAll(async function () {
                 const resource = resourceExplorer.getResource('a.en-US.lg');
                 generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
             });
 
-            it('"${templatea()}", no data', async () => {
+            it('"${templatea()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templatea()}', undefined);
                 assert.strictEqual(result, 'from a.en-us.lg');
             });
 
-            it('"${templateb()}", no data', async () => {
+            it('"${templateb()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templateb()}', undefined);
                 assert.strictEqual(result, 'from b.en-us.lg');
             });
 
-            it('"${templatec()}", no data', async () => {
+            it('"${templatec()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templatec()}', undefined);
                 assert.strictEqual(result, 'from c.en.lg');
             });
 
-            it('should throw for missing template: "${greeting()}", no data', async () => {
-                assert.throws(() => {generator.generate(getDialogContext(), '${greeting()}', undefined);});
-            });       
+            it('should throw for missing template: "${greeting()}", no data', async function () {
+                assert.throws(() => {
+                    generator.generate(getDialogContext(), '${greeting()}', undefined);
+                });
+            });
         });
-        
-        describe('Test Multi-Language Import with no locale', function() {   
-            let generator; 
-            this.beforeAll(async function() {
+
+        describe('Test Multi-Language Import with no locale', function () {
+            let generator;
+            this.beforeAll(async function () {
                 const resource = resourceExplorer.getResource('a.lg');
                 generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
             });
 
-            it('"${templatea()}", no data', async () => {
+            it('"${templatea()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templatea()}', undefined);
                 assert.strictEqual(result, 'from a.lg');
             });
 
-            it('"${templateb()}", no data', async () => {
+            it('"${templateb()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templateb()}', undefined);
                 assert.strictEqual(result, 'from b.lg');
             });
 
-            it('"${templatec()}", no data', async () => {
+            it('"${templatec()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${templatec()}', undefined);
                 assert.strictEqual(result, 'from c.lg');
             });
 
-            it('"${greeting()}", no data', async () => {
+            it('"${greeting()}", no data', async function () {
                 const result = await generator.generate(getDialogContext(), '${greeting()}', undefined);
                 assert.strictEqual(result, 'hi');
-            });    
+            });
         });
     });
 
-    describe('TestMultiLangGenerator', () => {
+    describe('TestMultiLangGenerator', function () {
         const lg = new MultiLanguageGenerator();
 
-        this.beforeAll(async function() {
+        this.beforeAll(async function () {
             const multiLanguageResources = await LanguageResourceLoader.groupByLocale(resourceExplorer);
 
             //Should have a setup for the threadLocale here.
-        
+
             let resource = resourceExplorer.getResource('test.lg');
             lg.languageGenerators.set('', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.de.lg');
             lg.languageGenerators.set('de', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en.lg');
             lg.languageGenerators.set('en', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en-US.lg');
             lg.languageGenerators.set('en-us', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en-GB.lg');
             lg.languageGenerators.set('en-gb', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.fr.lg');
             lg.languageGenerators.set('fr', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
         });
 
-        it('en-US, "${test()}", no data', async () => {
+        it('en-US, "${test()}", no data', async function () {
             const result1 = await lg.generate(getDialogContext('en-US'), '${test()}', undefined);
             assert.equal(result1, 'english-us');
         });
 
-        it('en-GB, "${test()}", no data', async () => {
+        it('en-GB, "${test()}", no data', async function () {
             const result2 = await lg.generate(getDialogContext('en-GB'), '${test()}', undefined);
             assert.equal(result2, 'english-gb');
         });
 
-        it('en, "${test()}", no data', async () => {
+        it('en, "${test()}", no data', async function () {
             const result3 = await lg.generate(getDialogContext('en'), '${test()}', undefined);
             assert.equal(result3, 'english');
         });
 
-        it('no locale, "${test()}", no data', async () => {
+        it('no locale, "${test()}", no data', async function () {
             const result4 = await lg.generate(getDialogContext(''), '${test()}', undefined);
             assert.equal(result4, 'default');
         });
 
-        it('bad locale, "${test()}", no data', async () => {
+        it('bad locale, "${test()}", no data', async function () {
             const result5 = await lg.generate(getDialogContext('foo'), '${test()}', undefined);
             assert.equal(result5, 'default');
         });
 
-        it('en-US, "${test2()}", country data', async () => {
-            const result6 = await lg.generate(getDialogContext('en-US'), '${test2()}', {country: 'US'});
+        it('en-US, "${test2()}", country data', async function () {
+            const result6 = await lg.generate(getDialogContext('en-US'), '${test2()}', { country: 'US' });
             assert.equal(result6, 'english-US');
         });
 
-        it('en-GB, "${test2()}", no data', async () => {
+        it('en-GB, "${test2()}", no data', async function () {
             const result7 = await lg.generate(getDialogContext('en-GB'), '${test2()}', undefined);
             assert.equal(result7, 'default2');
         });
 
-        it('en, "${test2()}", no data', async () => {
+        it('en, "${test2()}", no data', async function () {
             const result8 = await lg.generate(getDialogContext('en'), '${test2()}', undefined);
             assert.equal(result8, 'default2');
         });
 
-        it('no locale, "${test2()}", no data', async () => {
+        it('no locale, "${test2()}", no data', async function () {
             const result9 = await lg.generate(getDialogContext(''), '${test2()}', undefined);
             assert.equal(result9, 'default2');
         });
 
-        it('bad locale, "${test2()}", no data', async () => {
+        it('bad locale, "${test2()}", no data', async function () {
             const result10 = await lg.generate(getDialogContext('foo'), '${test2()}', undefined);
             assert.equal(result10, 'default2');
         });
     });
 
-    describe('TestResourceMultiLangGenerator', () => {
+    describe('TestResourceMultiLangGenerator', function () {
         const lg = new ResourceMultiLanguageGenerator('test.lg');
-/*
+        /*
         it('en-us, "${test()}", no data', async () => {
             const result1 = await lg.generate(await getTurnContext('en-us', lg), '${test()}', undefined);
             assert.equal(result1, 'english-us');
@@ -214,41 +244,41 @@ describe('LGLanguageGenerator', function() {
             assert.equal(result3, 'english-gb');
         });
 */
-        it('en, "${test()}", no data', async () => {
+        it('en, "${test()}", no data', async function () {
             const result4 = await lg.generate(getDialogContext('en', lg), '${test()}', undefined);
             assert.equal(result4, 'english');
         });
 
-        it('no locale, "${test()}", no data', async () => {
+        it('no locale, "${test()}", no data', async function () {
             const result5 = await lg.generate(getDialogContext('', lg), '${test()}', undefined);
             assert.equal(result5, 'default');
         });
 
-        it('bad locale, "${test()}", no data', async () => {
+        it('bad locale, "${test()}", no data', async function () {
             const result6 = await lg.generate(getDialogContext('foo', lg), '${test()}', undefined);
             assert.equal(result6, 'default');
         });
 
-        it('en-gb, "${test2()}", no data', async () => {
+        it('en-gb, "${test2()}", no data', async function () {
             const result7 = await lg.generate(getDialogContext('en-gb', lg), '${test2()}', undefined);
             assert.equal(result7, 'default2');
         });
 
-        it('en, "${test2()}", no data', async () => {
+        it('en, "${test2()}", no data', async function () {
             const result8 = await lg.generate(getDialogContext('en', lg), '${test2()}', undefined);
             assert.equal(result8, 'default2');
         });
 
-        it('no locale, "${test2()}", no data', async () => {
+        it('no locale, "${test2()}", no data', async function () {
             const result9 = await lg.generate(getDialogContext('', lg), '${test2()}', undefined);
             assert.equal(result9, 'default2');
         });
 
-        it('bad locale, "${test2()}", no data', async () => {
+        it('bad locale, "${test2()}", no data', async function () {
             const result10 = await lg.generate(getDialogContext('foo', lg), '${test2()}', undefined);
             assert.equal(result10, 'default2');
         });
-/*
+        /*
         it('en-us, "${test2()}", country data', async () => {
             const result11 = await lg.generate(await getTurnContext('en-us', lg), '${test2()}', {country: 'US'});
             assert.equal(result11, 'english-US');

--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -283,6 +283,6 @@ describe('LGLanguageGenerator', function () {
             const result11 = await lg.generate(await getTurnContext('en-us', lg), '${test2()}', {country: 'US'});
             assert.equal(result11, 'english-US');
         });
-*/
+        */
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
@@ -1,23 +1,22 @@
 // this test would be migrated to adaptive dialog package
 
 const { Templates } = require('botbuilder-lg');
-const {ActivityFactory, ActivityTypes } = require('botbuilder');
+const { ActivityFactory, ActivityTypes } = require('botbuilder');
 const assert = require('assert');
 
-function getTemplates(){
-    const filePath =  `${ __dirname }/lg/NormalStructuredLG.lg`;
+function getTemplates() {
+    const filePath = `${__dirname}/lg/NormalStructuredLG.lg`;
     return Templates.parseFile(filePath);
 }
 
 const templates = getTemplates();
-function getActivity(templateName, data){
+function getActivity(templateName, data) {
     const lgResult = templates.evaluate(templateName, data);
     return ActivityFactory.fromObject(lgResult);
 }
 
-describe('ActivityFactoryTest', function() {
-
-    it('inlineActivityFactory', function() {
+describe('ActivityFactoryTest', function () {
+    it('inlineActivityFactory', function () {
         let result = ActivityFactory.fromObject('text');
         assert(result.text === 'text');
         assert(result.speak === 'text');
@@ -25,216 +24,218 @@ describe('ActivityFactoryTest', function() {
 
         const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
 
         const cardActionLgResult = templates.evaluateText('${HerocardWithCardAction()}', data);
         result = ActivityFactory.fromObject(cardActionLgResult);
         assertCardActionActivity(result);
-
     });
 
-    it('NotSupportStructuredType', function() {
+    it('NotSupportStructuredType', function () {
         const result = getActivity('notSupport', undefined);
         assert.strictEqual(result.attachments, undefined);
-        assert.strictEqual(result.text.replace(/\r\n/g, '\n').replace(/\n/g, '').replace(/\s+/g, ''), '{"lgType":"Acti","key":"value"}');
+        assert.strictEqual(
+            result.text.replace(/\r\n/g, '\n').replace(/\n/g, '').replace(/\s+/g, ''),
+            '{"lgType":"Acti","key":"value"}'
+        );
     });
 
-    it('HerocardWithCardAction', function() {
-        let data = {
+    it('HerocardWithCardAction', function () {
+        const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
-        let result = getActivity('HerocardWithCardAction', data);
+        const result = getActivity('HerocardWithCardAction', data);
         assertCardActionActivity(result);
     });
 
-    it('adaptivecardActivity', function() {
-        let data = {
-            adaptiveCardTitle: 'test'
+    it('adaptivecardActivity', function () {
+        const data = {
+            adaptiveCardTitle: 'test',
         };
-        let result = getActivity('adaptivecardActivity', data);
+        const result = getActivity('adaptivecardActivity', data);
         assertAdaptiveCardActivity(result);
     });
 
-    it('externalAdaptiveCardActivity', function() {
-        let data = {
-            adaptiveCardTitle: 'test'
+    it('externalAdaptiveCardActivity', function () {
+        const data = {
+            adaptiveCardTitle: 'test',
         };
-        let result = getActivity('externalAdaptiveCardActivity', data);
+        const result = getActivity('externalAdaptiveCardActivity', data);
         assertAdaptiveCardActivity(result);
     });
 
-    it('multiExternalAdaptiveCardActivity', function() {
-        let data = {titles: ['test0', 'test1', 'test2']};
-        let result = getActivity('multiExternalAdaptiveCardActivity', data);
+    it('multiExternalAdaptiveCardActivity', function () {
+        const data = { titles: ['test0', 'test1', 'test2'] };
+        const result = getActivity('multiExternalAdaptiveCardActivity', data);
         assertMultiAdaptiveCardActivity(result);
     });
 
-    it('adaptivecardActivityWithAttachmentStructure', function() {
-        let data = {
-            adaptiveCardTitle: 'test'
+    it('adaptivecardActivityWithAttachmentStructure', function () {
+        const data = {
+            adaptiveCardTitle: 'test',
         };
-        let result = getActivity('adaptivecardActivityWithAttachmentStructure', data);
+        const result = getActivity('adaptivecardActivityWithAttachmentStructure', data);
         assertAdaptiveCardActivity(result);
     });
 
-    it('externalHeroCardActivity', function() {
-        let data = {
+    it('externalHeroCardActivity', function () {
+        const data = {
             type: 'imBack',
             title: 'taptitle',
-            value: 'tapvalue'
+            value: 'tapvalue',
         };
-        let result = getActivity('externalHeroCardActivity', data);
+        const result = getActivity('externalHeroCardActivity', data);
         assertActivityWithHeroCardAttachment(result);
     });
 
-    it('eventActivity', function() {
-        let data = {
-            text: 'textContent'
+    it('eventActivity', function () {
+        const data = {
+            text: 'textContent',
         };
-        let result = getActivity('eventActivity', data);
+        const result = getActivity('eventActivity', data);
         assertEventActivity(result);
     });
 
-    it('customizedActivityType', function() {
-        let result = getActivity('customizedActivityType', undefined);
+    it('customizedActivityType', function () {
+        const result = getActivity('customizedActivityType', undefined);
         assertCustomizedActivityType(result);
     });
 
-    it('handoffActivity', function() {
-        let data = {
-            text: 'textContent'
+    it('handoffActivity', function () {
+        const data = {
+            text: 'textContent',
         };
-        let result = getActivity('handoffActivity', data);
+        const result = getActivity('handoffActivity', data);
         assertHandoffActivity(result);
     });
 
-    it('activityWithHeroCardAttachment', function() {
-        let data = {
+    it('activityWithHeroCardAttachment', function () {
+        const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
-        let result = getActivity('activityWithHeroCardAttachment', data);
+        const result = getActivity('activityWithHeroCardAttachment', data);
         assertActivityWithHeroCardAttachment(result);
     });
 
-    it('herocardAttachment', function() {
-        let data = {
+    it('herocardAttachment', function () {
+        const data = {
             type: 'imBack',
             title: 'taptitle',
-            value: 'tapvalue'
+            value: 'tapvalue',
         };
-        let result = getActivity('herocardAttachment', data);
+        const result = getActivity('herocardAttachment', data);
         assertActivityWithHeroCardAttachment(result);
     });
 
-    it('activityWithMultiAttachments', function() {
-        let data = {
+    it('activityWithMultiAttachments', function () {
+        const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
-        let result = getActivity('activityWithMultiAttachments', data);
+        const result = getActivity('activityWithMultiAttachments', data);
         assertActivityWithMultiAttachments(result);
     });
 
-    it('activityWithSuggestionActions', function() {
-        let data = {
+    it('activityWithSuggestionActions', function () {
+        const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
-        let result = getActivity('activityWithSuggestionActions', data);
+        const result = getActivity('activityWithSuggestionActions', data);
         assertActivityWithSuggestionActions(result);
     });
 
-    it('messageActivityAll', function() {
-        let data = {
+    it('messageActivityAll', function () {
+        const data = {
             title: 'titleContent',
-            text: 'textContent'
+            text: 'textContent',
         };
-        let result = getActivity('messageActivityAll', data);
+        const result = getActivity('messageActivityAll', data);
         assertMessageActivityAll(result);
     });
 
-    it('activityWithMultiStructuredSuggestionActions', function() {
-        let data = {
-            text: 'textContent'
+    it('activityWithMultiStructuredSuggestionActions', function () {
+        const data = {
+            text: 'textContent',
         };
-        let result = getActivity('activityWithMultiStructuredSuggestionActions', data);
+        const result = getActivity('activityWithMultiStructuredSuggestionActions', data);
         assertActivityWithMultiStructuredSuggestionActions(result);
     });
 
-    it('activityWithMultiStringSuggestionActions', function() {
-        let data = {
-            text: 'textContent'
+    it('activityWithMultiStringSuggestionActions', function () {
+        const data = {
+            text: 'textContent',
         };
-        let result = getActivity('activityWithMultiStringSuggestionActions', data);
+        const result = getActivity('activityWithMultiStringSuggestionActions', data);
         assertActivityWithMultiStringSuggestionActions(result);
     });
 
-    it('HeroCardTemplate', function() {
-        let data = {
-            type: 'herocard'
+    it('HeroCardTemplate', function () {
+        const data = {
+            type: 'herocard',
         };
-        let result = getActivity('HeroCardTemplate', data);
+        const result = getActivity('HeroCardTemplate', data);
         assertHeroCardActivity(result);
     });
 
-    it('CustomizedCardTemplate', function() {
-        let result = getActivity('customizedCardActionActivity', undefined);
+    it('CustomizedCardTemplate', function () {
+        const result = getActivity('customizedCardActionActivity', undefined);
         assertCustomizedCardActivity(result);
     });
 
-    it('ThumbnailCardTemplate', function() {
-        let data = {
-            type: 'thumbnailcard'
+    it('ThumbnailCardTemplate', function () {
+        const data = {
+            type: 'thumbnailcard',
         };
-        let result = getActivity('ThumbnailCardTemplate', data);
+        const result = getActivity('ThumbnailCardTemplate', data);
         assertThumbnailCardActivity(result);
     });
 
-    it('AudioCardTemplate', function() {
-        let data = {
-            type: 'audiocard'
+    it('AudioCardTemplate', function () {
+        const data = {
+            type: 'audiocard',
         };
-        let result = getActivity('AudioCardTemplate', data);
+        const result = getActivity('AudioCardTemplate', data);
         assertAudioCardActivity(result);
     });
 
-    it('VideoCardTemplate', function() {
-        let data = {
-            type: 'videocard'
+    it('VideoCardTemplate', function () {
+        const data = {
+            type: 'videocard',
         };
-        let result = getActivity('VideoCardTemplate', data);
+        const result = getActivity('VideoCardTemplate', data);
         assertVideoCardActivity(result);
     });
 
-    it('SigninCardTemplate', function() {
-        let data = {
+    it('SigninCardTemplate', function () {
+        const data = {
             signinlabel: 'Sign in',
-            url: 'https://login.microsoftonline.com/'
+            url: 'https://login.microsoftonline.com/',
         };
-        let result = getActivity('SigninCardTemplate', data);
+        const result = getActivity('SigninCardTemplate', data);
         assertSigninCardActivity(result);
     });
 
-    it('OAuthCardTemplate', function() {
-        let data = {
+    it('OAuthCardTemplate', function () {
+        const data = {
             connectionName: 'MyConnection',
             signinlabel: 'Sign in',
-            url: 'https://login.microsoftonline.com/'
+            url: 'https://login.microsoftonline.com/',
         };
-        let result = getActivity('OAuthCardTemplate', data);
+        const result = getActivity('OAuthCardTemplate', data);
         assertOAuthCardActivity(result);
     });
 
-    it('AnimationCardTemplate', function() {
-        let result = getActivity('AnimationCardTemplate', undefined);
+    it('AnimationCardTemplate', function () {
+        const result = getActivity('AnimationCardTemplate', undefined);
         assertAnimationCardActivity(result);
     });
 
-    it('ReceiptCardTemplate', function() {
-        let data = {
+    it('ReceiptCardTemplate', function () {
+        const data = {
             type: 'ReceiptCard',
             receiptItems: [
                 {
@@ -242,28 +243,28 @@ describe('ActivityFactoryTest', function() {
                     price: '$ 38.45',
                     quantity: '368',
                     image: {
-                        url: 'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png'
-                    }
+                        url: 'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png',
+                    },
                 },
                 {
                     title: 'App Service',
                     price: '$ 45.00',
                     quantity: '720',
                     image: {
-                        url: 'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png'
-                    }
-                }
-            ]
+                        url: 'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png',
+                    },
+                },
+            ],
         };
-        let result = getActivity('ReceiptCardTemplate', data);
+        const result = getActivity('ReceiptCardTemplate', data);
         assertReceiptCardActivity(result);
     });
 
-    it('SuggestedActionsReference', function() {
-        let data = {
-            text: 'textContent'
+    it('SuggestedActionsReference', function () {
+        const data = {
+            text: 'textContent',
         };
-        let result = getActivity('SuggestedActionsReference', data);
+        const result = getActivity('SuggestedActionsReference', data);
         assertSuggestedActionsReferenceActivity(result);
     });
 });
@@ -287,7 +288,7 @@ function assertOAuthCardActivity(activity) {
     assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.oauth');
     const card = activity.attachments[0].content;
     assert(card);
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.connectionName, 'MyConnection');
     assert.strictEqual(card.buttons.length, 1);
     assert.strictEqual(card.buttons[0].title, 'Sign in');
@@ -319,7 +320,7 @@ function assertVideoCardActivity(activity) {
     assert(card);
     assert.strictEqual(card.title, 'Cheese gromit!');
     assert.strictEqual(card.subtitle, 'videocard');
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.image.url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.media[0].url, 'https://youtu.be/530FEFogfBQ');
     assert.strictEqual(card.shareable, false);
@@ -329,7 +330,7 @@ function assertVideoCardActivity(activity) {
     assert.strictEqual(card.buttons.length, 3);
 
     for (let i = 0; i < card.buttons.length; i++) {
-        assert.strictEqual(card.buttons[i].title, `Option ${ i + 1 }`);
+        assert.strictEqual(card.buttons[i].title, `Option ${i + 1}`);
     }
 }
 
@@ -343,7 +344,7 @@ function assertAudioCardActivity(activity) {
     assert(card);
     assert.strictEqual(card.title, 'Cheese gromit!');
     assert.strictEqual(card.subtitle, 'audiocard');
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.image.url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.media[0].url, 'https://contoso.com/media/AllegrofromDuetinCMajor.mp3');
     assert.strictEqual(card.shareable, false);
@@ -353,7 +354,7 @@ function assertAudioCardActivity(activity) {
     assert.strictEqual(card.buttons.length, 3);
 
     for (let i = 0; i < card.buttons.length; i++) {
-        assert.strictEqual(card.buttons[i].title, `Option ${ i + 1 }`);
+        assert.strictEqual(card.buttons[i].title, `Option ${i + 1}`);
     }
 }
 
@@ -381,13 +382,13 @@ function assertThumbnailCardActivity(activity) {
     assert(card);
     assert.strictEqual(card.title, 'Cheese gromit!');
     assert.strictEqual(card.subtitle, 'thumbnailcard');
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.images[0].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.images[1].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.buttons.length, 3);
 
     for (let i = 0; i < card.buttons.length; i++) {
-        assert.strictEqual(card.buttons[i].title, `Option ${ i + 1 }`);
+        assert.strictEqual(card.buttons[i].title, `Option ${i + 1}`);
     }
 }
 
@@ -401,13 +402,13 @@ function assertHeroCardActivity(activity) {
     assert(card);
     assert.strictEqual(card.title, 'Cheese gromit!');
     assert.strictEqual(card.subtitle, 'herocard');
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.images[0].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.images[1].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.buttons.length, 3);
 
     for (let i = 0; i < card.buttons.length; i++) {
-        assert.strictEqual(card.buttons[i].title, `Option ${ i + 1 }`);
+        assert.strictEqual(card.buttons[i].title, `Option ${i + 1}`);
     }
 }
 
@@ -494,13 +495,13 @@ function assertActivityWithMultiAttachments(activity) {
     assert(card);
     assert.strictEqual(card.title, 'Cheese gromit!');
     assert.strictEqual(card.subtitle, 'type');
-    assert.strictEqual(card.text, 'This is some text describing the card, it\'s cool because it\'s cool');
+    assert.strictEqual(card.text, "This is some text describing the card, it's cool because it's cool");
     assert.strictEqual(card.images[0].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.images[1].url, 'https://memegenerator.net/img/instances/500x/73055378/cheese-gromit.jpg');
     assert.strictEqual(card.buttons.length, 3);
 
     for (let i = 0; i < card.buttons.length; i++) {
-        assert.strictEqual(card.buttons[i].title, `Option ${ i + 1 }`);
+        assert.strictEqual(card.buttons[i].title, `Option ${i + 1}`);
     }
 }
 
@@ -562,7 +563,11 @@ function assertAdaptiveCardActivity(activity) {
     assert(activity.text === undefined);
     assert(activity.speak === undefined);
     assert.strictEqual(activity.attachments.length, 1, 'should have one attachment');
-    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive', 'attachment type should be adaptivecard');
+    assert.strictEqual(
+        activity.attachments[0].contentType,
+        'application/vnd.microsoft.card.adaptive',
+        'attachment type should be adaptivecard'
+    );
     assert.strictEqual(activity.attachments[0].content.body[0].text, 'test', 'text of first body should have value');
 }
 
@@ -572,8 +577,8 @@ function assertMultiAdaptiveCardActivity(activity) {
     assert(activity.speak === undefined);
     assert.strictEqual(activity.attachments.length, 3);
     for (let i = 0; i < activity.attachments.length; i++) {
-        assert.strictEqual(activity.attachments[i].contentType, `application/vnd.microsoft.card.adaptive`);
-        assert.strictEqual(activity.attachments[i].content.body[0].text, `test${ i }`);
+        assert.strictEqual(activity.attachments[i].contentType, 'application/vnd.microsoft.card.adaptive');
+        assert.strictEqual(activity.attachments[i].content.body[0].text, `test${i}`);
     }
 }
 
@@ -595,7 +600,10 @@ function assertAnimationCardActivity(activity) {
     assert.strictEqual(card.title, 'Animation Card');
     assert.strictEqual(card.subtitle, 'look at it animate');
     assert.strictEqual(card.autostart, true);
-    assert.strictEqual(card.image.url, 'https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png');
+    assert.strictEqual(
+        card.image.url,
+        'https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png'
+    );
     assert.strictEqual(card.media[0].url, 'http://oi42.tinypic.com/1rchlx.jpg');
 }
 
@@ -616,7 +624,10 @@ function assertReceiptCardActivity(activity) {
     assert.strictEqual(button.title, 'More information');
     assert.strictEqual(button.type, 'openUrl');
     assert.strictEqual(button.value, 'https://azure.microsoft.com/en-us/pricing/');
-    assert.strictEqual(button.image, 'https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png');
+    assert.strictEqual(
+        button.image,
+        'https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png'
+    );
 
     const facts = card.facts;
     assert.strictEqual(facts.length, 2);
@@ -628,11 +639,17 @@ function assertReceiptCardActivity(activity) {
     const items = card.items;
     assert.strictEqual(items.length, 2);
     assert.strictEqual(items[0].title, 'Data Transfer');
-    assert.strictEqual(items[0].image.url, 'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png');
+    assert.strictEqual(
+        items[0].image.url,
+        'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png'
+    );
     assert.strictEqual(items[0].price, '$ 38.45');
     assert.strictEqual(items[0].quantity, '368');
     assert.strictEqual(items[1].title, 'App Service');
-    assert.strictEqual(items[1].image.url, 'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png');
+    assert.strictEqual(
+        items[1].image.url,
+        'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png'
+    );
     assert.strictEqual(items[1].price, '$ 45.00');
     assert.strictEqual(items[1].quantity, '720');
 }

--- a/libraries/botbuilder-dialogs-adaptive/tests/adaptiveDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/adaptiveDialog.test.js
@@ -58,7 +58,7 @@ const createDialogWithCustomInput = () => {
 };
 
 describe('AdaptiveDialog', function () {
-    it('Replace parent', async () => {
+    it('Replace parent', async function () {
         const root = new AdaptiveDialog('root').configure({
             autoEndDialog: false,
             triggers: [
@@ -98,7 +98,7 @@ describe('AdaptiveDialog', function () {
             .startTest();
     });
 
-    it('Replace parent complex verify post replace', async () => {
+    it('Replace parent complex verify post replace', async function () {
         const outerDialog = new AdaptiveDialog('outer').configure({
             autoEndDialog: false,
             recognizer: new RegexRecognizer().configure({
@@ -178,7 +178,7 @@ describe('AdaptiveDialog', function () {
             .startTest();
     });
 
-    it('Custom AttachmentInput dialog with no file', async () => {
+    it('Custom AttachmentInput dialog with no file', async function () {
         const dm = new DialogManager(createDialogWithCustomInput());
         const adapter = new TestAdapter(async (context) => {
             await dm.onTurn(context);
@@ -189,7 +189,7 @@ describe('AdaptiveDialog', function () {
         await adapter.send('hello').assertReply('Upload picture').send('skip').assertReply('passed').startTest();
     });
 
-    it('Custom AttachmentInput dialog with file', async () => {
+    it('Custom AttachmentInput dialog with file', async function () {
         const dm = new DialogManager(createDialogWithCustomInput());
         const adapter = new TestAdapter(async (context) => {
             await dm.onTurn(context);

--- a/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
@@ -10,12 +10,11 @@ const {
     SkillConversationIdFactoryBase,
     StatusCodes,
     TurnContext,
-    MessageFactory
+    MessageFactory,
 } = require('botbuilder');
 const { BoolExpression, StringExpression } = require('adaptive-expressions');
 const { DialogManager, DialogTurnStatus, DialogEvents, DialogSet } = require('botbuilder-dialogs');
 const { BeginSkill, SkillExtensions, StaticActivityTemplate } = require('../lib');
-
 
 class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
     constructor(opts = { useCreateSkillConversationId: false }) {
@@ -28,35 +27,45 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
         if (this.useCreateSkillConversationId) {
             return super.createSkillConversationIdWithOptions();
         }
-        const key = createHash('md5').update(opts.activity.conversation.id + opts.activity.serviceUrl).digest('hex');
+        const key = createHash('md5')
+            .update(opts.activity.conversation.id + opts.activity.serviceUrl)
+            .digest('hex');
 
         const ref = this._conversationRefs.has(key);
         if (!ref) {
             this._conversationRefs.set(key, {
                 conversationReference: TurnContext.getConversationReference(opts.activity),
-                oAuthScope: opts.fromBotOAuthScope
+                oAuthScope: opts.fromBotOAuthScope,
             });
         }
         return key;
     }
 
     async createSkillConversationId(convRef) {
-        const key = createHash('md5').update(convRef.conversation.id + convRef.serviceUrl).digest('hex');
+        const key = createHash('md5')
+            .update(convRef.conversation.id + convRef.serviceUrl)
+            .digest('hex');
 
         const ref = this._conversationRefs.has(key);
         if (!ref) {
             this._conversationRefs.set(key, {
-                conversationReference: convRef
+                conversationReference: convRef,
             });
         }
         return key;
     }
 
-    async getConversationReference(skillConversationId) { return this._conversationRefs.get(skillConversationId) }
+    async getConversationReference(skillConversationId) {
+        return this._conversationRefs.get(skillConversationId);
+    }
 
-    async getSkillConversationReference(skillConversationId) { return this.getConversationReference(skillConversationId) }
+    async getSkillConversationReference(skillConversationId) {
+        return this.getConversationReference(skillConversationId);
+    }
 
-    async deleteConversationReference() { /* not used in BeginSkill */ }
+    async deleteConversationReference() {
+        /* not used in BeginSkill */
+    }
 }
 
 describe('BeginSkill', function () {
@@ -105,7 +114,7 @@ describe('BeginSkill', function () {
     setSkillDialogOptions(dialog);
     dm.rootDialog = dialog;
 
-    it('should call skill via beginDialog()', async () => {
+    it('should call skill via beginDialog()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const { turnResult } = await dm.onTurn(context);
@@ -128,16 +137,16 @@ describe('BeginSkill', function () {
 
         await adapter.send('test').startTest();
     });
-    
-    it('should respect allow interruptions settings', async () => {
+
+    it('should respect allow interruptions settings', async function () {
         dialog.allowInterruptions = new BoolExpression(false);
         const adapter = new TestAdapter(async (context) => {
             const dc = await dialogs.createContext(context);
-            
+
             const bubbling = await dialog.onDialogEvent(dc, { name: DialogEvents.activityReceived });
             strictEqual(bubbling, true);
         });
-        
+
         await adapter.send('test').startTest();
     });
 });
@@ -155,7 +164,7 @@ function setSkillDialogOptions(dialog) {
  * @remarks
  * captureAction should match the below signature:
  * `(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => void`
- * @param {Function} captureAction 
+ * @param {Function} captureAction A function to capture the action.
  * @param {StatusCodes} returnStatusCode Defaults to StatusCodes.OK
  * @returns [BotFrameworkHttpClient, postActivityStub]
  */
@@ -164,7 +173,9 @@ function createSkillClientAndStub(captureAction, returnStatusCode = StatusCodes.
     const { BotFrameworkHttpClient } = require('../../botbuilder/lib');
 
     if (captureAction && typeof captureAction !== 'function') {
-        throw new TypeError(`Failed test arrangement - createSkillClientAndStub() received ${typeof captureAction} instead of undefined or a function.`);
+        throw new TypeError(
+            `Failed test arrangement - createSkillClientAndStub() received ${typeof captureAction} instead of undefined or a function.`
+        );
     }
 
     // Create ExpectedReplies object for response body

--- a/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import 'mocha';
-import {ObjectExpression} from 'adaptive-expressions';
+import { ObjectExpression } from 'adaptive-expressions';
 import * as assert from 'assert';
 import { Choice } from 'botbuilder-dialogs';
 import { ChoiceSet } from '../';
@@ -9,36 +9,34 @@ interface Bar {
     choices: ChoiceSet;
 }
 
-function assertValues(value){
+function assertValues(value) {
     assert.equal('test1', value[0].value);
     assert.equal('test2', value[1].value);
     assert.equal('test3', value[2].value);
 }
 
-describe('ChoiceSetTests', function() {
+describe('ChoiceSetTests', function () {
     this.timeout(10000);
 
-    it('TestExpression', async () => {
+    it('TestExpression', async function () {
         const state = {
-            choices: [
-                { value: 'test1' } as Choice,
-                { value: 'test2' } as Choice,
-                { value: 'test3' } as Choice,
-            ]
+            choices: [{ value: 'test1' } as Choice, { value: 'test2' } as Choice, { value: 'test3' } as Choice],
         };
         const ep = new ObjectExpression<ChoiceSet>('choices');
         const { value } = ep.tryGetValue(state);
         assertValues(value);
     });
 
-    it('TestValue', async () => {
+    it('TestValue', async function () {
         const state = {};
-        const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }]));
+        const ep = new ObjectExpression<ChoiceSet>(
+            new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }])
+        );
         const { value } = ep.tryGetValue(state);
         assertValues(value);
     });
 
-    it('TestStringArrayAccess', async () => {
+    it('TestStringArrayAccess', async function () {
         const state = {};
         const stringArr = ['test1', 'test2', 'test3'];
         const ep = new ObjectExpression<ChoiceSet>(new ChoiceSet(stringArr));
@@ -46,17 +44,13 @@ describe('ChoiceSetTests', function() {
         assertValues(value);
     });
 
-    it('TestConverterExpressionAccess', async () => {
+    it('TestConverterExpressionAccess', async function () {
         const state = {
-            test: [
-                { value: 'test1' } as Choice,
-                { value: 'test2' } as Choice,
-                { value: 'test3' } as Choice,
-            ]
+            test: [{ value: 'test1' } as Choice, { value: 'test2' } as Choice, { value: 'test3' } as Choice],
         };
 
         const sample = {
-            choices: 'test'
+            choices: 'test',
         };
 
         const ep = new ObjectExpression<ChoiceSet>(sample.choices);
@@ -64,35 +58,27 @@ describe('ChoiceSetTests', function() {
         assertValues(value);
     });
 
-    it('TestConvertObjectAccess', async () => {
+    it('TestConvertObjectAccess', async function () {
         const state = {};
 
         const sample = {
-            choices: [
-                { value: 'test1' },
-                { value: 'test2' },
-                { value: 'test3' }
-            ]
+            choices: [{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }],
         };
 
         const json = JSON.stringify(sample);
         const bar = JSON.parse(json) as Bar;
-        
+
         // TS doesn't run 'new' automatically unlike C#
         const choicesBar = new ObjectExpression<ChoiceSet>(bar.choices);
         const { value } = choicesBar.tryGetValue(state);
         assertValues(value);
     });
 
-    it('TestConvertStringAccess', async () => {
+    it('TestConvertStringAccess', async function () {
         const state = {};
 
         const sample = {
-            choices: [
-                'test1',
-                'test2',
-                'test3',
-            ]
+            choices: ['test1', 'test2', 'test3'],
         };
 
         const json = JSON.stringify(sample);
@@ -105,7 +91,7 @@ describe('ChoiceSetTests', function() {
         assertValues(value);
     });
 
-    it('TestConvertStringArray', async () => {
+    it('TestConvertStringArray', async function () {
         const sample = [];
         sample.push('test1');
         sample.push('test2');

--- a/libraries/botbuilder-dialogs-adaptive/tests/conversationAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/conversationAction.test.js
@@ -20,7 +20,7 @@ const {
     ActivityTemplate,
     GetConversationReference,
 } = require('../lib');
-const { AssertCondition } = require('botbuilder-dialogs-adaptive-testing')
+const { AssertCondition } = require('botbuilder-dialogs-adaptive-testing');
 
 class MockQueue extends QueueStorage {
     constructor() {
@@ -62,7 +62,7 @@ class MockQueue extends QueueStorage {
 describe('ConversationAction', function () {
     this.timeout(5000);
 
-    it('ContinueConverationLater', async () => {
+    it('ContinueConverationLater', async function () {
         const storage = new MemoryStorage();
         const queueStorage = new MockQueue();
         const dm = new DialogManager(
@@ -99,7 +99,7 @@ describe('ConversationAction', function () {
         assert.deepStrictEqual(cr, cr2);
     });
 
-    it('ContinueConversation', async () => {
+    it('ContinueConversation', async function () {
         const storage = new MemoryStorage();
         const queueStorage = new MockQueue();
         const cr = TestAdapter.createConversation('ContinueConversationTests');
@@ -146,7 +146,7 @@ describe('ConversationAction', function () {
         assert.deepStrictEqual(cr, cr2);
     });
 
-    it('GetConversationReference', async () => {
+    it('GetConversationReference', async function () {
         const storage = new MemoryStorage();
         const queueStorage = new MockQueue();
         const dm = new DialogManager(

--- a/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizer.test.js
@@ -44,7 +44,7 @@ const getDialogContext = (testName, text, locale = 'en-us') => {
     );
 };
 
-describe('EntityRecognizer Tests', () => {
+describe('EntityRecognizer Tests', function () {
     const recognizers = new EntityRecognizerSet(
         new AgeEntityRecognizer(),
         new ConfirmationEntityRecognizer(),

--- a/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizerRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizerRecognizer.test.js
@@ -48,7 +48,7 @@ const getDialogContext = (testName, text, locale = 'en-us') => {
     );
 };
 
-describe('EntityRecognizer Recognizer Tests', () => {
+describe('EntityRecognizer Recognizer Tests', function () {
     const recognizers = new RecognizerSet().configure({
         recognizers: [
             new AgeEntityRecognizer(),
@@ -314,8 +314,8 @@ describe('EntityRecognizer Recognizer Tests', () => {
         strictEqual(results.entities.color[1], 'Blue');
     });
 
-    describe('Telemetry', () => {
-        it('ChannelMentionEntityRecognizer does not log telemetry by default', async () => {
+    describe('Telemetry', function () {
+        it('ChannelMentionEntityRecognizer does not log telemetry by default', async function () {
             const recognizer = new ChannelMentionEntityRecognizer();
             const spy = spyOnTelemetryClientTrackEvent(recognizer);
             const dialogContext = getDialogContext('ChannelMentionEntityRecognizer - no telemetry', 'gobble gobble');
@@ -330,7 +330,7 @@ describe('EntityRecognizer Recognizer Tests', () => {
             strictEqual(Object.entries(result.entities).length, 0);
         });
 
-        it('EntityRecognizer does not log telemetry by default', async () => {
+        it('EntityRecognizer does not log telemetry by default', async function () {
             const recognizer = new EntityRecognizer();
             const spy = spyOnTelemetryClientTrackEvent(recognizer);
             const dialogContext = getDialogContext('EntityRecognizer - no telemetry', 'gobble gobble');

--- a/libraries/botbuilder-dialogs-adaptive/tests/expressionProperty.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/expressionProperty.test.ts
@@ -2,8 +2,8 @@
 import * as assert from 'assert';
 import { DialogExpression, AdaptiveDialog } from '../';
 
-describe('expressionProperty tests', () => {
-    it('DialogExpression', () => {
+describe('expressionProperty tests', function () {
+    it('DialogExpression', function () {
         const dialog = new AdaptiveDialog('AskNameDialog');
         const data = { test: dialog };
         let val = new DialogExpression('=test');
@@ -18,5 +18,4 @@ describe('expressionProperty tests', () => {
         result = val.getValue(data);
         assert.equal(result, dialog);
     });
-
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
@@ -1,15 +1,8 @@
 const { ok, strictEqual } = require('assert');
 const { createTelemetryClientAndStub } = require('./telemetryUtils');
-const {
-    ConversationState,
-    MemoryStorage,
-    TestAdapter,
-    MessageFactory,
-    InputHints,
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TestAdapter, InputHints } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { InputDialog, StaticActivityTemplate } = require('../lib')
-
+const { InputDialog, StaticActivityTemplate } = require('../lib');
 
 describe('InputDialog', function () {
     this.timeout(3000);
@@ -32,10 +25,10 @@ describe('InputDialog', function () {
 
     // Setup inputDialog dialog
     const dialog = new InputDialog();
-    dialog.prompt = new StaticActivityTemplate({text:'test', type: 'message', inputHint:InputHints.AcceptingInput});
+    dialog.prompt = new StaticActivityTemplate({ text: 'test', type: 'message', inputHint: InputHints.AcceptingInput });
     dialog._telemetryClient = telemetryClient;
 
-    it('eval promptUser()', async () => {
+    it('eval promptUser()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const dc = await dialogs.createContext(context);

--- a/libraries/botbuilder-dialogs-adaptive/tests/languageGeneratorConverter.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/languageGeneratorConverter.test.js
@@ -3,13 +3,16 @@ const { LanguageGeneratorConverter } = require('../lib/converters');
 const { ok, strictEqual } = require('assert');
 
 describe('LanguageGeneratorConverter', function () {
-    it('convert() should return new ResourceMultiLanguageGenerator with string param', () => {
+    it('convert() should return new ResourceMultiLanguageGenerator with string param', function () {
         const converter = new LanguageGeneratorConverter();
         const newGenerator = converter.convert('');
-        ok(newGenerator instanceof ResourceMultiLanguageGenerator, 'expected newGenerator to be instance of ResourceMultiLanguageGenerator');
+        ok(
+            newGenerator instanceof ResourceMultiLanguageGenerator,
+            'expected newGenerator to be instance of ResourceMultiLanguageGenerator'
+        );
     });
 
-    it('convert() should return param if param type is not string', () => {
+    it('convert() should return param if param type is not string', function () {
         const firstGenerator = new ResourceMultiLanguageGenerator('resourceId');
         const converter = new LanguageGeneratorConverter();
         const newGenerator = converter.convert(firstGenerator);
@@ -21,6 +24,5 @@ describe('LanguageGeneratorConverter', function () {
 
         const numberGenerator = converter.convert(2);
         strictEqual(numberGenerator, 2);
-
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
@@ -1,14 +1,8 @@
 const { ok, strictEqual } = require('assert');
 const { createTelemetryClientAndStub } = require('./telemetryUtils');
-const {
-    ConversationState,
-    MemoryStorage,
-    TestAdapter,
-    MessageFactory,
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TestAdapter, MessageFactory } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { LogAction, StaticActivityTemplate } = require('../lib')
-
+const { LogAction, StaticActivityTemplate } = require('../lib');
 
 describe('LogAction', function () {
     this.timeout(3000);
@@ -34,7 +28,7 @@ describe('LogAction', function () {
     dialog.text = new StaticActivityTemplate(MessageFactory.text('test'));
     dialog._telemetryClient = telemetryClient;
 
-    it('eval beginDialog()', async () => {
+    it('eval beginDialog()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const dc = await dialogs.createContext(context);

--- a/libraries/botbuilder-dialogs-adaptive/tests/recognizerTelemetryUtils.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/recognizerTelemetryUtils.js
@@ -45,7 +45,7 @@ async function recognizeIntentAndValidateTelemetry({ text, callCount, recognizer
     const dialogContext = createContext(text);
     const activity = dialogContext.context.activity;
 
-    let result = await recognizer.recognize(dialogContext, activity);
+    const result = await recognizer.recognize(dialogContext, activity);
 
     validateIntent(text, result);
     validateTelemetry({
@@ -70,7 +70,7 @@ async function recognizeIntentAndValidateTelemetry_withCustomActivity({ text, ca
     customActivity.text = text;
     customActivity.locale = 'en-us';
 
-    let result = await recognizer.recognize(dialogContext, customActivity);
+    const result = await recognizer.recognize(dialogContext, customActivity);
 
     validateIntent(text, result);
     validateTelemetry({

--- a/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
@@ -34,7 +34,7 @@ const { createContext, createMessageActivity } = require('./activityUtils');
 const { validateCodeIntent, validateColorIntent } = require('./intentValidations');
 const { Culture } = require('@microsoft/recognizers-text-suite');
 
-describe('RegexRecognizer Tests', () => {
+describe('RegexRecognizer Tests', function () {
     const recognizer = new RegexRecognizer().configure({
         intents: [
             new IntentPattern('codeIntent', '(?<code>[a-z][0-9])'),
@@ -107,14 +107,14 @@ describe('RegexRecognizer Tests', () => {
         validateColorIntent(result);
     });
 
-    describe('telemetry', () => {
+    describe('telemetry', function () {
         let spy;
 
-        beforeEach(() => {
+        beforeEach(function () {
             spy = spyOnTelemetryClientTrackEvent(recognizer);
         });
 
-        afterEach(() => {
+        afterEach(function () {
             spy.restore();
         });
 
@@ -397,8 +397,8 @@ describe('RegexRecognizer Tests', () => {
         assert.strictEqual(result.entities.title, undefined);
     });
 
-    it('basic telemetry test', () => {
-        let properties = {};
+    it('basic telemetry test', function () {
+        const properties = {};
         properties['test'] = 'testvalue';
         properties['foo'] = 'foovalue';
         const metrics = {};
@@ -406,7 +406,7 @@ describe('RegexRecognizer Tests', () => {
         const activity = {};
 
         let callCount = 0;
-        let telemetryClient = {
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -437,13 +437,13 @@ describe('RegexRecognizer Tests', () => {
             },
         };
 
-        let recognizer = new MockTelemetryInRecognizer();
+        const recognizer = new MockTelemetryInRecognizer();
         recognizer.telemetryClient = telemetryClient;
         recognizer.recognize(context, activity, properties, metrics);
     });
 
-    it('check fillRecognizerResultTelemetryProperties', () => {
-        let recognizer = new Recognizer();
+    it('check fillRecognizerResultTelemetryProperties', function () {
+        const recognizer = new Recognizer();
         const telemetryProperties = {
             TelemetryPropertiesKey1: 'TelemetryPropertiesValue1',
             TelemetryPropertiesKey2: 'TelemetryPropertiesValue2',

--- a/libraries/botbuilder-dialogs-adaptive/tests/schemaHelper.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/schemaHelper.test.js
@@ -1,15 +1,15 @@
 const assert = require('assert');
 const { SchemaHelper } = require('../lib');
 const fs = require('fs');
- 
-const schemaDirPath = `${ __dirname }/schema/`;
-const schemaFilePath = `${ schemaDirPath }test.schema`;
 
-describe('schemaHelper tests', function() {
+const schemaDirPath = `${__dirname}/schema/`;
+const schemaFilePath = `${schemaDirPath}test.schema`;
+
+describe('schemaHelper tests', function () {
     const schemaInJson = JSON.parse(fs.readFileSync(schemaFilePath));
     const schemaRoot = new SchemaHelper(schemaInJson);
 
-    it('parse child schema', function() {
+    it('parse child schema', function () {
         const schemaChildrens = schemaRoot.property.children;
         const child = schemaRoot.pathToSchema('propertyChildren.subProperty1');
         assert.equal(child.path, 'propertyChildren.subProperty1');
@@ -19,28 +19,28 @@ describe('schemaHelper tests', function() {
         assert.equal(errChild, undefined);
     });
 
-    it('common property', function(){
+    it('common property', function () {
         assert.equal(schemaRoot.property.expectedOnly, schemaInJson['$expectedOnly']);
         assert.equal(schemaRoot.required, schemaInJson['required']);
         const stringChild = schemaRoot.pathToSchema('propertyString');
         assert.equal(stringChild.type, schemaInJson['properties']['propertyString']['type']);
     });
 
-    it('enum type schema', async function() {
+    it('enum type schema', async function () {
         const enumChild = schemaRoot.pathToSchema('propertyEnum');
         assert.equal(enumChild.isEnum(), true);
         assert.equal(enumChild.entities, schemaInJson['properties']['propertyEnum']['$entities']);
     });
 
-    it('array type schema', async function() {
+    it('array type schema', async function () {
         const arrayChild = schemaRoot.pathToSchema('propertyArray');
         assert.equal(arrayChild.isArray(), true);
     });
 
-    it('error type test', async function() {
-        const errorSchemaType1InJson = JSON.parse(fs.readFileSync(`${ schemaDirPath }test_errorType1.schema`));
+    it('error type test', async function () {
+        const errorSchemaType1InJson = JSON.parse(fs.readFileSync(`${schemaDirPath}test_errorType1.schema`));
         assert.throws(() => new SchemaHelper(errorSchemaType1InJson), Error);
-        const errorSchemaType2InJson = JSON.parse(fs.readFileSync(`${ schemaDirPath }test_errorType2.schema`));
+        const errorSchemaType2InJson = JSON.parse(fs.readFileSync(`${schemaDirPath}test_errorType2.schema`));
         assert.throws(() => new SchemaHelper(errorSchemaType2InJson), Error);
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
@@ -1,14 +1,8 @@
 const { ok, strictEqual } = require('assert');
 const { createTelemetryClientAndStub } = require('./telemetryUtils');
-const {
-    ConversationState,
-    MemoryStorage,
-    TestAdapter,
-    MessageFactory,
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TestAdapter, MessageFactory } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { SendActivity } = require('../lib')
-
+const { SendActivity } = require('../lib');
 
 describe('SendActivity', function () {
     this.timeout(3000);
@@ -33,7 +27,7 @@ describe('SendActivity', function () {
     const dialog = new SendActivity(MessageFactory.text('test'));
     dialog._telemetryClient = telemetryClient;
 
-    it('eval beginDialog()', async () => {
+    it('eval beginDialog()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const dc = await dialogs.createContext(context);

--- a/libraries/botbuilder-dialogs-adaptive/tests/telemetryTrackEventAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/telemetryTrackEventAction.test.js
@@ -1,13 +1,8 @@
 const { ok, strictEqual } = require('assert');
 const { createTelemetryClientAndStub } = require('./telemetryUtils');
-const {
-    ConversationState,
-    MemoryStorage,
-    TestAdapter
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TestAdapter } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
 const { TelemetryTrackEventAction } = require('../lib');
-
 
 describe('TelemetryTrackEventAction', function () {
     this.timeout(3000);
@@ -29,10 +24,10 @@ describe('TelemetryTrackEventAction', function () {
     const dialogs = new DialogSet(dialogState);
 
     // Setup sendActivity dialog
-    const dialog = new TelemetryTrackEventAction('testEvent', {'test': 'test123'});
+    const dialog = new TelemetryTrackEventAction('testEvent', { test: 'test123' });
     dialog._telemetryClient = telemetryClient;
 
-    it('eval beginDialog()', async () => {
+    it('eval beginDialog()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const dc = await dialogs.createContext(context);

--- a/libraries/botbuilder-dialogs-adaptive/tests/templates.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/templates.test.js
@@ -1,15 +1,15 @@
 const assert = require('assert');
-const {
-    ConversationState,
-    MemoryStorage,
-    TurnContext,
-    TestAdapter,
-    ActivityFactory,
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TurnContext, TestAdapter, ActivityFactory } = require('botbuilder');
 const { DialogContext, DialogSet } = require('botbuilder-dialogs');
-const { TextTemplate, languageGeneratorKey, TemplateEngineLanguageGenerator, ActivityTemplate, StaticActivityTemplate } = require('../lib');
+const {
+    TextTemplate,
+    languageGeneratorKey,
+    TemplateEngineLanguageGenerator,
+    ActivityTemplate,
+    StaticActivityTemplate,
+} = require('../lib');
 
-describe('Templates', function() {
+describe('Templates', function () {
     this.timeout(3000);
 
     const conversationState = new ConversationState(new MemoryStorage());
@@ -17,64 +17,64 @@ describe('Templates', function() {
     const dialogs = new DialogSet(dialogState);
     const turnContext = new TurnContext(new TestAdapter());
 
-    it('TextTemplate should throw if template is not defined', async function() {
+    it('TextTemplate should throw if template is not defined', async function () {
         const template = new TextTemplate();
         const dc = new DialogContext(dialogs, turnContext, dialogState);
         assert.rejects(() => template.bind(dc, {}));
     });
 
-    it('TextTemplate should apply default language generator if language generator is not provided', async function() {
+    it('TextTemplate should apply default language generator if language generator is not provided', async function () {
         const template = new TextTemplate('test');
         const dc = new DialogContext(dialogs, turnContext, dialogState);
         const result = await template.bind(dc, {});
         assert.strictEqual(result, 'test');
     });
 
-    it('TextTemplte should return result if language generator is provided', async function() {
+    it('TextTemplte should return result if language generator is provided', async function () {
         const template = new TextTemplate('${test}');
         const dc = new DialogContext(dialogs, turnContext, dialogState);
         dc.services.set(languageGeneratorKey, new TemplateEngineLanguageGenerator());
-        const result = await template.bind(dc, {test: 123});
+        const result = await template.bind(dc, { test: 123 });
         assert.strictEqual(result, '123');
     });
 
-    it('TextTemplate toString', async function() {
+    it('TextTemplate toString', async function () {
         const template = new TextTemplate('test');
         assert.strictEqual(template.toString(), 'TextTemplate(test)');
     });
 
-    it('ActivityTemplate should return undefined if template is not defined', async function() {
+    it('ActivityTemplate should return undefined if template is not defined', async function () {
         const template = new ActivityTemplate();
         const dc = new DialogContext(dialogs, turnContext, dialogState);
         const result = await template.bind(dc, {});
         assert.strictEqual(result, undefined);
     });
 
-    it('ActivityTemplate should return lg result if language generator is provided', async function() {
+    it('ActivityTemplate should return lg result if language generator is provided', async function () {
         const template = new ActivityTemplate('${test}');
         const dc = new DialogContext(dialogs, turnContext, dialogState);
         dc.services.set(languageGeneratorKey, new TemplateEngineLanguageGenerator());
-        const result = await template.bind(dc, {test: 123});
+        const result = await template.bind(dc, { test: 123 });
         assert(result);
         assert.strictEqual(typeof result, 'object');
         assert.strictEqual(result.text, '123');
     });
 
-    it('ActivityTemplate should apply default language generator if language generator is not provided', async function() {
+    it('ActivityTemplate should apply default language generator if language generator is not provided', async function () {
         const template = new ActivityTemplate('${test}');
         const dc = new DialogContext(dialogs, turnContext, dialogState);
-        const result = await template.bind(dc, {test: 123});
+        const result = await template.bind(dc, { test: 123 });
         assert(result);
         assert.strictEqual(typeof result, 'object');
         assert.strictEqual(result.text, '123');
     });
 
-    it('ActivityTemplate toString', async function() {
+    it('ActivityTemplate toString', async function () {
         const template = new ActivityTemplate('test');
         assert.strictEqual(template.toString(), 'ActivityTemplate(test)');
     });
 
-    it('StaticActivityTemplate should return template as Activity', async function() {
+    it('StaticActivityTemplate should return template as Activity', async function () {
         const activity = ActivityFactory.buildActivityFromText('test');
         const template = new StaticActivityTemplate(activity);
         const dc = new DialogContext(dialogs, turnContext, dialogState);
@@ -84,7 +84,7 @@ describe('Templates', function() {
         assert.strictEqual(result.text, activity.text);
     });
 
-    it('StaticActivityTemplate toString', async function() {
+    it('StaticActivityTemplate toString', async function () {
         const activity = ActivityFactory.buildActivityFromText('test');
         const template = new StaticActivityTemplate(activity);
         assert(template.toString(), 'StaticActivityTemplate(test)');

--- a/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
@@ -1,15 +1,9 @@
 const { ok, strictEqual } = require('assert');
 const { stub } = require('sinon');
 const { createTelemetryClientAndStub } = require('./telemetryUtils');
-const {
-    ConversationState,
-    MemoryStorage,
-    TestAdapter,
-    MessageFactory,
-} = require('botbuilder');
+const { ConversationState, MemoryStorage, TestAdapter, MessageFactory } = require('botbuilder');
 const { DialogSet } = require('botbuilder-dialogs');
-const { UpdateActivity } = require('../lib')
-
+const { UpdateActivity } = require('../lib');
 
 describe('UpdateActivity', function () {
     this.timeout(3000);
@@ -34,7 +28,7 @@ describe('UpdateActivity', function () {
     const dialog = new UpdateActivity('activityId', MessageFactory.text('test'));
     dialog._telemetryClient = telemetryClient;
 
-    it('eval beginDialog()', async () => {
+    it('eval beginDialog()', async function () {
         // Send initial activity
         const adapter = new TestAdapter(async (context) => {
             const updateActivitySub = stub(context, 'updateActivity');


### PR DESCRIPTION
Adresses # 2745
#minor

## Description
When reviewing the botbuilder-js project it was found that eslint is showing several warnings for the botbuilder-dialogs-adaptive library.

## Specific Changes

- Replaced strings quotes with the correct one depending of the case
- Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
- Adjusted formatting
- Limited importing scopes
- Added missing jsdocs documentation for parameters and returns for functions
- Removed unused variables
- Added _ (underscore) to unused parameters that couldn't be removed to omit them in the eslint validation
- Omitted validation for unknow/any/object variables as they will be treated in a different task

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149823185-f518820c-91ba-4cdc-9776-3e7434225438.png)