### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs-adaptive library - actions

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -81,7 +81,7 @@ export class ActionScope<O extends object = {}> extends Dialog<O> implements Dia
     constructor(actions?: Dialog[]);
     actions: Dialog[];
     protected beginAction(dc: DialogContext, offset: number): Promise<DialogTurnResult>;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     continueDialog(dc: DialogContext): Promise<DialogTurnResult>;
     // (undocumented)
     getConverter(property: keyof ActionScopeConfiguration): Converter | ConverterFactory;
@@ -308,7 +308,7 @@ export enum AttachmentOutputFormat {
 export class BaseInvokeDialog<O extends object = {}> extends Dialog<O> implements DialogDependencies, BaseInvokeDialogConfiguration {
     constructor(dialogIdToCall?: string, bindingOptions?: O);
     activityProcessed: BoolExpression;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult<any>>;
+    beginDialog(_dc: DialogContext, _options?: O): Promise<DialogTurnResult<any>>;
     protected bindOptions(dc: DialogContext, options: object): object;
     dialog: DialogExpression;
     // (undocumented)
@@ -408,7 +408,7 @@ export type BoolProperty = boolean | BoolExpression | Property;
 export class BreakLoop<O extends object = {}> extends Dialog<O> implements BreakLoopConfiguration {
     // (undocumented)
     static $kind: string;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof BreakLoopConfiguration): Converter | ConverterFactory;
@@ -648,7 +648,7 @@ export interface ContinueConversationConfiguration extends DialogConfiguration {
 export class ContinueConversationLater extends Dialog implements ContinueConversationLaterConfiguration {
     // (undocumented)
     static $kind: string;
-    beginDialog(dc: DialogContext, options?: Record<string, unknown>): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: Record<string, unknown>): Promise<DialogTurnResult>;
     date: StringExpression;
     disabled?: BoolExpression;
     // (undocumented)
@@ -672,7 +672,7 @@ export interface ContinueConversationLaterConfiguration extends DialogConfigurat
 export class ContinueLoop<O extends object = {}> extends Dialog<O> implements ContinueLoopConfiguration {
     // (undocumented)
     static $kind: string;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof ContinueLoopConfiguration): Converter | ConverterFactory;
@@ -744,7 +744,7 @@ export class DeleteActivity<O extends object = {}> extends Dialog<O> implements 
     static $kind: string;
     constructor();
     activityId: StringExpression;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof DeleteActivityConfiguration): Converter | ConverterFactory;
@@ -764,7 +764,7 @@ export class DeleteProperties<O extends object = {}> extends Dialog<O> implement
     // (undocumented)
     static $kind: string;
     constructor();
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof DeletePropertiesConfiguration): Converter | ConverterFactory;
@@ -785,7 +785,7 @@ export class DeleteProperty<O extends object = {}> extends Dialog<O> implements 
     // (undocumented)
     static $kind: string;
     constructor(property?: string);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof DeletePropertyConfiguration): Converter | ConverterFactory;
@@ -865,7 +865,7 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
     static $kind: string;
     constructor();
     constructor(changeType: ArrayChangeType, itemsProperty: string, value?: any, resultProperty?: string);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     changeType: EnumExpression<ArrayChangeType>;
     disabled?: BoolExpression;
     // (undocumented)
@@ -903,7 +903,7 @@ export class EmitEvent<O extends object = {}> extends Dialog<O> implements EmitE
     static $kind: string;
     constructor();
     constructor(eventName: string, eventValue?: string, bubbleEvent?: boolean);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     bubbleEvent: BoolExpression;
     disabled?: BoolExpression;
     eventName: StringExpression;
@@ -933,7 +933,7 @@ export class EndDialog<O extends object = {}> extends Dialog<O> implements EndDi
     // (undocumented)
     static $kind: string;
     constructor(value?: any);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     protected endParentDialog(dc: DialogContext, result?: any): Promise<DialogTurnResult>;
     // (undocumented)
@@ -954,7 +954,7 @@ export interface EndDialogConfiguration extends DialogConfiguration {
 export class EndTurn<O extends object = {}> extends Dialog<O> implements EndTurnConfiguration {
     // (undocumented)
     static $kind: string;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     continueDialog(dc: DialogContext): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
@@ -998,7 +998,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
     static $kind: string;
     constructor();
     constructor(itemsProperty: string, actions: Dialog[]);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof ForEachConfiguration): Converter | ConverterFactory;
@@ -1006,10 +1006,10 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
     index: StringExpression;
     itemsProperty: StringExpression;
     protected nextItem(dc: DialogContext): Promise<DialogTurnResult>;
-    protected onBreakLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
+    protected onBreakLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
     protected onComputeId(): string;
-    protected onContinueLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
-    protected onEndOfActions(dc: DialogContext, result?: any): Promise<DialogTurnResult>;
+    protected onContinueLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
+    protected onEndOfActions(dc: DialogContext, _result?: any): Promise<DialogTurnResult>;
     value: StringExpression;
 }
 
@@ -1030,16 +1030,16 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
     // (undocumented)
     static $kind: string;
     constructor();
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof ForEachPageConfiguration): Converter | ConverterFactory;
     getDependencies(): Dialog[];
     itemsProperty: StringExpression;
-    protected onBreakLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
+    protected onBreakLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
     protected onComputeId(): string;
-    protected onContinueLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
-    protected onEndOfActions(dc: DialogContext, result?: any): Promise<DialogTurnResult>;
+    protected onContinueLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult>;
+    protected onEndOfActions(dc: DialogContext, _result?: any): Promise<DialogTurnResult>;
     page: StringExpression;
     pageIndex: StringExpression;
     pageSize: IntExpression;
@@ -1065,7 +1065,7 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
     static $kind: string;
     constructor();
     activityId: StringExpression;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof GetActivityMembersConfiguration): Converter | ConverterFactory;
@@ -1088,7 +1088,7 @@ export class GetConversationMembers<O extends object = {}> extends Dialog<O> imp
     // (undocumented)
     static $kind: string;
     constructor();
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof GetConversationMembersConfiguration): Converter | ConverterFactory;
@@ -1130,7 +1130,7 @@ export class GotoAction<O extends object = {}> extends Dialog<O> implements Goto
     static $kind: string;
     constructor();
     actionId: StringExpression;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof GotoActionConfiguration): Converter | ConverterFactory;
@@ -1182,7 +1182,7 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
     constructor(method: HttpMethod, url: string, headers: {
         [key: string]: string;
     }, body: any);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     body?: ValueExpression;
     contentType?: StringExpression;
     disabled?: BoolExpression;
@@ -1227,7 +1227,7 @@ export class IfCondition<O extends object = {}> extends Dialog<O> implements Dia
     static $kind: string;
     constructor();
     actions: Dialog[];
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     condition: BoolExpression;
     disabled?: BoolExpression;
     elseActions: Dialog[];
@@ -1416,7 +1416,7 @@ export class LogAction<O extends object = {}> extends Dialog<O> implements LogAc
     // (undocumented)
     static $kind: string;
     constructor(text: string);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof LogActionConfiguration): Converter | ConverterFactory;
@@ -2148,7 +2148,7 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
     static $kind: string;
     constructor();
     assignments: PropertyAssignment[];
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof SetPropertiesConfiguration): Converter | ConverterFactory;
@@ -2171,7 +2171,7 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
     static $kind: string;
     constructor();
     constructor(property: string, value: any);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof SetPropertyConfiguration): Converter | ConverterFactory;
@@ -2195,7 +2195,7 @@ export class SignOutUser<O extends object = {}> extends Dialog<O> implements Sig
     // (undocumented)
     static $kind: string;
     constructor();
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     connectionName: StringExpression;
     disabled?: BoolExpression;
     // (undocumented)
@@ -2250,13 +2250,13 @@ export interface StaticActivityTemplateConfiguration {
 // @public (undocumented)
 export type StringProperty = StringExpression | Property;
 
-// @public (undocumented)
+// @public
 export class SwitchCondition<O extends object = {}> extends Dialog<O> implements DialogDependencies, SwitchConditionConfiguration {
     // (undocumented)
     static $kind: string;
     constructor();
     constructor(condition: string, defaultDialogs: Dialog[], cases: Case[]);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     cases: Case[];
     condition: Expression;
     default: Dialog[];
@@ -2289,7 +2289,7 @@ export class TelemetryTrackEventAction<O extends object = {}> extends Dialog imp
     constructor(eventName: string, properties: {
         [name: string]: string;
     });
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled: BoolExpression;
     eventName: StringExpression;
     // (undocumented)
@@ -2393,7 +2393,7 @@ export class ThrowException extends Dialog implements ThrowExceptionConfiguratio
     // (undocumented)
     static $kind: string;
     constructor(errorValue: unknown);
-    beginDialog(dc: DialogContext, options?: Record<string, unknown>): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: Record<string, unknown>): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     errorValue?: ValueExpression;
     // (undocumented)
@@ -2415,7 +2415,7 @@ export class TraceActivity<O extends object = {}> extends Dialog<O> implements T
     static $kind: string;
     constructor();
     constructor(name: string, valueType: string, value: any, label: string);
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     disabled?: BoolExpression;
     // (undocumented)
     getConverter(property: keyof TraceActivityConfiguration): Converter | ConverterFactory;

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
@@ -44,6 +44,8 @@ export class ActionScope<O extends object = {}>
     implements DialogDependencies, ActionScopeConfiguration {
     /**
      * Creates a new `ActionScope` instance.
+     *
+     * @param actions The actions for the scope.
      */
     public constructor(actions: Dialog[] = []) {
         super();
@@ -55,6 +57,10 @@ export class ActionScope<O extends object = {}>
      */
     public actions: Dialog[] = [];
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ActionScopeConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'actions':
@@ -65,9 +71,10 @@ export class ActionScope<O extends object = {}>
     }
 
     /**
-     * Gets a unique `string` which represents the version of this dialog. If the version 
+     * Gets a unique `string` which represents the version of this dialog. If the version
      * changes between turns the dialog system will emit a DialogChanged event.
-     * @returns Unique `string` which should only change when dialog has changed in a 
+     *
+     * @returns Unique `string` which should only change when dialog has changed in a
      * way that should restart the dialog.
      */
     public getVersion(): string {
@@ -77,6 +84,7 @@ export class ActionScope<O extends object = {}>
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -85,11 +93,12 @@ export class ActionScope<O extends object = {}>
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.actions && this.actions.length > 0) {
             return await this.beginAction(dc, 0);
         } else {
@@ -98,8 +107,9 @@ export class ActionScope<O extends object = {}>
     }
 
     /**
-     * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the 
+     * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -109,14 +119,15 @@ export class ActionScope<O extends object = {}>
 
     /**
      * Called when a child [Dialog](xref:botbuilder-dialogs.Dialog) completed its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param _reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
-     * @param result Optional. Value returned from the dialog that was called. The type 
+     * @param result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
     public async resumeDialog(dc: DialogContext, _reason: DialogReason, result?: any): Promise<DialogTurnResult> {
-        if (result && typeof result === 'object' && result.hasOwnProperty('actionScopeCommand')) {
+        if (result && typeof result === 'object' && Object.hasOwnProperty.call(result, 'actionScopeCommand')) {
             return await this.onActionScopeResult(dc, result as ActionScopeResult);
         }
 
@@ -195,7 +206,7 @@ export class ActionScope<O extends object = {}>
      * @protected
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) continues to the next action.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param result Optional. Value returned from the dialog that was called. The type 
+     * @param result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -234,7 +245,7 @@ export class ActionScope<O extends object = {}>
      * @protected
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog)'s action ends.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param result Optional. Value returned from the dialog that was called. The type 
+     * @param result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -246,7 +257,7 @@ export class ActionScope<O extends object = {}>
      * @protected
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param offset Optional, value returned from the dialog that was called. The type 
+     * @param offset Optional, value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
@@ -40,6 +40,11 @@ export interface BaseInvokeDialogConfiguration extends DialogConfiguration {
 export class BaseInvokeDialog<O extends object = {}>
     extends Dialog<O>
     implements DialogDependencies, BaseInvokeDialogConfiguration {
+    /**
+     * Initializes a new instance of the [BaseInvokeDialog](xref:botbuilder-dialogs-adaptive.BaseInvokeDialog) class.
+     * @param dialogIdToCall The dialog id.
+     * @param bindingOptions (optional) Binding options.
+     */
     public constructor(dialogIdToCall?: string, bindingOptions?: O) {
         super();
         if (dialogIdToCall) {
@@ -65,6 +70,10 @@ export class BaseInvokeDialog<O extends object = {}>
      */
     public activityProcessed: BoolExpression = new BoolExpression(true);
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof BaseInvokeDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'options':
@@ -80,17 +89,18 @@ export class BaseInvokeDialog<O extends object = {}>
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @remarks Method not implemented.
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
-     * @returns A `Promise` representing the asynchronous operation.
+     * @param _dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param _options Optional. Initial information to pass to the dialog.
      */
-    public beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult<any>> {
+    public beginDialog(_dc: DialogContext, _options?: O): Promise<DialogTurnResult<any>> {
         throw new Error('Method not implemented.');
     }
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog<{}>[] {
@@ -113,6 +123,7 @@ export class BaseInvokeDialog<O extends object = {}>
      * @protected
      * Resolve Dialog Expression as either [Dialog](xref:botbuilder-dialogs.Dialog), or [StringExpression](xref:adaptive-expressions.StringExpression) to get `dialogid`.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @returns The dialog.
      */
     protected resolveDialog(dc: DialogContext): Dialog {
         if (this.dialog && this.dialog.value) {

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginDialog.ts
@@ -37,6 +37,7 @@ export class BeginDialog<O extends object = {}> extends BaseInvokeDialog<O> impl
 
     /**
      * Creates a new `BeginDialog` instance.
+     *
      * @param dialogIdToCall ID of the dialog to call.
      * @param options (Optional) static options to pass the called dialog.
      */
@@ -44,6 +45,7 @@ export class BeginDialog<O extends object = {}> extends BaseInvokeDialog<O> impl
 
     /**
      * Creates a new [BeginDialog](xref:botbuilder-dialogs-adaptive.BeginDialog) instance.
+     *
      * @param dialogIdToCall Optional. ID of the [Dialog](xref:botbuilder-dialogs.Dialog) to call.
      * @param options Optional. Static options to pass the called dialog.
      */
@@ -61,6 +63,10 @@ export class BeginDialog<O extends object = {}> extends BaseInvokeDialog<O> impl
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof BeginDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'resultProperty':
@@ -74,6 +80,7 @@ export class BeginDialog<O extends object = {}> extends BaseInvokeDialog<O> impl
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -95,6 +102,7 @@ export class BeginDialog<O extends object = {}> extends BaseInvokeDialog<O> impl
 
     /**
      * Called when a child [Dialog](xref:botbuilder-dialogs.Dialog) completed its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
      * @param result Optional. Value returned from the dialog that was called. The type

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -115,6 +115,10 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
      */
     public allowInterruptions: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof BeginSkillConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -147,6 +151,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
     /**
      * Creates a new `BeginSkillDialog instance.
+     *
      * @param options Optional options used to configure the skill dialog.
      */
     constructor(options?: SkillDialogOptions) {
@@ -155,6 +160,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -223,6 +229,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -242,6 +249,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) should re-prompt the user for input.
+     *
      * @param turnContext [TurnContext](xref:botbuilder-core.TurnContext), the context object for this turn.
      * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), state information for this dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -253,6 +261,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
     /**
      * Called when a child [Dialog](xref:botbuilder-dialogs.Dialog) completed its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
      * @param result Optional. Value returned from the dialog that was called. The type
@@ -266,6 +275,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is ending.
+     *
      * @param turnContext [TurnContext](xref:botbuilder-core.TurnContext), the context object for this turn.
      * @param instance [DialogInstance](xref:botbuilder-dialogs.DialogInstance), state information associated with the instance of this dialog on the dialog stack.
      * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog ended.

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/breakLoop.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/breakLoop.ts
@@ -33,6 +33,10 @@ export class BreakLoop<O extends object = {}> extends Dialog<O> implements Break
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof BreakLoopConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -44,11 +48,12 @@ export class BreakLoop<O extends object = {}> extends Dialog<O> implements Break
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -66,6 +71,6 @@ export class BreakLoop<O extends object = {}> extends Dialog<O> implements Break
      * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
-        return `BreakLoop[]`;
+        return 'BreakLoop[]';
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogs.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogs.ts
@@ -18,6 +18,7 @@ export class CancelAllDialogs<O extends object = {}> extends CancelAllDialogsBas
 
     /**
      * Initializes a new instance of the [CancelAllDialogs](xref:botbuilder-dialogs-adaptive.CancelAllDialogs) class.
+     *
      * @param eventName Expression for event name.
      * @param eventValue Optional. Expression for event value.
      */
@@ -25,6 +26,7 @@ export class CancelAllDialogs<O extends object = {}> extends CancelAllDialogsBas
 
     /**
      * Initializes a new instance of the [CancelAllDialogs](xref:botbuilder-dialogs-adaptive.CancelAllDialogs) class.
+     *
      * @param eventName Optional. Expression for event name.
      * @param eventValue Optional. Expression for event value.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogsBase.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogsBase.ts
@@ -44,6 +44,7 @@ export class CancelAllDialogsBase<O extends object = {}>
 
     /**
      * Initializes a new instance of the [CancelAllDialogsBase](xref:botbuilder-dialogs-adaptive.CancelAllDialogsBase) class.
+     *
      * @param eventName Expression for event name.
      * @param eventValue Optional. Expression for event value.
      * @param isCancelAll Set to `true` to cancel all dialogs; `false` otherwise.
@@ -52,6 +53,7 @@ export class CancelAllDialogsBase<O extends object = {}>
 
     /**
      * Initializes a new instance of the [CancelAllDialogsBase](xref:botbuilder-dialogs-adaptive.CancelAllDialogsBase) class.
+     *
      * @param eventName Optional. Expression for event name.
      * @param eventValue Optional. Expression for event value.
      * @param isCancelAll Set to `true` to cancel all [Dialogs](xref:botbuilder-dialogs.Dialog); `false` otherwise.
@@ -89,6 +91,10 @@ export class CancelAllDialogsBase<O extends object = {}>
 
     private _cancelAll: boolean;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof CancelAllDialogsBaseConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'eventName':
@@ -106,11 +112,12 @@ export class CancelAllDialogsBase<O extends object = {}>
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/cancelDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/cancelDialog.ts
@@ -18,6 +18,7 @@ export class CancelDialog<O extends object = {}> extends CancelAllDialogsBase<O>
 
     /**
      * Initializes a new instance of the [CancelDialog](xref:botbuilder-dialogs-adaptive.CancelDialog) class.
+     *
      * @param eventName Expression for event name.
      * @param eventValue Optional. Expression for event value.
      */
@@ -25,6 +26,7 @@ export class CancelDialog<O extends object = {}> extends CancelAllDialogsBase<O>
 
     /**
      * Initializes a new instance of the [CancelDialog](xref:botbuilder-dialogs-adaptive.CancelDialog) class.
+     *
      * @param eventName Optional. Expression for event name.
      * @param eventValue Optional. Expression for event value.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/case.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/case.ts
@@ -14,6 +14,7 @@ import { ActionScope } from './actionScope';
 export class Case extends ActionScope {
     /**
      * Initializes a new instance of the [Case](xref:botbuilder-dialogs-adaptive.Case) class.
+     *
      * @param value Optional. Case's string value.
      * @param actions Optional. Numerable list of [Dialog](xref:botbuilder-dialogs.Dialog) actions.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/codeAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/codeAction.ts
@@ -32,6 +32,10 @@ export class CodeAction<O extends object = {}> extends Dialog<O> {
 
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof CodeActionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -43,6 +47,7 @@ export class CodeAction<O extends object = {}> extends Dialog<O> {
 
     /**
      * Initializes a new instance of the [CodeAction](xref:botbuilder-dialogs-adaptive.CodeAction) class.
+     *
      * @param codeHandler [CodeActionHandler](xref:botbuilder-dialogs-adaptive.CodeActionHandler), code handler for the action.
      */
     public constructor(codeHandler: CodeActionHandler) {
@@ -52,6 +57,7 @@ export class CodeAction<O extends object = {}> extends Dialog<O> {
 
     /**
      * Builds the compute Id for the [Dialog](xref:botbuilder-dialogs.Dialog).
+     *
      * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
@@ -60,6 +66,7 @@ export class CodeAction<O extends object = {}> extends Dialog<O> {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversation.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversation.ts
@@ -62,6 +62,10 @@ export class ContinueConversation extends Dialog implements ContinueConversation
      */
     public value: ValueExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ContinueConversationConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversationLater.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversationLater.ts
@@ -62,6 +62,10 @@ export class ContinueConversationLater extends Dialog implements ContinueConvers
      */
     public value: ValueExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ContinueConversationLaterConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -79,10 +83,10 @@ export class ContinueConversationLater extends Dialog implements ContinueConvers
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
      *
      * @param {DialogContext} dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param {object} options Optional. Initial information to pass to the dialog.
+     * @param {object} _options Optional. Initial information to pass to the dialog.
      * @returns {Promise<DialogTurnResult>} A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: Record<string, unknown>): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: Record<string, unknown>): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/continueLoop.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/continueLoop.ts
@@ -33,6 +33,10 @@ export class ContinueLoop<O extends object = {}> extends Dialog<O> implements Co
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ContinueLoopConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -44,11 +48,12 @@ export class ContinueLoop<O extends object = {}> extends Dialog<O> implements Co
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -66,6 +71,6 @@ export class ContinueLoop<O extends object = {}> extends Dialog<O> implements Co
      * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
-        return `ContinueLoop[]`;
+        return 'ContinueLoop[]';
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/deleteActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/deleteActivity.ts
@@ -38,6 +38,7 @@ export class DeleteActivity<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Initializes a new instance of the [DeleteActivity](xref:botbuilder-dialogs-adaptive.DeleteActivity) class.
+     *
      * @param activityId ID of the activity to update.
      */
     public constructor(activityId?: string) {
@@ -57,6 +58,10 @@ export class DeleteActivity<O extends object = {}> extends Dialog<O> implements 
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof DeleteActivityConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'activityId':
@@ -70,11 +75,12 @@ export class DeleteActivity<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/deleteProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/deleteProperties.ts
@@ -38,6 +38,7 @@ export class DeleteProperties<O extends object = {}> extends Dialog<O> implement
 
     /**
      * Initializes a new instance of the [DeleteProperties](xref:botbuilder-dialogs-adaptive.DeleteProperties) class.
+     *
      * @param properties Optional. Collection of property paths to remove.
      */
     public constructor(properties?: string[]) {
@@ -57,6 +58,10 @@ export class DeleteProperties<O extends object = {}> extends Dialog<O> implement
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof DeletePropertiesConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'properties':
@@ -70,11 +75,12 @@ export class DeleteProperties<O extends object = {}> extends Dialog<O> implement
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/deleteProperty.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/deleteProperty.ts
@@ -36,6 +36,7 @@ export class DeleteProperty<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Creates a new `DeleteProperty` instance.
+     *
      * @param property (Optional) property to delete.
      */
     public constructor(property?: string) {
@@ -55,6 +56,10 @@ export class DeleteProperty<O extends object = {}> extends Dialog<O> implements 
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof DeletePropertyConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'property':
@@ -68,11 +73,12 @@ export class DeleteProperty<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/dynamicBeginDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/dynamicBeginDialog.ts
@@ -20,7 +20,8 @@ export class DynamicBeginDialog extends BeginDialog {
      * @protected
      * Evaluates expressions in options.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options The options to bind.
+     * @param _options The options to bind.
+     * @returns An object with the binded options
      */
     protected bindOptions(dc: DialogContext, _options: object): object {
         const options = {};

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/editActions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/editActions.ts
@@ -13,13 +13,7 @@ import { BoolProperty, EnumProperty } from '../properties';
 import { DialogListConverter } from '../converters';
 import { StringUtils } from 'botbuilder';
 
-import {
-    BoolExpression,
-    BoolExpressionConverter,
-    EnumExpression,
-    EnumExpressionConverter,
-    Expression,
-} from 'adaptive-expressions';
+import { BoolExpression, BoolExpressionConverter, EnumExpression, EnumExpressionConverter } from 'adaptive-expressions';
 
 import {
     Converter,
@@ -49,6 +43,7 @@ export class EditActions<O extends object = {}>
 
     /**
      * Initializes a new instance of the [EditActions](xref:botbuilder-dialogs-adaptive.EditActions) class.
+     *
      * @param changeType [ActionChangeType](xref:botbuilder-dialogs-adaptive.ActionChangeType), type of change to apply to the active actions.
      * @param actions Optional. Child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers dialogset.
      */
@@ -57,6 +52,7 @@ export class EditActions<O extends object = {}>
 
     /**
      * Initializes a new instance of the [EditActions](xref:botbuilder-dialogs-adaptive.EditActions) class.
+     *
      * @param changeType Optional. [ActionChangeType](xref:botbuilder-dialogs-adaptive.ActionChangeType), type of change to apply to the active actions.
      * @param actions Optional. Child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers dialogset.
      */
@@ -85,6 +81,10 @@ export class EditActions<O extends object = {}>
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof EditActionsConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'actions':
@@ -100,6 +100,7 @@ export class EditActions<O extends object = {}>
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -108,6 +109,7 @@ export class EditActions<O extends object = {}>
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -136,7 +138,7 @@ export class EditActions<O extends object = {}>
             dc.parent.queueChanges(changes);
             return await dc.endDialog();
         } else {
-            throw new Error(`EditActions should only be used in the context of an adaptive dialog.`);
+            throw new Error('EditActions should only be used in the context of an adaptive dialog.');
         }
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/editArray.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/editArray.ts
@@ -53,6 +53,7 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
 
     /**
      * Initializes a new instance of the [EditArray](xref:botbuilder-dialogs-adaptive.EditArray) class.
+     *
      * @param changeType [ArrayChangeType](xref:botbuilder-dialogs-adaptive.ArrayChangeType), change type.
      * @param itemsProperty Array property.
      * @param value Optional. Value to insert.
@@ -62,6 +63,7 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
 
     /**
      * Initializes a new instance of the [EditArray](xref:botbuilder-dialogs-adaptive.EditArray) class.
+     *
      * @param changeType Optional. [ArrayChangeType](xref:botbuilder-dialogs-adaptive.ArrayChangeType), change type.
      * @param itemsProperty Optional. Array property.
      * @param value Optional. Value to insert.
@@ -115,6 +117,10 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof EditArrayConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'changeType':
@@ -134,11 +140,12 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/emitEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/emitEvent.ts
@@ -43,6 +43,7 @@ export class EmitEvent<O extends object = {}> extends Dialog<O> implements EmitE
 
     /**
      * Initializes a new instance of the [EmitEvent](xref:botbuilder-dialogs-adaptive.EmitEvent) class.
+     *
      * @param eventName Name of the event to emit.
      * @param eventValue Optional. Memory property path to use to get the value to send as part of the event.
      * @param bubbleEvent Default = `false`. Value indicating whether the event should bubble to parents or not.
@@ -51,6 +52,7 @@ export class EmitEvent<O extends object = {}> extends Dialog<O> implements EmitE
 
     /**
      * Initializes a new instance of the [EmitEvent](xref:botbuilder-dialogs-adaptive.EmitEvent) class.
+     *
      * @param eventName Optional. Name of the event to emit.
      * @param eventValue Optional. Memory property path to use to get the value to send as part of the event.
      * @param bubbleEvent Default = `false`. Value indicating whether the event should bubble to parents or not.
@@ -91,6 +93,10 @@ export class EmitEvent<O extends object = {}> extends Dialog<O> implements EmitE
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof EmitEventConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'eventName':
@@ -108,11 +114,12 @@ export class EmitEvent<O extends object = {}> extends Dialog<O> implements EmitE
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/endDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/endDialog.ts
@@ -37,6 +37,7 @@ export class EndDialog<O extends object = {}> extends Dialog<O> implements EndDi
 
     /**
      * Creates a new `EndDialog` instance.
+     *
      * @param value Optional, a value expression for the result to be returned to the caller.
      */
     public constructor(value?: any) {
@@ -56,6 +57,10 @@ export class EndDialog<O extends object = {}> extends Dialog<O> implements EndDi
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof EndDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'value':
@@ -69,11 +74,12 @@ export class EndDialog<O extends object = {}> extends Dialog<O> implements EndDi
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -89,6 +95,7 @@ export class EndDialog<O extends object = {}> extends Dialog<O> implements EndDi
 
     /**
      * Ends the parent [Dialog](xref:botbuilder-dialogs.Dialog).
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/endTurn.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/endTurn.ts
@@ -33,6 +33,10 @@ export class EndTurn<O extends object = {}> extends Dialog<O> implements EndTurn
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof EndTurnConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -44,11 +48,12 @@ export class EndTurn<O extends object = {}> extends Dialog<O> implements EndTurn
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -58,6 +63,7 @@ export class EndTurn<O extends object = {}> extends Dialog<O> implements EndTurn
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the
      * user replies with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
      */
@@ -76,6 +82,6 @@ export class EndTurn<O extends object = {}> extends Dialog<O> implements EndTurn
      * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
-        return `EndTurn[]`;
+        return 'EndTurn[]';
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
@@ -38,6 +38,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
 
     /**
      * Initializes a new instance of the [Foreach](xref:botbuilder-dialogs-adaptive.Foreach) class.
+     *
      * @param itemsProperty Property path expression to the collection of items.
      * @param actions The actions to execute.
      */
@@ -45,6 +46,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
 
     /**
      * Initializes a new instance of the [Foreach](xref:botbuilder-dialogs-adaptive.Foreach) class.
+     *
      * @param itemsProperty Optional. Property path expression to the collection of items.
      * @param actions Optional. The actions to execute.
      */
@@ -78,6 +80,10 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ForEachConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'itemsProperty':
@@ -95,6 +101,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -103,11 +110,12 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -120,10 +128,10 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      * Called when returning control to this [Dialog](xref:botbuilder-dialogs.Dialog) with an [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult)
      * with the property `ActionCommand` set to `BreakLoop`.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param actionScopeResult The [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult).
+     * @param _actionScopeResult The [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult).
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onBreakLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
+    protected async onBreakLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
         return await dc.endDialog();
     }
 
@@ -132,10 +140,13 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      * Called when returning control to this [Dialog](xref:botbuilder-dialogs.Dialog) with an [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult)
      * with the property `ActionCommand` set to `ContinueLoop`.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param actionScopeResult The [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult).
+     * @param _actionScopeResult The [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult).
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onContinueLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
+    protected async onContinueLoop(
+        dc: DialogContext,
+        _actionScopeResult: ActionScopeResult
+    ): Promise<DialogTurnResult> {
         return await this.nextItem(dc);
     }
 
@@ -143,11 +154,11 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      * @protected
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) continues to the next action.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param result Optional. Value returned from the dialog that was called. The type
+     * @param _result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onEndOfActions(dc: DialogContext, result?: any): Promise<DialogTurnResult> {
+    protected async onEndOfActions(dc: DialogContext, _result?: any): Promise<DialogTurnResult> {
         return await this.nextItem(dc);
     }
 
@@ -180,11 +191,11 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
     }
 
     private convertToList(value: unknown) {
-        let result: { index: string | number, value: unknown }[] = [];
+        const result: { index: string | number; value: unknown }[] = [];
         if (Array.isArray(value)) {
             value.forEach((item, index) => result.push({ index: index, value: item }));
         } else if (typeof value === 'object') {
-            Object.entries(value).forEach(([key, value]) => result.push({ index: key, value: value }))
+            Object.entries(value).forEach(([key, value]) => result.push({ index: key, value: value }));
         }
 
         return result;

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEachPage.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEachPage.ts
@@ -45,6 +45,7 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
 
     /**
      * Initializes a new instance of the [ForeachPage](xref:botbuilder-dialogs-adaptive.ForeachPage) class.
+     *
      * @param itemsProperty Optional. Expression used to compute the list that should be enumerated.
      * @param pageSize Default = `10`. Page size.
      */
@@ -81,6 +82,10 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ForEachPageConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'itemsProperty':
@@ -100,6 +105,7 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -108,11 +114,12 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -125,11 +132,11 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
      * @protected
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) continues to the next action.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param result Optional. Value returned from the dialog that was called. The type
+     * @param _result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onEndOfActions(dc: DialogContext, result?: any): Promise<DialogTurnResult> {
+    protected async onEndOfActions(dc: DialogContext, _result?: any): Promise<DialogTurnResult> {
         return await this.nextPage(dc);
     }
 
@@ -138,10 +145,10 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
      * Called when returning control to this [Dialog](xref:botbuilder-dialogs.Dialog) with an [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult)
      * with the property `ActionCommand` set to `BreakLoop`.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param actionScopeResult [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult), contains the actions scope result.
+     * @param _actionScopeResult [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult), contains the actions scope result.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onBreakLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
+    protected async onBreakLoop(dc: DialogContext, _actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
         return await dc.endDialog();
     }
 
@@ -150,10 +157,13 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
      * Called when returning control to this [Dialog](xref:botbuilder-dialogs.Dialog) with an [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult)
      * with the property `ActionCommand` set to `ContinueLoop`.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param actionScopeResult [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult), contains the actions scope result.
+     * @param _actionScopeResult [ActionScopeResult](xref:botbuilder-dialogs-adaptive.ActionScopeResult), contains the actions scope result.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    protected async onContinueLoop(dc: DialogContext, actionScopeResult: ActionScopeResult): Promise<DialogTurnResult> {
+    protected async onContinueLoop(
+        dc: DialogContext,
+        _actionScopeResult: ActionScopeResult
+    ): Promise<DialogTurnResult> {
         return await this.nextPage(dc);
     }
 
@@ -202,7 +212,7 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
         } else if (typeof list === 'object') {
             let i = index;
             for (const key in list) {
-                if (list.hasOwnProperty(key)) {
+                if (Object.hasOwnProperty.call(list, key)) {
                     if (i < end) {
                         page.push(list[key]);
                     }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getActivityMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getActivityMembers.ts
@@ -39,6 +39,7 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
 
     /**
      * Initializes a new instance of the [GetActivityMembers](xref:botbuilder-dialogs-adaptive.GetActivityMembers) class.
+     *
      * @param activityId Optional. The expression to get the value to put into property path.
      * @param property Optional. Property path to put the value in.
      */
@@ -67,6 +68,10 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof GetActivityMembersConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'activityId':
@@ -82,11 +87,12 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
@@ -49,6 +49,7 @@ export class GetConversationMembers<O extends object = {}>
 
     /**
      * Initializes a new instance of the [GetConversationMembers](xref:botbuilder-dialogs-adaptive.GetConversationMembers) class.
+     *
      * @param property Property path to put the value in.
      */
     public constructor(property?: string) {
@@ -68,6 +69,10 @@ export class GetConversationMembers<O extends object = {}>
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof GetConversationMembersConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'property':
@@ -81,11 +86,12 @@ export class GetConversationMembers<O extends object = {}>
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationReference.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationReference.ts
@@ -45,6 +45,10 @@ export class GetConversationReference extends Dialog implements GetConversationR
      */
     public property: StringExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof GetConversationReferenceConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/gotoAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/gotoAction.ts
@@ -39,6 +39,7 @@ export class GotoAction<O extends object = {}> extends Dialog<O> implements Goto
 
     /**
      * Initializes a new instance of the [GotoAction](xref:botbuilder-dialogs-adaptive.GotoAction) class.
+     *
      * @param actionId Optional. Action's unique identifier.
      */
     public constructor(actionId?: string) {
@@ -58,6 +59,10 @@ export class GotoAction<O extends object = {}> extends Dialog<O> implements Goto
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof GotoActionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'actionId':
@@ -71,17 +76,18 @@ export class GotoAction<O extends object = {}> extends Dialog<O> implements Goto
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
 
         if (!this.actionId) {
-            throw new Error(`Action id cannot be null.`);
+            throw new Error('Action id cannot be null.');
         }
 
         const actionScopeResult: ActionScopeResult = {

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
@@ -40,6 +40,7 @@ type HeadersOutput = Record<string, StringExpression>;
 class HttpHeadersConverter implements Converter<HeadersInput, HeadersOutput> {
     /**
      * Converts a [HeadersInput](xref:botbuilder-dialogs-adaptive.HeadersInput) or [HeadersOutput](xref:botbuilder-dialogs-adaptive.HeadersOutput) to [HttpHeader](xref:botbuilder-dialogs-adaptive.HttpHeader).
+     *
      * @param value [HeadersInput](xref:botbuilder-dialogs-adaptive.HeadersInput) or [HeadersOutput](xref:botbuilder-dialogs-adaptive.HeadersOutput) to convert.
      * @returns The [HttpHeader](xref:botbuilder-dialogs-adaptive.HttpHeader).
      */
@@ -113,6 +114,7 @@ export enum HttpMethod {
 export class Result {
     /**
      * Initialize a new instance of Result class.
+     *
      * @param headers Response headers.
      */
     public constructor(headers?: Headers) {
@@ -165,6 +167,7 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
 
     /**
      * Initializes a new instance of the [HttpRequest](xref:botbuilder-dialogs-adaptive.HttpRequest) class.
+     *
      * @param method The [HttpMethod](xref:botbuilder-dialogs-adaptive.HttpMethod), for example POST, GET, DELETE or PUT.
      * @param url URL for the request.
      * @param headers The headers of the request.
@@ -174,6 +177,7 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
 
     /**
      * Initializes a new instance of the [HttpRequest](xref:botbuilder-dialogs-adaptive.HttpRequest) class.
+     *
      * @param method Optional. The [HttpMethod](xref:botbuilder-dialogs-adaptive.HttpMethod), for example POST, GET, DELETE or PUT.
      * @param url Optional. URL for the request.
      * @param headers Optional. The headers of the request.
@@ -231,6 +235,10 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof HttpRequestConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'contentType':
@@ -254,11 +262,12 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
@@ -330,7 +339,7 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
                 result.content = await response.json();
                 dc.context.sendActivities(result.content as Activity[]);
                 break;
-            case ResponsesTypes.Json:
+            case ResponsesTypes.Json: {
                 const content = await response.text();
                 try {
                     result.content = JSON.parse(content);
@@ -338,10 +347,12 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
                     result.content = content;
                 }
                 break;
-            case ResponsesTypes.Binary:
+            }
+            case ResponsesTypes.Binary: {
                 const buffer = await response.arrayBuffer();
                 result.content = new Uint8Array(buffer);
                 break;
+            }
             case ResponsesTypes.None:
             default:
                 break;

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/ifCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/ifCondition.ts
@@ -40,6 +40,7 @@ export class IfCondition<O extends object = {}>
 
     /**
      * Initializes a new instance of the [IfCondition](xref:botbuilder-dialogs-adaptive.IfCondition) class.
+     *
      * @param condition Optional. Conditional expression to evaluate.
      * @param elseActions Optional. The actions to run if [condition](#condition) returns false.
      */
@@ -73,6 +74,10 @@ export class IfCondition<O extends object = {}>
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof IfConditionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'condition':
@@ -119,6 +124,7 @@ export class IfCondition<O extends object = {}>
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -127,11 +133,12 @@ export class IfCondition<O extends object = {}>
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/logAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/logAction.ts
@@ -43,12 +43,14 @@ export class LogAction<O extends object = {}> extends Dialog<O> implements LogAc
 
     /**
      * Creates a new [LogAction](xref:botbuilder-dialogs-adaptive.LogAction) instance.
+     *
      * @param template The text template to log.
      */
     public constructor(text: string);
 
     /**
      * Creates a new [LogAction](xref:botbuilder-dialogs-adaptive.LogAction) instance.
+     *
      * @param text Optional. The text template to log.
      */
     public constructor(text?: string) {
@@ -79,6 +81,10 @@ export class LogAction<O extends object = {}> extends Dialog<O> implements LogAc
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof LogActionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'text':
@@ -96,11 +102,12 @@ export class LogAction<O extends object = {}> extends Dialog<O> implements LogAc
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/repeatDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/repeatDialog.ts
@@ -25,6 +25,7 @@ export class RepeatDialog<O extends object = {}> extends BaseInvokeDialog<O> imp
 
     /**
      * Initializes a new instance of the [RepeatDialog](xref:botbuilder-dialogs-adaptive.RepeatDialog) class.
+     *
      * @param options Optional. Object with additional options.
      */
     public constructor(options?: O) {
@@ -41,6 +42,10 @@ export class RepeatDialog<O extends object = {}> extends BaseInvokeDialog<O> imp
      */
     public allowLoop?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof RepeatDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -54,6 +59,7 @@ export class RepeatDialog<O extends object = {}> extends BaseInvokeDialog<O> imp
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/replaceDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/replaceDialog.ts
@@ -22,6 +22,7 @@ export class ReplaceDialog<O extends object = {}> extends BaseInvokeDialog<O> im
 
     /**
      * Creates a new [ReplaceDialog](xref:botbuilder-dialogs-adaptive.ReplaceDialog) instance.
+     *
      * @param dialogId ID of the [Dialog](xref:botbuilder-dialogs.Dialog) to goto.
      * @param options Optional, static options to pass the [Dialog](xref:botbuilder-dialogs.Dialog).
      */
@@ -29,7 +30,8 @@ export class ReplaceDialog<O extends object = {}> extends BaseInvokeDialog<O> im
 
     /**
      * Creates a new [ReplaceDialog](xref:botbuilder-dialogs-adaptive.ReplaceDialog) instance.
-     * @param dialogId Optional. ID of the [Dialog](xref:botbuilder-dialogs.Dialog) to goto.
+     *
+     * @param dialogIdToCall Optional. ID of the [Dialog](xref:botbuilder-dialogs.Dialog) to goto.
      * @param options Optional. Static options to pass the [Dialog](xref:botbuilder-dialogs.Dialog).
      */
     public constructor(dialogIdToCall?: string, options?: O) {
@@ -41,6 +43,10 @@ export class ReplaceDialog<O extends object = {}> extends BaseInvokeDialog<O> im
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ReplaceDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -52,6 +58,7 @@ export class ReplaceDialog<O extends object = {}> extends BaseInvokeDialog<O> im
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
@@ -39,6 +39,7 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
 
     /**
      * Creates a new [SendActivity](xref:botbuilder-dialogs-adaptive.SendActivity) instance.
+     *
      * @param activity [Activity](xref:botframework-schema.Activity) or message text to send the user.
      */
     public constructor(activity?: Partial<Activity> | string) {
@@ -62,6 +63,10 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SendActivityConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'activity':
@@ -75,6 +80,7 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The `DialogContext` for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -86,7 +92,7 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
 
         if (!this.activity) {
             // throw new Error(`SendActivity: no activity assigned for action '${this.id}'.`)
-            throw new Error(`SendActivity: no activity assigned for action.`);
+            throw new Error('SendActivity: no activity assigned for action.');
         }
 
         // Send activity and return result

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/sendHandoffActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/sendHandoffActivity.ts
@@ -40,6 +40,10 @@ export class SendHandoffActivity extends Dialog implements SendHandoffActivityCo
      */
     public transcript: ObjectExpression<Transcript>;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SendHandoffActivityConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'context':

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
@@ -53,6 +53,7 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
 
     /**
      * Initializes a new instance of the [SetProperties](xref:botbuilder-dialogs-adaptive.SetProperties) class.
+     *
      * @param assignments Optional. [PropertyAssignment](xref:botbuilder-dialogs-adaptive.PropertyAssignment), additional property settings as property/value pairs.
      */
     public constructor(assignments?: PropertyAssignment[]) {
@@ -72,6 +73,10 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SetPropertiesConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'assignments':
@@ -85,11 +90,12 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/setProperty.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/setProperty.ts
@@ -42,6 +42,7 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
 
     /**
      * Initializes a new instance of the [SetProperty](xref:botbuilder-dialogs-adaptive.SetProperty) class.
+     *
      * @param property Property path to put the value in.
      * @param value The expression to get the value to put into property path.
      */
@@ -49,6 +50,7 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
 
     /**
      * Initializes a new instance of the [SetProperty](xref:botbuilder-dialogs-adaptive.SetProperty) class.
+     *
      * @param property Optional. Property path to put the value in.
      * @param value Optional. The expression to get the value to put into property path.
      */
@@ -77,6 +79,10 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SetPropertyConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'property':
@@ -92,11 +98,12 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/signOutUser.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/signOutUser.ts
@@ -39,6 +39,7 @@ export class SignOutUser<O extends object = {}> extends Dialog<O> implements Sig
 
     /**
      * Initializes a new instance of the [SignOutUser](xref:botbuilder-dialogs-adaptive.SignOutUser) class.
+     *
      * @param userId Optional. The expression which resolves to the userId to sign out.
      * @param connectionName Optional. The name of the OAuth connection.
      */
@@ -67,6 +68,10 @@ export class SignOutUser<O extends object = {}> extends Dialog<O> implements Sig
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SignOutUserConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'userId':
@@ -82,11 +87,12 @@ export class SignOutUser<O extends object = {}> extends Dialog<O> implements Sig
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/switchCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/switchCondition.ts
@@ -19,7 +19,7 @@ import {
     ValueExpression,
 } from 'adaptive-expressions';
 
-import {BoolProperty, Property} from '../properties';
+import { BoolProperty, Property } from '../properties';
 
 import {
     Converter,
@@ -54,6 +54,9 @@ export interface SwitchConditionConfiguration extends DialogConfiguration {
     disabled?: BoolProperty;
 }
 
+/**
+ * Conditional branch with multiple cases.
+ */
 export class SwitchCondition<O extends object = {}>
     extends Dialog<O>
     implements DialogDependencies, SwitchConditionConfiguration {
@@ -63,6 +66,7 @@ export class SwitchCondition<O extends object = {}>
 
     /**
      * Initializes a new instance of the [SwitchCondition](xref:botbuilder-dialogs-adaptive.SwitchCondition) class
+     *
      * @param condition Condition expression against memory.
      * @param defaultDialogs Default [Dialog](xref:botbuilder-dialogs.Dialog) array.
      * @param cases Cases.
@@ -71,6 +75,7 @@ export class SwitchCondition<O extends object = {}>
 
     /**
      * Initializes a new instance of the [SwitchCondition](xref:botbuilder-dialogs-adaptive.SwitchCondition) class
+     *
      * @param condition Optional. Condition expression against memory.
      * @param defaultDialogs Optional. Default [Dialog](xref:botbuilder-dialogs.Dialog) array.
      * @param cases Optional. Cases.
@@ -108,6 +113,10 @@ export class SwitchCondition<O extends object = {}>
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SwitchConditionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'condition':
@@ -129,6 +138,7 @@ export class SwitchCondition<O extends object = {}>
 
     /**
      * Gets the child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies so they can be added to the containers [Dialog](xref:botbuilder-dialogs.Dialog) set.
+     *
      * @returns The child [Dialog](xref:botbuilder-dialogs.Dialog) dependencies.
      */
     public getDependencies(): Dialog[] {
@@ -145,11 +155,12 @@ export class SwitchCondition<O extends object = {}>
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/telemetryTrackEventAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/telemetryTrackEventAction.ts
@@ -33,7 +33,7 @@ class TelemetryPropertiesConverter implements Converter<PropertiesInput, Propert
     /**
      * Converts a [PropertiesInput](xref:botbuilder-dialogs-adaptive.PropertiesInput) or [PropertiesOutput](xref:botbuilder-dialogs-adaptive.PropertiesOutput) into telemetry [PropertiesOutput](xref:botbuilder-dialogs-adaptive.PropertiesOutput).
      *
-     * @param properties The [PropertiesInput](xref:botbuilder-dialogs-adaptive.PropertiesInput) or [PropertiesOutput](xref:botbuilder-dialogs-adaptive.PropertiesOutput) to convert.
+     * @param value The [PropertiesInput](xref:botbuilder-dialogs-adaptive.PropertiesInput) or [PropertiesOutput](xref:botbuilder-dialogs-adaptive.PropertiesOutput) to convert.
      * @returns The converted [StringExpression](xref:adaptive-expressions.StringExpression).
      */
     public convert(value: PropertiesInput | PropertiesOutput): PropertiesOutput {
@@ -60,6 +60,7 @@ export class TelemetryTrackEventAction<O extends object = {}>
 
     /**
      * Initializes a new instance of the [TelemetryTrackEventAction](xref:botbuilder-dialogs-adaptive.TelemetryTrackEventAction) class.
+     *
      * @param eventName Name to use for the event.
      * @param properties Properties to attach to the tracked event.
      */
@@ -67,6 +68,7 @@ export class TelemetryTrackEventAction<O extends object = {}>
 
     /**
      * Initializes a new instance of the [TelemetryTrackEventAction](xref:botbuilder-dialogs-adaptive.TelemetryTrackEventAction) class.
+     *
      * @param eventName Optional. Name to use for the event.
      * @param properties Optional. Properties to attach to the tracked event.
      */
@@ -98,6 +100,10 @@ export class TelemetryTrackEventAction<O extends object = {}>
      */
     public properties: { [name: string]: StringExpression };
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof TelemetryTrackEventActionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'eventName':
@@ -113,11 +119,12 @@ export class TelemetryTrackEventAction<O extends object = {}>
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/throwException.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/throwException.ts
@@ -37,6 +37,7 @@ export class ThrowException extends Dialog implements ThrowExceptionConfiguratio
 
     /**
      * Initializes a new instance of the [ThrowException](xref:botbuilder-dialogs-adaptive.ThrowException) class.
+     *
      * @param errorValue Optional. Memory property path to use to get the error value to throw.
      */
     public constructor(errorValue: unknown) {
@@ -56,6 +57,10 @@ export class ThrowException extends Dialog implements ThrowExceptionConfiguratio
      */
     public errorValue?: ValueExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     getConverter(property: keyof ThrowExceptionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'disabled':
@@ -71,10 +76,10 @@ export class ThrowException extends Dialog implements ThrowExceptionConfiguratio
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
      *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: Record<string, unknown>): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: Record<string, unknown>): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/traceActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/traceActivity.ts
@@ -44,6 +44,7 @@ export class TraceActivity<O extends object = {}> extends Dialog<O> implements T
 
     /**
      * Initializes a new instance of the [TraceActivity](xref:botbuilder-dialogs-adaptive.TraceActivity) class.
+     *
      * @param name Name of the trace activity.
      * @param valueType Value type of the trace activity.
      * @param value Value expression to send as the value.
@@ -53,6 +54,7 @@ export class TraceActivity<O extends object = {}> extends Dialog<O> implements T
 
     /**
      * Initializes a new instance of the [TraceActivity](xref:botbuilder-dialogs-adaptive.TraceActivity) class.
+     *
      * @param name Optional. Name of the trace activity.
      * @param valueType Optional. Value type of the trace activity.
      * @param value Optional. Value expression to send as the value.
@@ -99,6 +101,10 @@ export class TraceActivity<O extends object = {}> extends Dialog<O> implements T
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof TraceActivityConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'name':
@@ -118,11 +124,12 @@ export class TraceActivity<O extends object = {}> extends Dialog<O> implements T
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional. Initial information to pass to the dialog.
+     * @param _options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
@@ -48,6 +48,7 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Initializes a new instance of the [UpdateActivity](xref:botbuilder-dialogs-adaptive.UpdateActivity) class.
+     *
      * @param activityId Optional. The expression which resolves to the activityId to update.
      * @param activity Optional. Template for the [Activity](xref:botframework-schema.Activity).
      */
@@ -80,6 +81,10 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof UpdateActivityConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'activity':
@@ -95,6 +100,7 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
 
     /**
      * Starts a new [Dialog](xref:botbuilder-dialogs.Dialog) and pushes it onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the dialog.
      * @returns A `Promise` representing the asynchronous operation.
@@ -105,7 +111,7 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
         }
 
         if (!this.activity) {
-            throw new Error(`UpdateActivity: no activity assigned for action.`);
+            throw new Error('UpdateActivity: no activity assigned for action.');
         }
 
         const data = Object.assign(


### PR DESCRIPTION
Adresses # 2745
#minor

## Description
When reviewing the botbuilder-js project it was found that eslint is showing several warnings for the botbuilder-dialogs-adaptive library.

## Specific Changes

- Replaced strings quotes with the correct one depending of the case
- Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
- Adjusted formatting
- Limited importing scopes
- Added missing jsdocs documentation for parameters and returns for functions
- Removed unused variables
- Added _ (underscore) to unused parameters that couldn't be removed to omit them in the eslint validation
- Omitted validation for unknow/any/object variables as they will be treated in a different task

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149823185-f518820c-91ba-4cdc-9776-3e7434225438.png)