### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs-adaptive library - recognizers

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -1328,11 +1328,9 @@ export enum InputState {
 // @public
 export class IntentPattern {
     constructor(intent?: string, pattern?: string);
-    // (undocumented)
     get intent(): string;
     // Warning: (ae-setter-with-docs) The doc comment for the property "intent" must appear on the getter, not the setter.
     set intent(value: string);
-    // (undocumented)
     get pattern(): string;
     // Warning: (ae-setter-with-docs) The doc comment for the property "pattern" must appear on the getter, not the setter.
     set pattern(value: string);
@@ -1494,7 +1492,7 @@ export interface MultiLanguageGeneratorBaseConfiguration {
     languagePolicy?: Record<string, string[]> | LanguagePolicy;
 }
 
-// @public (undocumented)
+// @public
 export class MultiLanguageRecognizer extends AdaptiveRecognizer implements MultiLanguageRecognizerConfiguration {
     // (undocumented)
     static $kind: string;
@@ -1502,7 +1500,6 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
     getConverter(property: keyof MultiLanguageRecognizerConfiguration): Converter | ConverterFactory;
     // (undocumented)
     languagePolicy: LanguagePolicy;
-    // (undocumented)
     recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: {
         [key: string]: string;
     }, telemetryMetrics?: {
@@ -1951,7 +1948,6 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
     static $kind: string;
     // (undocumented)
     getConverter(property: keyof RecognizerSetConfiguration): Converter | ConverterFactory;
-    // (undocumented)
     recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: {
         [key: string]: string;
     }, telemetryMetrics?: {
@@ -1967,7 +1963,7 @@ export interface RecognizerSetConfiguration extends RecognizerConfiguration {
     recognizers?: string[] | Recognizer[];
 }
 
-// @public (undocumented)
+// @public
 export class RegexEntityRecognizer extends TextEntityRecognizer implements RegexEntityRecognizerConfiguration {
     // (undocumented)
     static $kind: string;
@@ -1988,7 +1984,7 @@ export interface RegexEntityRecognizerConfiguration {
     pattern?: string;
 }
 
-// @public (undocumented)
+// @public
 export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecognizerConfiguration {
     // (undocumented)
     static $kind: string;
@@ -1996,7 +1992,6 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
     // (undocumented)
     getConverter(property: keyof RegexRecognizerConfiguration): Converter | ConverterFactory;
     intents: IntentPattern[];
-    // (undocumented)
     recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: {
         [key: string]: string;
     }, telemetryMetrics?: {

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -461,7 +461,7 @@ export class Case extends ActionScope {
 export class ChannelMentionEntityRecognizer extends AdaptiveRecognizer {
     // (undocumented)
     static $kind: string;
-    recognize(dialogContext: DialogContext, activity: Partial<Activity>, telemetryProperties?: Record<string, string>, telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
+    recognize(_dialogContext: DialogContext, activity: Partial<Activity>, _telemetryProperties?: Record<string, string>, _telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
 }
 
 // @public (undocumented)
@@ -970,8 +970,8 @@ export interface EndTurnConfiguration extends DialogConfiguration {
 
 // @public
 export class EntityRecognizer extends AdaptiveRecognizer {
-    recognize(dialogContext: DialogContext, activity: Partial<Activity>, telemetryProperties?: Record<string, string>, telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
-    recognizeEntities(dialogContext: DialogContext, text: string, locale: string, entities: Entity[]): Promise<Entity[]>;
+    recognize(dialogContext: DialogContext, activity: Partial<Activity>, _telemetryProperties?: Record<string, string>, _telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
+    recognizeEntities(_dialogContext: DialogContext, _text: string, _locale: string, _entities: Entity[]): Promise<Entity[]>;
 }
 
 // @public
@@ -1330,9 +1330,11 @@ export class IntentPattern {
     constructor(intent?: string, pattern?: string);
     // (undocumented)
     get intent(): string;
+    // Warning: (ae-setter-with-docs) The doc comment for the property "intent" must appear on the getter, not the setter.
     set intent(value: string);
     // (undocumented)
     get pattern(): string;
+    // Warning: (ae-setter-with-docs) The doc comment for the property "pattern" must appear on the getter, not the setter.
     set pattern(value: string);
     // (undocumented)
     get regex(): RegExp;
@@ -1973,8 +1975,9 @@ export class RegexEntityRecognizer extends TextEntityRecognizer implements Regex
     // (undocumented)
     name: string;
     get pattern(): string;
+    // Warning: (ae-setter-with-docs) The doc comment for the property "pattern" must appear on the getter, not the setter.
     set pattern(value: string);
-    protected _recognize(text: string, culture: string): ModelResult[];
+    protected _recognize(text: string, _culture: string): ModelResult[];
 }
 
 // @public

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/adaptiveRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/adaptiveRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { BoolExpression } from 'adaptive-expressions';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import { getTopScoringIntent, RecognizerResult } from 'botbuilder';
 import { DialogContext, Recognizer } from 'botbuilder-dialogs';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -6,7 +6,8 @@
  * Licensed under the MIT License.
  */
 
-import { merge, pickBy } from 'lodash';
+import merge from 'lodash/merge';
+import pickBy from 'lodash/pickBy';
 import { Activity, RecognizerResult, getTopScoringIntent } from 'botbuilder';
 import { Converter, ConverterFactory, DialogContext, Recognizer, RecognizerConfiguration } from 'botbuilder-dialogs';
 import { RecognizerListConverter } from '../converters';
@@ -32,6 +33,10 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
      */
     public recognizers: Recognizer[] = [];
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof CrossTrainedRecognizerSetConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'recognizers':

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ageEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ageEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes age input.
  */
 export class AgeEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.AgeEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/channelMentionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/channelMentionEntityRecognizer.ts
@@ -19,17 +19,17 @@ export class ChannelMentionEntityRecognizer extends AdaptiveRecognizer {
     /**
      * To recognize intents and entities in a users utterance.
      *
-     * @param {DialogContext} dialogContext Dialog Context.
+     * @param {DialogContext} _dialogContext Dialog Context.
      * @param {Partial<Activity>} activity Activity.
-     * @param {object} telemetryProperties Additional properties to be logged to telemetry with event.
-     * @param {object} telemetryMetrics Additional metrics to be logged to telemetry with event.
+     * @param {object} _telemetryProperties Additional properties to be logged to telemetry with event.
+     * @param {object} _telemetryMetrics Additional metrics to be logged to telemetry with event.
      * @returns {Promise<RecognizerResult>} Analysis of utterance.
      */
     public async recognize(
-        dialogContext: DialogContext,
+        _dialogContext: DialogContext,
         activity: Partial<Activity>,
-        telemetryProperties?: Record<string, string>,
-        telemetryMetrics?: Record<string, number>
+        _telemetryProperties?: Record<string, string>,
+        _telemetryMetrics?: Record<string, number>
     ): Promise<RecognizerResult> {
         const result: RecognizerResult = {
             text: '',

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/confirmationEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/confirmationEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes yes/no confirmation style input.
  */
 export class ConfirmationEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.ConfirmationEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/currencyEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/currencyEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes currency input.
  */
 export class CurrencyEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.CurrencyEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dateTimeEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dateTimeEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes DateTime input.
  */
 export class DateTimeEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.DateTimeEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dimensionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dimensionEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes dimension input.
  */
 export class DimensionEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.DimensionEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/emailEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/emailEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes email input.
  */
 export class EmailEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.EmailEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizer.ts
@@ -20,15 +20,15 @@ export class EntityRecognizer extends AdaptiveRecognizer {
      *
      * @param {DialogContext} dialogContext Dialog Context.
      * @param {Partial<Activity>} activity Activity.
-     * @param {object} telemetryProperties Additional properties to be logged to telemetry with event.
-     * @param {object} telemetryMetrics Additional metrics to be logged to telemetry with event.
+     * @param {object} _telemetryProperties Additional properties to be logged to telemetry with event.
+     * @param {object} _telemetryMetrics Additional metrics to be logged to telemetry with event.
      * @returns {Promise<RecognizerResult>} Analysis of utterance.
      */
     public async recognize(
         dialogContext: DialogContext,
         activity: Partial<Activity>,
-        telemetryProperties?: Record<string, string>,
-        telemetryMetrics?: Record<string, number>
+        _telemetryProperties?: Record<string, string>,
+        _telemetryMetrics?: Record<string, number>
     ): Promise<RecognizerResult> {
         // Identify matched intents
         const text = activity.text ?? '';
@@ -99,17 +99,17 @@ export class EntityRecognizer extends AdaptiveRecognizer {
     /**
      * Recognizes entities from an [Entity](xref:botbuilder-core.Entity) list.
      *
-     * @param {DialogContext} dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param {string} text Text to recognize.
-     * @param {string} locale Locale to use.
-     * @param {Entity[]} entities The [Entity](xref:botbuilder-core.Entity) list to be recognized.
+     * @param {DialogContext} _dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param {string} _text Text to recognize.
+     * @param {string} _locale Locale to use.
+     * @param {Entity[]} _entities The [Entity](xref:botbuilder-core.Entity) list to be recognized.
      * @returns {Promise<Entity[]>} Recognized [Entity](xref:botbuilder-core.Entity) list.
      */
     public async recognizeEntities(
-        dialogContext: DialogContext,
-        text: string,
-        locale: string,
-        entities: Entity[]
+        _dialogContext: DialogContext,
+        _text: string,
+        _locale: string,
+        _entities: Entity[]
     ): Promise<Entity[]> {
         return [];
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizerSet.ts
@@ -19,6 +19,7 @@ export class EntityRecognizerSet extends Array<EntityRecognizer> {
 
     /**
      * Implement [EntityRecognizer.recognizeEntities](xref:botbuilder-dialogs-adaptive.EntityRecognizer.recognizeEntities) by iterating against the Recognizer pool.
+     *
      * @param dialogContext [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param text Text to recognize.
      * @param locale Locale to use.

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/guidEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/guidEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes GUID input.
  */
 export class GuidEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.GuidEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/hashtagEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/hashtagEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes hashtag input.
  */
 export class HashtagEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.HashtagEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ipEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ipEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes IP input.
  */
 export class IpEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.IpEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/mentionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/mentionEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes mention input.
  */
 export class MentionEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.MentionEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/numberEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/numberEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes number input.
  */
 export class NumberEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.NumberEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ordinalEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ordinalEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes ordinal input.
  */
 export class OrdinalEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.OrdinalEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/percentageEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/percentageEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes percentage input.
  */
 export class PercentageEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.PercentageEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/phoneNumberEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/phoneNumberEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes phone number input.
  */
 export class PhoneNumberEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.PhoneNumberEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/regexEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/regexEntityRecognizer.ts
@@ -14,12 +14,16 @@ export interface RegexEntityRecognizerConfiguration {
     pattern?: string;
 }
 
+/**
+ * Matches input against a regular expression.
+ */
 export class RegexEntityRecognizer extends TextEntityRecognizer implements RegexEntityRecognizerConfiguration {
     public static $kind = 'Microsoft.RegexEntityRecognizer';
 
     public constructor();
     /**
      * Initializes a new instance of the [RegexEntityRecognizer](xref:botbuilder-dialogs-adaptive.RegexEntityRecognizer) class.
+     *
      * @param name The name match result `typeName` value.
      * @param pattern The regular expression pattern value.
      */
@@ -37,11 +41,16 @@ export class RegexEntityRecognizer extends TextEntityRecognizer implements Regex
 
     /**
      * Gets the regular expression pattern value.
+     *
+     * @returns The pattern.
      */
     public get pattern(): string {
         return this._pattern;
     }
 
+    /**
+     * Sets the pattern.
+     */
     public set pattern(value: string) {
         if (value.startsWith('(?i)')) {
             value = value.substr(4);
@@ -55,14 +64,15 @@ export class RegexEntityRecognizer extends TextEntityRecognizer implements Regex
      * @protected
      * Match recognizing implementation.
      * @param text Text to match.
-     * @param culture Culture to use.
+     * @param _culture Culture to use.
      * @returns The matched [ModelResult](xref:botbuilder-dialogs.ModelResult) list.
      */
-    protected _recognize(text: string, culture: string): ModelResult[] {
+    protected _recognize(text: string, _culture: string): ModelResult[] {
         const results: ModelResult[] = [];
 
         const matches = [];
         let matched: RegExpExecArray;
+        // eslint-disable-next-line security/detect-non-literal-regexp
         const regexp = new RegExp(this._pattern, 'ig');
         while ((matched = regexp.exec(text))) {
             matches.push(matched);

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/temperatureEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/temperatureEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes temperature input.
  */
 export class TemperatureEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.TemperatureEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntity.ts
@@ -18,6 +18,7 @@ export class TextEntity implements Entity {
 
     /**
      * Initializes a new instance of the [TextEntity](xref:botbuilder-dialogs-adaptive.TextEntity) class.
+     *
      * @param text The text value.
      */
     public constructor(text?: string) {

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
@@ -12,6 +12,9 @@ import { DialogContext, ModelResult } from 'botbuilder-dialogs';
 import { EntityRecognizer } from './entityRecognizer';
 import { TextEntity } from './textEntity';
 
+/**
+ * TextEntityRecognizer - base class for Text.Recogizers from the text recognizer library.
+ */
 export abstract class TextEntityRecognizer extends EntityRecognizer {
     /**
      * Recognizes entities from an [Entity](xref:botframework-schema.Entity) list.

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/urlEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/urlEntityRecognizer.ts
@@ -14,7 +14,6 @@ import { TextEntityRecognizer } from './textEntityRecognizer';
  * Recognizes URL input.
  */
 export class UrlEntityRecognizer extends TextEntityRecognizer {
-
     public static $kind = 'Microsoft.UrlEntityRecognizer';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/intentPattern.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/intentPattern.ts
@@ -9,6 +9,12 @@ export class IntentPattern {
     private _intent: string;
     private _pattern: string;
 
+    /**
+     * Initializes a new instance of the [IntentPattern](xref:botbuilder-dialogs-adaptive.IntentPattern) class.
+     *
+     * @param intent The intent.
+     * @param pattern The regex pattern to match..
+     */
     public constructor(intent?: string, pattern?: string) {
         if (intent && pattern) {
             this.intent = intent;
@@ -16,22 +22,42 @@ export class IntentPattern {
         }
     }
 
+    /**
+     * @returns An instance of RegExp with the given pattern.
+     */
     public get regex(): RegExp {
+        // eslint-disable-next-line security/detect-non-literal-regexp
         return new RegExp(this._pattern, 'ig');
     }
 
+    /**
+     * Gets the intent.
+     *
+     * @returns The intent.
+     */
     public get intent(): string {
         return this._intent;
     }
 
+    /**
+     * Sets the intent.
+     */
     public set intent(value: string) {
         this._intent = value[0] == '#' ? value.substr(1) : value;
     }
 
+    /**
+     * Gets the pattern.
+     *
+     * @returns The pattern.
+     */
     public get pattern(): string {
         return this._pattern;
     }
 
+    /**
+     * Sets the pattern
+     */
     public set pattern(value: string) {
         this._pattern = value.startsWith('(?i)') ? value.substr(4) : value;
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
@@ -18,6 +18,9 @@ export interface MultiLanguageRecognizerConfiguration extends RecognizerConfigur
     recognizers?: Record<string, string> | Record<string, Recognizer>;
 }
 
+/**
+ * Defines map of languages -> recognizer.
+ */
 export class MultiLanguageRecognizer extends AdaptiveRecognizer implements MultiLanguageRecognizerConfiguration {
     public static $kind = 'Microsoft.MultiLanguageRecognizer';
 
@@ -25,6 +28,10 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
 
     public recognizers: { [locale: string]: Recognizer };
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof MultiLanguageRecognizerConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'languagePolicy':
@@ -36,6 +43,15 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
         }
     }
 
+    /**
+     * Runs current DialogContext.TurnContext.Activity through a recognizer and returns a [RecognizerResult](xref:botbuilder-core.RecognizerResult).
+     *
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param activity [Activity](xref:botframework-schema.Activity) to recognize.
+     * @param telemetryProperties Optional, additional properties to be logged to telemetry with the LuisResult event.
+     * @param telemetryMetrics Optional, additional metrics to be logged to telemetry with the LuisResult event.
+     * @returns {Promise<RecognizerResult>} Analysis of utterance.
+     */
     public async recognize(
         dialogContext: DialogContext,
         activity: Activity,

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
@@ -23,6 +23,10 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
 
     public recognizers: Recognizer[] = [];
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof RecognizerSetConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'recognizers':
@@ -32,6 +36,15 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
         }
     }
 
+    /**
+     * Runs current DialogContext.TurnContext.Activity through a recognizer and returns a [RecognizerResult](xref:botbuilder-core.RecognizerResult).
+     *
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param activity [Activity](xref:botframework-schema.Activity) to recognize.
+     * @param telemetryProperties Optional, additional properties to be logged to telemetry with the LuisResult event.
+     * @param telemetryMetrics Optional, additional metrics to be logged to telemetry with the LuisResult event.
+     * @returns {Promise<RecognizerResult>} Analysis of utterance.
+     */
     public async recognize(
         dialogContext: DialogContext,
         activity: Activity,
@@ -81,7 +94,7 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
                 // merge intents
                 for (const [intentName, intent] of Object.entries(result.intents)) {
                     const intentScore = intent.score ?? 0;
-                    if (mergedRecognizerResult.intents.hasOwnProperty(intentName)) {
+                    if (Object.hasOwnProperty.call(mergedRecognizerResult.intents, intentName)) {
                         if (intentScore < mergedRecognizerResult.intents[intentName].score) {
                             // we already have a higher score for this intent
                             continue;
@@ -111,7 +124,7 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
                         }
                     } else {
                         const mergedEntities = (mergedRecognizerResult.entities[propertyName] ??= []);
-                        mergedEntities.push(...propertyVal as any);
+                        mergedEntities.push(...(propertyVal as any));
                     }
                 }
             }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -32,6 +32,9 @@ export interface RegexRecognizerConfiguration extends RecognizerSetConfiguration
     intents?: IntentPatternInput[] | IntentPattern[];
 }
 
+/**
+ * Recognizer implementation which uses regex expressions to identify intents.
+ */
 export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecognizerConfiguration {
     public static $kind = 'Microsoft.RegexRecognizer';
 
@@ -45,6 +48,10 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
      */
     public entities: EntityRecognizer[] = [];
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof RegexRecognizerConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'intents':
@@ -54,6 +61,15 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
         }
     }
 
+    /**
+     * Runs current DialogContext.TurnContext.Activity through a recognizer and returns a [RecognizerResult](xref:botbuilder-core.RecognizerResult).
+     *
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param activity [Activity](xref:botframework-schema.Activity) to recognize.
+     * @param telemetryProperties Optional, additional properties to be logged to telemetry with the LuisResult event.
+     * @param telemetryMetrics Optional, additional metrics to be logged to telemetry with the LuisResult event.
+     * @returns {Promise<RecognizerResult>} Analysis of utterance.
+     */
     public async recognize(
         dialogContext: DialogContext,
         activity: Activity,

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
@@ -10,7 +10,24 @@ import { Activity, ActivityTypes, RecognizerResult } from 'botbuilder';
 import { DialogContext } from 'botbuilder-dialogs';
 import { AdaptiveRecognizer } from './adaptiveRecognizer';
 
+/**
+ * ValueRecognizer - Recognizer for mapping message activity. Value payload into intent/entities.
+ * 
+ * @remarks
+ * This recognizer will map MessageActivity Value payloads into intents and entities.
+ *      activity.Value.intent => RecognizerResult.Intents.
+ *      activity.Value.properties => RecognizerResult.Entities.
+ */
 export class ValueRecognizer extends AdaptiveRecognizer {
+    /**
+     * Runs current DialogContext.TurnContext.Activity through a recognizer and returns a [RecognizerResult](xref:botbuilder-core.RecognizerResult).
+     *
+     * @param dialogContext The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param activity [Activity](xref:botframework-schema.Activity) to recognize.
+     * @param telemetryProperties Optional, additional properties to be logged to telemetry with the LuisResult event.
+     * @param telemetryMetrics Optional, additional metrics to be logged to telemetry with the LuisResult event.
+     * @returns {Promise<RecognizerResult>} Analysis of utterance.
+     */
     public async recognize(
         dialogContext: DialogContext,
         activity: Activity,
@@ -30,7 +47,7 @@ export class ValueRecognizer extends AdaptiveRecognizer {
                     if (property.toLowerCase() == 'intent') {
                         recognizerResult.intents[value[property]] = { score: 1.0 };
                     } else {
-                        if (!recognizerResult.entities.hasOwnProperty(property)) {
+                        if (!Object.hasOwnProperty.call(recognizerResult.entities, property)) {
                             recognizerResult.entities[property] = [];
                         }
                         recognizerResult.entities[property].push(value[property]);


### PR DESCRIPTION
Adresses # 2745
#minor

## Description
When reviewing the botbuilder-js project it was found that eslint is showing several warnings for the botbuilder-dialogs-adaptive library.

## Specific Changes

- Replaced strings quotes with the correct one depending of the case
- Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
- Adjusted formatting
- Limited importing scopes
- Added missing jsdocs documentation for parameters and returns for functions
- Removed unused variables

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149823185-f518820c-91ba-4cdc-9776-3e7434225438.png)