### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs-adaptive library - misc

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -260,7 +260,6 @@ export class Ask extends SendActivity implements AskConfiguration {
     // (undocumented)
     static $kind: string;
     constructor(text?: string, expectedProperties?: ArrayExpression<string>);
-    // (undocumented)
     beginDialog(dc: DialogContext, options?: object): Promise<DialogTurnResult>;
     defaultOperation: StringExpression;
     expectedProperties: ArrayExpression<string>;
@@ -564,7 +563,6 @@ export class ConditionalSelector extends TriggerSelector implements ConditionalS
     // (undocumented)
     static $kind: string;
     condition: BoolExpression;
-    // (undocumented)
     getConverter(property: keyof ConditionalSelectorConfiguration): Converter | ConverterFactory;
     ifFalse: TriggerSelector;
     ifTrue: TriggerSelector;
@@ -1266,7 +1264,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
     getConverter(property: keyof InputDialogConfiguration): Converter | ConverterFactory;
     invalidPrompt: TemplateInterface<Partial<Activity>, DialogStateManager>;
     maxTurnCount?: IntExpression;
-    protected onInitializeOptions(dc: DialogContext, options: any): Promise<any>;
+    protected onInitializeOptions(_dc: DialogContext, options: any): Promise<any>;
     protected onPreBubbleEvent(dc: DialogContext, event: DialogEvent): Promise<boolean>;
     // (undocumented)
     protected abstract onRecognizeInput(dc: DialogContext): Promise<InputState>;
@@ -1275,7 +1273,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
     static OPTIONS_PROPERTY: string;
     prompt: TemplateInterface<Partial<Activity>, DialogStateManager>;
     property: StringExpression;
-    resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult>;
+    resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult>;
     // (undocumented)
     static TURN_COUNT_PROPERTY: string;
     unrecognizedPrompt: TemplateInterface<Partial<Activity>, DialogStateManager>;
@@ -1445,13 +1443,11 @@ export class MentionEntityRecognizer extends TextEntityRecognizer {
     protected _recognize(text: string, culture: string): ModelResult[];
 }
 
-// @public (undocumented)
+// @public
 export class MostSpecificSelector extends TriggerSelector implements MostSpecificSelectorConfiguration {
     // (undocumented)
     static $kind: string;
-    // (undocumented)
     initialize(conditionals: OnCondition[], _evaluate: boolean): void;
-    // (undocumented)
     select(context: ActionContext): Promise<OnCondition[]>;
     // (undocumented)
     selector: TriggerSelector;
@@ -1566,7 +1562,7 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
     getUserToken(dc: DialogContext, code?: string): Promise<TokenResponse | undefined>;
     // (undocumented)
     protected onComputeId(): string;
-    protected onRecognizeInput(dc: DialogContext): Promise<InputState>;
+    protected onRecognizeInput(_dc: DialogContext): Promise<InputState>;
     signOutUser(dc: DialogContext): Promise<void>;
     text?: StringExpression;
     timeout?: IntExpression;
@@ -2054,7 +2050,7 @@ export class ResourceExtensions {
     static useResourceExplorer(dialogManager: DialogManager, resourceExplorer: ResourceExplorer): DialogManager;
 }
 
-// @public (undocumented)
+// @public
 export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string, unknown> = Record<string, unknown>> extends MultiLanguageGeneratorBase<T, D> implements ResourceMultiLanguageGeneratorConfiguration {
     // (undocumented)
     static $kind: string;
@@ -2348,7 +2344,7 @@ export class TextEntity implements Entity {
     type: string;
 }
 
-// @public (undocumented)
+// @public
 export class TextInput extends InputDialog implements TextInputConfiguration {
     // (undocumented)
     static $kind: string;

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
@@ -17,8 +17,9 @@ type Output = TemplateInterface<Partial<Activity>, DialogStateManager>;
  * Activity template converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class ActivityTemplateConverter implements Converter<Input, Output> {
-      /**
+    /**
      * Converts a template to one of the following classes [ActivityTemplate](xref:botbuilder-dialogs-adaptive.ActivityTemplate) | [StaticActivityTemplate](xref:botbuilder-dialogs-adaptive.Static.ActivityTemplate)
+     *
      * @param value The template to evaluate to create the activity.
      * @returns A new instance that could be the following classes [ActivityTemplate](xref:botbuilder-dialogs-adaptive.ActivityTemplate) | [StaticActivityTemplate](xref:botbuilder-dialogs-adaptive.Static.ActivityTemplate).
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
@@ -16,14 +16,16 @@ type Input = string | Record<string, unknown>;
  * Dialog expression converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class DialogExpressionConverter implements Converter<Input, DialogExpression> {
-     /**
+    /**
      * Initializes a new instance of the [DialogExpressionConverter](xref:botbuilder-dialogs-adaptive.DialogExpressionConverter) class.
-     * @param resouceExplorer Resource explorer to use for resolving references.
+     *
+     * @param _resourceExplorer Resource explorer to use for resolving references.
      */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
-  
+
     /**
      * Converts an object or string to a [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) instance.
+     *
      * @param value An object or string value.
      * @returns A new [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) instance.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/dialogListConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/dialogListConverter.ts
@@ -9,9 +9,21 @@
 import { Converter, Dialog } from 'botbuilder-dialogs';
 import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
 
+/**
+ * Converter which allows json to be expression to object or static object.
+ */
 export class DialogListConverter implements Converter<string[], Dialog[]> {
+    /**
+     * Initializes a new instance of the [DialogListConverter](xref:botbuilder-dialogs-adaptive.DialogListConverter) class.
+     *
+     * @param _resourceExplorer Resource explorer to use for resolving references.
+     */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
+    /**
+     * @param value A list of strings representing dialogs, or a list of dialogs.
+     * @returns A new list of [Dialog](xref:botbuilder-dialogs.Dialog) instance.
+     */
     public convert(value: string[] | Dialog[]): Dialog[] {
         const results: Dialog[] = [];
 

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/languageGeneratorConverter.ts
@@ -15,11 +15,11 @@ import { ResourceMultiLanguageGenerator } from '../generators';
 export class LanguageGeneratorConverter implements Converter<string, ResourceMultiLanguageGenerator> {
     /**
      * Creates a new [ResourceMultiLanguageGenerator](xref:botbuilder-dialogs-adaptive.ResourceMultiLanguageGenerator) instance from Resource id value.
+     *
      * @param value Resource id of LG file.
      * @returns A new [ResourceMultiLanguageGenerator](xref:botbuilder-dialogs-adaptive.ResourceMultiLanguageGenerator) instance.
      */
     public convert(value: string | ResourceMultiLanguageGenerator): ResourceMultiLanguageGenerator {
-
         return typeof value === 'string' ? new ResourceMultiLanguageGenerator(value) : value;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/multiLanguageRecognizerConverter.ts
@@ -17,17 +17,21 @@ type Output = Record<string, Recognizer>;
  * Language generator converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
  */
 export class MultiLanguageRecognizerConverter implements Converter<Input, Output> {
-
     private _recognizerConverter: RecognizerConverter;
 
     /**
      * Initializes a new instance of the [MultiLanguageRecognizerConverter](xref:botbuilder-dialogs-adaptive.MultiLanguageRecognizerConverter) class.
-     * @param resouceExplorer Resource explorer to use for resolving references.
+     *
+     * @param resourceExplorer Resource explorer to use for resolving references.
      */
-    public constructor(resouceExplorer: ResourceExplorer) {
-        this._recognizerConverter = new RecognizerConverter(resouceExplorer);
+    public constructor(resourceExplorer: ResourceExplorer) {
+        this._recognizerConverter = new RecognizerConverter(resourceExplorer);
     }
 
+    /**
+     * @param value An [Input](xref:botbuilder-dialogs-adaptive.Input) or [Output](xref:botbuilder-dialogs-adaptive.Output).
+     * @returns A new [Output](xref:botbuilder-dialogs-adaptive.Output) instance.
+     */
     public convert(value: Input | Output): Output {
         return Object.entries(value).reduce((recognizers, [key, value]) => {
             return { ...recognizers, [key]: this._recognizerConverter.convert(value) };

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/recognizerConverter.ts
@@ -15,12 +15,14 @@ import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
 export class RecognizerConverter implements Converter<string, Recognizer> {
     /**
      * Initializes a new instance of the [RecognizerConverter](xref:botbuilder-dialogs-adaptive.RecognizerConverter) class.
-     * @param resouceExplorer Resource explorer to use for resolving references.
+     *
+     * @param _resourceExplorer Resource explorer to use for resolving references.
      */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
     /**
      * Converts an object or string to a [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance.
+     *
      * @param value An object or string value.
      * @returns A new [Recognizer](xref:botbuilder-dialogs-adaptive.Recognizer) instance.
      */
@@ -33,13 +35,29 @@ export class RecognizerConverter implements Converter<string, Recognizer> {
     }
 }
 
+/**
+ * Recognizer list converter that implements [Converter](xref:botbuilder-dialogs-declarative.Converter).
+ */
 export class RecognizerListConverter implements Converter<string[], Recognizer[]> {
     private _recognizerConverter: RecognizerConverter;
 
+    /**
+     * Initializes a new instance of the [MultiLanguageRecognizerConverter](xref:botbuilder-dialogs-adaptive.MultiLanguageRecognizerConverter) class.
+     *
+     * @param resourceExplorer Resource explorer to use for resolving references.
+     */
     public constructor(resourceExplorer: ResourceExplorer) {
         this._recognizerConverter = new RecognizerConverter(resourceExplorer);
     }
 
+    /**
+     * @param value A list of recognizers as strings or recognizers.
+     * @returns The list of recognizers
+     */
+    /**
+     * @param value A list of string or a list of [Recognizer](xref:botbuilder-dialogs.Recognizer).
+     * @returns A new list of [Recognizer](xref:botbuilder-dialogs.Recognizer) instances.
+     */
     public convert(value: string[] | Recognizer[]): Recognizer[] {
         const recognizers: Recognizer[] = [];
         value.forEach((item: string | Recognizer) => {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/textTemplateConverter.ts
@@ -15,6 +15,7 @@ import { TextTemplate } from '../templates';
 export class TextTemplateConverter implements Converter<string, TextTemplate> {
     /**
      * Converts a string to a [TextTemplate](xref:botbuilder-dialogs-adaptive.TextTemplate) instance.
+     *
      * @param value The template to evaluate to create text.
      * @returns A new [TextTemplate](xref:botbuilder-dialogs-adaptive.TextTemplate) instance.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/expressions/dialogExpression.ts
@@ -10,6 +10,7 @@ import { Dialog } from 'botbuilder-dialogs';
 
 /**
  * Represents a property which is either a [Dialog](xref:botbuilder-dialogs.Dialog) or a string expression for a dialogId.
+ *
  * @remarks
  * String values are always interpreted as a string with interpolation, unless it has '=' prefix
  * or not. The result is interpreted as a resource Id or dialogId.
@@ -17,6 +18,7 @@ import { Dialog } from 'botbuilder-dialogs';
 export class DialogExpression extends ExpressionProperty<Dialog> {
     /**
      * Initializes a new instance of the [DialogExpression](xref:botbuilder-dialogs-adaptive.DialogExpression) class.
+     *
      * @param value Optional. A [Dialog](xref:botbuilder-dialogs.Dialog), a `string` that is interpreted as a resource Id or dialogId, or an [Expression](xref:adaptive-expressions.Expression).
      */
     public constructor(value?: Dialog | string | Expression) {
@@ -25,6 +27,7 @@ export class DialogExpression extends ExpressionProperty<Dialog> {
 
     /**
      * Sets the raw value of the expression property.
+     *
      * @param value A [Dialog](xref:botbuilder-dialogs.Dialog), a `string` that is interpreted as a resource Id or dialogId, or an [Expression](xref:adaptive-expressions.Expression).
      */
     public setValue(value: Dialog | string | Expression): void {

--- a/libraries/botbuilder-dialogs-adaptive/src/functions/hasPendingActionsFunction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/functions/hasPendingActionsFunction.ts
@@ -32,7 +32,7 @@ export class HasPendingActionsFunction extends ExpressionEvaluator {
         super(HasPendingActionsFunction.functionName, HasPendingActionsFunction.function, ReturnType.Boolean);
     }
 
-    private static function(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
+    private static function(expression: Expression, state: MemoryInterface, _options: Options): ValueWithError {
         const actions: unknown[] = state.getValue('dialog._adaptive.actions');
         if (actions) {
             return {

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
@@ -33,6 +33,7 @@ export class LanguageGeneratorManager<T = unknown, D extends Record<string, unkn
 
     /**
      * Initialize a new instance of [LanguageResourceManager](xref:botbuilder-dialogs-adaptive.LanguageResourceManager) class.
+     *
      * @param resourceManager Resource explorer to manager LG files.
      */
     public constructor(resourceManager: ResourceExplorer) {
@@ -66,6 +67,7 @@ export class LanguageGeneratorManager<T = unknown, D extends Record<string, unkn
 
     /**
      * Returns the resolver to resolve LG import id to template text based on language and a template resource loader delegate.
+     *
      * @param locale Locale to identify language.
      * @param resourceMapping Template resource loader delegate.
      * @returns The delegate to resolve the resource.

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGenerator.ts
@@ -24,8 +24,10 @@ export class MultiLanguageGenerator extends MultiLanguageGeneratorBase {
 
     /**
      * Implementation of lookup by locale.
+     *
      * @param dialogContext Context for the current turn of conversation with the user.
      * @param locale Locale to lookup.
+     * @returns An object with a boolean showing existence and the language generator.
      */
     public tryGetGenerator(
         dialogContext: DialogContext,

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
@@ -29,6 +29,10 @@ export abstract class MultiLanguageGeneratorBase<
      */
     public languagePolicy: LanguagePolicy;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof MultiLanguageGeneratorBaseConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'languagePolicy':
@@ -40,6 +44,7 @@ export abstract class MultiLanguageGeneratorBase<
 
     /**
      * Abstract method to get a language generator by locale.
+     *
      * @param dialogContext DialogContext.
      * @param locale Locale to lookup.
      */
@@ -50,9 +55,11 @@ export abstract class MultiLanguageGeneratorBase<
 
     /**
      * Find a language generator that matches the current context locale.
+     *
      * @param dialogContext Context for the current turn of conversation.
      * @param template Template to use.
      * @param data Data to bind to.
+     * @returns A promise representing the asynchronous operation.
      */
     public async generate(dialogContext: DialogContext, template: string, data: D): Promise<T> {
         // priority

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
@@ -19,6 +19,11 @@ export interface ResourceMultiLanguageGeneratorConfiguration extends MultiLangua
     resourceId?: string;
 }
 
+/**
+ * Uses resourceExplorer to mount root lg and all language variants as a multi language generator.
+ *
+ * @remarks Given file name like "foo.lg" this will generate a map of foo.{LOCALE}.lg files.
+ */
 export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string, unknown> = Record<string, unknown>>
     extends MultiLanguageGeneratorBase<T, D>
     implements ResourceMultiLanguageGeneratorConfiguration {
@@ -26,6 +31,7 @@ export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string
 
     /**
      * Initializes a new instance of the ResourceMultiLanguageGenerator class.
+     *
      * @param resourceId Resource id of LG file.
      */
     public constructor(resourceId?: string) {
@@ -40,8 +46,10 @@ export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string
 
     /**
      * Implementation of lookup by locale.
+     *
      * @param dialogContext Context for the current turn of conversation.
      * @param locale Locale to lookup.
+     * @returns An object with a boolean showing existence and the language generator.
      */
     public tryGetGenerator(
         dialogContext: DialogContext,

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
@@ -20,7 +20,6 @@ export interface TemplateEngineLanguageGeneratorConfiguration {
 /**
  * [LanguageGenerator](xref:botbuilder-dialogs-adaptive.LanguageGenerator) implementation which uses LGFile.
  */
-
 export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<string, unknown> = Record<string, unknown>>
     extends Configurable
     implements LanguageGenerator<T, D>, TemplateEngineLanguageGeneratorConfiguration {
@@ -31,9 +30,10 @@ export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<strin
     private lg: Templates;
 
     public id = '';
- 
+
     /**
      * Initializes a new instance of the [TemplateEngineLanguageGenerator](xref:botbuilder-dialogs-adaptive.TemplateEngineLanguageGenerator) class.
+     *
      * @param arg1 Optional. An LG [Templates](xref:botbuilder-lg.Templates) or a [Resource](xref:botbuilder-dialogs-declarative.Resource).
      * @param arg2 Optional. A `Map` object with a `Resource` array for each key.
      */
@@ -56,6 +56,7 @@ export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<strin
 
     /**
      * Method to generate text from given template and data.
+     *
      * @param dialogContext Context for the current turn of conversation.
      * @param template Template to evaluate.
      * @param data Data to bind to.

--- a/libraries/botbuilder-dialogs-adaptive/src/input/ask.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/ask.ts
@@ -45,6 +45,7 @@ export class Ask extends SendActivity implements AskConfiguration {
 
     /**
      *Initializes a new instance of the [Ask](xref:botbuilder-dialogs-adaptive.Ask) class.
+     *
      * @param text Optional, text value.
      * @param expectedProperties Optional, [ArrayExpression](xref:adaptive-expressions.ArrayExpression) of expected properties.
      */
@@ -65,10 +66,9 @@ export class Ask extends SendActivity implements AskConfiguration {
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param options Optional, initial information to pass to the [Dialog](xref:botbuilder-dialogs.Dialog).
-     * @param property
-     * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
+     *
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
      */
     public getConverter(property: keyof AskConfiguration): Converter | ConverterFactory {
         switch (property) {
@@ -81,6 +81,21 @@ export class Ask extends SendActivity implements AskConfiguration {
         }
     }
 
+    /**
+     * Called when the dialog is started and pushed onto the dialog stack.
+     *
+     * @summary
+     * If the task is successful, the result indicates whether the dialog is still
+     * active after the turn has been processed by the dialog.
+     *
+     * You can use the [options](#options) parameter to include the QnA Maker context data,
+     * which represents context from the previous query. To do so, the value should include a
+     * `context` property of type [QnAResponseContext](#QnAResponseContext).
+     *
+     * @param {DialogContext} dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param {object} options (Optional) Initial information to pass to the dialog.
+     * @returns {Promise<DialogTurnResult>} A promise resolving to the turn result
+     */
     public async beginDialog(dc: DialogContext, options?: object): Promise<DialogTurnResult> {
         // get number of retries from memory
         let retries: number = dc.state.getValue<number>(DialogPath.retries, 0);

--- a/libraries/botbuilder-dialogs-adaptive/src/input/attachmentInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/attachmentInput.ts
@@ -30,7 +30,8 @@ export class AttachmentInput extends InputDialog implements AttachmentInputConfi
     );
 
     /**
-     * @protected
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
      */
     public getConverter(property: keyof AttachmentInputConfiguration): Converter | ConverterFactory {
         switch (property) {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
@@ -106,6 +106,10 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
      */
     public recognizerOptions?: ObjectExpression<FindChoicesOptions> = new ObjectExpression();
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ChoiceInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'choices':
@@ -204,6 +208,7 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
 
     /**
      * @protected
+     * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
         return `ChoiceInput[${this.prompt && this.prompt.toString()}]`;
@@ -227,7 +232,7 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
         const candidateLocale = dc.getLocale() ?? opt?.locale ?? this.defaultLocale?.getValue(dc.state);
         let culture = PromptCultureModels.mapToNearestLanguage(candidateLocale);
 
-        if (!(culture && ChoiceInput.defaultChoiceOptions.hasOwnProperty(culture))) {
+        if (!(culture && Object.hasOwnProperty.call(ChoiceInput.defaultChoiceOptions, culture))) {
             culture = PromptCultureModels.English.locale;
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceSet.ts
@@ -17,6 +17,7 @@ export class ChoiceSet extends Array<Choice> implements TemplateInterface<Choice
 
     /**
      * Initializes a new instance of the [ChoiceSet](xref:botbuilder-dialogs-adaptive.ChoiceSet) class.
+     *
      * @param obj Choice values.
      */
     public constructor(obj: any) {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
@@ -118,6 +118,10 @@ export class ConfirmInput extends InputDialog implements ConfirmInputConfigurati
      */
     public outputFormat: StringExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ConfirmInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'defaultLocale':
@@ -137,6 +141,7 @@ export class ConfirmInput extends InputDialog implements ConfirmInputConfigurati
 
     /**
      * @protected
+     * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
         return `ConfirmInput[${this.prompt && this.prompt.toString()}]`;
@@ -193,7 +198,7 @@ export class ConfirmInput extends InputDialog implements ConfirmInputConfigurati
      */
     protected async onRenderPrompt(dc: DialogContext, state: InputState): Promise<Partial<Activity>> {
         // Determine locale
-        let locale = this.determineCulture(dc);
+        const locale = this.determineCulture(dc);
         const defaults = ConfirmInput.defaultChoiceOptions[locale].choices;
         // Format choices
         const confirmChoices = await this.getConfirmChoices(dc, defaults);
@@ -215,7 +220,7 @@ export class ConfirmInput extends InputDialog implements ConfirmInputConfigurati
          */
         const candidateLocale = dc.getLocale() ?? this.defaultLocale?.getValue(dc.state);
         let culture = PromptCultureModels.mapToNearestLanguage(candidateLocale);
-        if (!(culture && ConfirmInput.defaultChoiceOptions.hasOwnProperty(culture))) {
+        if (!(culture && Object.hasOwnProperty.call(ConfirmInput.defaultChoiceOptions, culture))) {
             culture = PromptCultureModels.English.locale;
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
@@ -29,6 +29,10 @@ export class DateTimeInput extends InputDialog implements DateTimeInputConfigura
 
     public outputFormat: StringExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof DateTimeInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'defaultLocale':
@@ -42,6 +46,7 @@ export class DateTimeInput extends InputDialog implements DateTimeInputConfigura
 
     /**
      * @protected
+     * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
         return `DateTimeInput[${this.prompt && this.prompt.toString()}]`;

--- a/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
@@ -133,6 +133,10 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
      */
     public disabled?: BoolExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof InputDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'alwaysPrompt':
@@ -164,6 +168,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
 
     /**
      * Initializes a new instance of the [InputDialog](xref:botbuilder-dialogs-adaptive.InputDialog) class
+     *
      * @param property Optional. The value expression which the input will be bound to.
      * @param prompt Optional. The [Activity](xref:botframework-schema.Activity) to send to the user,
      * if a string is specified it will instantiates an [ActivityTemplate](xref:botbuilder-dialogs-adaptive.ActivityTemplate).
@@ -184,6 +189,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is started and pushed onto the dialog stack.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Initial information to pass to the [Dialog](xref:botbuilder-dialogs.Dialog).
      * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
@@ -223,6 +229,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
 
     /**
      * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the user replies with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
      */
@@ -279,13 +286,14 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
 
     /**
      * Called when a child [Dialog](xref:botbuilder-dialogs.Dialog) completes its turn, returning control to this dialog.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
-     * @param result Optional. Value returned from the [Dialog](xref:botbuilder-dialogs.Dialog) that was called.
+     * @param _reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
+     * @param _result Optional. Value returned from the [Dialog](xref:botbuilder-dialogs.Dialog) that was called.
      * The type of the value returned is dependent on the child dialog.
      * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
      */
-    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+    public async resumeDialog(dc: DialogContext, _reason: DialogReason, _result?: any): Promise<DialogTurnResult> {
         // Re-send initial prompt
         return await this.promptUser(dc, InputState.missing);
     }
@@ -322,10 +330,11 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
     /**
      * @protected
      * Method which processes options.
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param _dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Initial information to pass to the dialog.
+     * @returns A promise representing the asynchronous operation.
      */
-    protected onInitializeOptions(dc: DialogContext, options: any): Promise<any> {
+    protected onInitializeOptions(_dc: DialogContext, options: any): Promise<any> {
         return Promise.resolve(Object.assign({}, options));
     }
 
@@ -384,11 +393,13 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
 
     /**
      * Helper function to compose an output activity containing a set of choices.
+     *
      * @param prompt The prompt to append the users choices to.
      * @param channelId ID of the channel the prompt is being sent to.
      * @param choices List of choices to append.
      * @param style Configured style for the list of choices.
      * @param options (Optional) options to configure the underlying ChoiceFactory call.
+     * @returns A bound activity ready to send to the user.
      */
     protected appendChoices(
         prompt: Partial<Activity>,

--- a/libraries/botbuilder-dialogs-adaptive/src/input/numberInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/numberInput.ts
@@ -32,6 +32,10 @@ export class NumberInput extends InputDialog implements NumberInputConfiguration
 
     public outputFormat?: NumberExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof NumberInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'defaultLocale':
@@ -45,6 +49,7 @@ export class NumberInput extends InputDialog implements NumberInputConfiguration
 
     /**
      * @protected
+     * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
         return `NumberInput[${this.prompt && this.prompt.toString()}]`;

--- a/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
@@ -27,9 +27,7 @@ import {
 import {
     Activity,
     ActivityTypes,
-    ExtendedUserTokenProvider,
     InputHints,
-    IUserTokenProvider,
     StatusCodes,
     TokenExchangeInvokeRequest,
     TokenResponse,
@@ -109,6 +107,10 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
      */
     public timeout?: IntExpression = new IntExpression(900000);
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof OAuthInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'connectionName':
@@ -126,6 +128,7 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
 
     /**
      * Initializes a new instance of the [OAuthInput](xref:botbuilder-dialogs-adaptive.OAuthInput) class
+     *
      * @param connectionName Optional. Name of the OAuth connection being used.
      * @param title Optional. Title of the cards signin button.
      * @param text Optional. Additional text to include on the signin card.
@@ -143,6 +146,7 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
 
     /**
      * Called when a prompt [Dialog](xref:botbuilder-dialogs.Dialog) is pushed onto the dialog stack and is being activated.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param options Optional. Additional information to pass to the prompt being started.
      * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
@@ -199,6 +203,7 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
 
     /**
      * Called when a prompt [Dialog](xref:botbuilder-dialogs.Dialog) is the active dialog and the user replied with a new activity.
+     *
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A [DialogTurnResult](xref:botbuilder-dialogs.DialogTurnResult) `Promise` representing the asynchronous operation.
      */
@@ -294,8 +299,10 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
 
     /**
      * Attempts to retrieve the stored token for the current user.
-     * @param context Context reference the user that's being looked up.
+     *
+     * @param dc Context reference the user that's being looked up.
      * @param code (Optional) login code received from the user.
+     * @returns A promise representing the asynchronous operation.
      */
     public getUserToken(dc: DialogContext, code?: string): Promise<TokenResponse | undefined> {
         return new OAuthPrompt(this.constructor.name, {
@@ -312,12 +319,13 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
      *
      * ```JavaScript
      * const prompt = new OAuthPrompt({
-     *    connectionName: 'GitConnection',
-     *    title: 'Login To GitHub'
+     * connectionName: 'GitConnection',
+     * title: 'Login To GitHub'
      * });
      * await prompt.signOutUser(context);
      * ```
-     * @param context Context referencing the user that's being signed out.
+     * @param dc Context referencing the user that's being signed out.
+     * @returns A promise representing the asynchronous operation.
      */
     public async signOutUser(dc: DialogContext): Promise<void> {
         return new OAuthPrompt(this.constructor.name, {
@@ -333,10 +341,9 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
     /**
      * @protected
      * Called when input has been received.
-     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
-     * @returns [InputState](xref:botbuilder-dialogs-adaptive.InputState) which reflects whether input was recognized as valid or not.
+     * @param _dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      */
-    protected onRecognizeInput(dc: DialogContext): Promise<InputState> {
+    protected onRecognizeInput(_dc: DialogContext): Promise<InputState> {
         throw new Error('Method not implemented.');
     }
 
@@ -404,7 +411,7 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
     }
 
     private isTokenExchangeRequest(obj: unknown): obj is TokenExchangeInvokeRequest {
-        if (obj.hasOwnProperty('token')) {
+        if (Object.hasOwnProperty.call(obj, 'token')) {
             return true;
         }
         return false;

--- a/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
@@ -319,8 +319,8 @@ export class OAuthInput extends InputDialog implements OAuthInputConfiguration {
      *
      * ```JavaScript
      * const prompt = new OAuthPrompt({
-     * connectionName: 'GitConnection',
-     * title: 'Login To GitHub'
+     *     connectionName: 'GitConnection',
+     *     title: 'Login To GitHub'
      * });
      * await prompt.signOutUser(context);
      * ```

--- a/libraries/botbuilder-dialogs-adaptive/src/input/textInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/textInput.ts
@@ -14,11 +14,18 @@ export interface TextInputConfiguration extends InputDialogConfiguration {
     outputFormat?: StringProperty;
 }
 
+/**
+ * Declarative text input to gather text data from users.
+ */
 export class TextInput extends InputDialog implements TextInputConfiguration {
     public static $kind = 'Microsoft.TextInput';
 
     public outputFormat: StringExpression;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof TextInputConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'outputFormat':
@@ -30,6 +37,7 @@ export class TextInput extends InputDialog implements TextInputConfiguration {
 
     /**
      * @protected
+     * @returns A `string` representing the compute Id.
      */
     protected onComputeId(): string {
         return `TextInput[${this.prompt && this.prompt.toString()}]`;

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
@@ -53,6 +53,12 @@ export class ConditionalSelector extends TriggerSelector implements ConditionalS
      */
     public parser: ExpressionParserInterface = new ExpressionParser();
 
+    /**
+     * Gets the converter for the selector configuration.
+     *
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof ConditionalSelectorConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'condition':
@@ -64,6 +70,7 @@ export class ConditionalSelector extends TriggerSelector implements ConditionalS
 
     /**
      * Initialize the selector with the set of rules.
+     *
      * @param conditionals Possible rules to match.
      * @param evaluate True if rules should be evaluated on select.
      */
@@ -74,6 +81,7 @@ export class ConditionalSelector extends TriggerSelector implements ConditionalS
 
     /**
      * Select the best rule to execute.
+     *
      * @param actionContext Dialog context for evaluation.
      * @returns A Promise with a number array.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
@@ -20,6 +20,7 @@ export class FirstSelector extends TriggerSelector {
 
     /**
      * Initialize the selector with the set of rules.
+     *
      * @param conditionals Possible rules to match.
      * @param evaluate A boolean representing if rules should be evaluated on select.
      */
@@ -30,6 +31,7 @@ export class FirstSelector extends TriggerSelector {
 
     /**
      * Select the best rule to execute.
+     *
      * @param actionContext Dialog context for evaluation.
      * @returns A Promise with a number array.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/mostSpecificSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/mostSpecificSelector.ts
@@ -14,6 +14,9 @@ export interface MostSpecificSelectorConfiguration {
     selector?: TriggerSelector;
 }
 
+/**
+ * Select the most specific true rule implementation of [TriggerSelector](xref:botbuilder-dialogs-adaptive.TriggerSelector).
+ */
 export class MostSpecificSelector extends TriggerSelector implements MostSpecificSelectorConfiguration {
     public static $kind = 'Microsoft.MostSpecificSelector';
 
@@ -21,12 +24,24 @@ export class MostSpecificSelector extends TriggerSelector implements MostSpecifi
 
     public selector: TriggerSelector;
 
+    /**
+     * Initializes the selector with the set of rules.
+     *
+     * @param conditionals Possible rules to match.
+     * @param _evaluate True by default if rules should be evaluated on select.
+     */
     public initialize(conditionals: OnCondition[], _evaluate: boolean): void {
         for (const conditional of conditionals) {
             this._tree.addTrigger(conditional.getExpression(), conditional);
         }
     }
 
+    /**
+     * Selects the best rule to execute.
+     *
+     * @param context The context for the current turn of conversation.
+     * @returns The best rule in original list to execute.
+     */
     public async select(context: ActionContext): Promise<OnCondition[]> {
         const triggers = this._tree.matches(context.state);
         const matches: OnCondition[] = triggers.map((trigger: Trigger) => trigger.action);

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
@@ -21,6 +21,7 @@ export class RandomSelector extends TriggerSelector {
 
     /**
      * Initialize the selector with the set of rules.
+     *
      * @param conditionals Possible rules to match.
      * @param evaluate A boolean representing if rules should be evaluated on select.
      */
@@ -31,6 +32,7 @@ export class RandomSelector extends TriggerSelector {
 
     /**
      * Select the best rule to execute.
+     *
      * @param actionContext Dialog context for evaluation.
      * @returns A Promise with a number array.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
@@ -20,6 +20,7 @@ export class TrueSelector extends TriggerSelector {
 
     /**
      * Initialize the selector with the set of rules.
+     *
      * @param conditionals Possible rules to match.
      * @param evaluate True if rules should be evaluated on select.
      */
@@ -30,6 +31,7 @@ export class TrueSelector extends TriggerSelector {
 
     /**
      * Select the best rule to execute.
+     *
      * @param actionContext Dialog context for evaluation.
      * @returns A Promise with a number array.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityFactory, MessageFactory } from 'botbuilder';
+import { Activity, ActivityFactory } from 'botbuilder';
 import {
     Configurable,
     Converter,
@@ -33,6 +33,7 @@ export class ActivityTemplate
 
     /**
      * Initialize a new instance of ActivityTemplate class.
+     *
      * @param template The template to evaluate to create the activity.
      */
     public constructor(template?: string) {
@@ -44,10 +45,18 @@ export class ActivityTemplate
      */
     public template: string;
 
+    /**
+     * @param _property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(_property: keyof ActivityTemplateConguration): Converter | ConverterFactory {
         return undefined;
     }
 
+    /**
+     * @param config The configuration.
+     * @returns A object with the given configuration.
+     */
     public configure(config: ActivityTemplateConguration): this {
         const { template } = config;
         this.template = template;
@@ -56,8 +65,10 @@ export class ActivityTemplate
 
     /**
      * Bind data to template.
+     *
      * @param dialogContext DialogContext
      * @param data Data to bind to.
+     * @returns A promise representing the asynchronous operation.
      */
     public async bind(dialogContext: DialogContext, data: DialogStateManager): Promise<Partial<Activity>> {
         if (this.template) {

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
@@ -22,6 +22,7 @@ export class StaticActivityTemplate
 
     /**
      * Intialize a new instance of StaticActivityTemplate class.
+     *
      * @param activity Activity as a template.
      */
     public constructor(activity?: Partial<Activity>) {
@@ -33,10 +34,18 @@ export class StaticActivityTemplate
      */
     public activity: Partial<Activity>;
 
+    /**
+     * @param _property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(_property: keyof StaticActivityTemplateConfiguration): Converter | ConverterFactory {
         return undefined;
     }
 
+    /**
+     * @param config The configuration.
+     * @returns A object with the given configuration.
+     */
     public configure(config: StaticActivityTemplateConfiguration): this {
         const { activity } = config;
         this.activity = activity;
@@ -45,10 +54,14 @@ export class StaticActivityTemplate
 
     /**
      * Get predefined activity.
+     *
      * @param dialogContext DialogContext.
      * @param data Data to bind to (not working with static activity template).
      */
     public async bind(dialogContext: DialogContext, data: unknown): Promise<Partial<Activity>>;
+    /**
+     * @returns A promise representing the asynchronous operation.
+     */
     public async bind(): Promise<Partial<Activity>> {
         return Promise.resolve(this.activity);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Converter, ConverterFactory, Configurable, DialogContext, TemplateInterface, DialogStateManager } from 'botbuilder-dialogs';
+import { Converter, ConverterFactory, Configurable, DialogContext, TemplateInterface } from 'botbuilder-dialogs';
 import { TemplateEngineLanguageGenerator } from '../generators/templateEngineLanguageGenerator';
 import { LanguageGenerator } from '../languageGenerator';
 import { languageGeneratorKey } from '../languageGeneratorExtensions';
@@ -25,6 +25,7 @@ export class TextTemplate<D = Record<string, unknown>>
 
     /**
      * Initialize a new instance of TextTemplate class.
+     *
      * @param template The template to evaluate to create text.
      */
     public constructor(template?: string) {
@@ -36,10 +37,18 @@ export class TextTemplate<D = Record<string, unknown>>
      */
     public template: string;
 
+    /**
+     * @param _property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(_property: keyof TextTemplateConfiguration): Converter | ConverterFactory {
         return undefined;
     }
 
+    /**
+     * @param config The configuration.
+     * @returns A object with the given configuration.
+     */
     public configure(config: TextTemplateConfiguration): this {
         const { template } = config;
         this.template = template;
@@ -48,8 +57,10 @@ export class TextTemplate<D = Record<string, unknown>>
 
     /**
      * Bind data to template.
+     *
      * @param dialogContext DialogContext.
      * @param data Data to bind to.
+     * @returns A promise representing the asynchronous operation.
      */
     public async bind(dialogContext: DialogContext, data: D): Promise<string> {
         if (!this.template) {


### PR DESCRIPTION
Adresses # 2745
#minor

## Description
When reviewing the botbuilder-js project it was found that eslint is showing several warnings for the botbuilder-dialogs-adaptive library.

## Specific Changes

- Replaced strings quotes with the correct one depending of the case
- Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
- Adjusted formatting
- Limited importing scopes
- Added missing jsdocs documentation for parameters and returns for functions
- Removed unused variables

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149823185-f518820c-91ba-4cdc-9776-3e7434225438.png)