### PR TITLE
fix: [#2745] Fix current eslint warnings - botbuilder-dialogs-adaptive library - src & conditions

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -180,6 +180,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     recognizer?: Recognizer;
     repromptDialog(context: DialogContext | TurnContext, instance: DialogInstance): Promise<void>;
     resumeDialog(dc: DialogContext, _reason?: DialogReason, _result?: any): Promise<DialogTurnResult>;
+    // Warning: (ae-setter-with-docs) The doc comment for the property "schema" must appear on the getter, not the setter.
     set schema(value: object);
     get schema(): object;
     selector: TriggerSelector;
@@ -1635,7 +1636,7 @@ export class OnBeginDialog extends OnDialogEvent {
 export class OnCancelDialog extends OnDialogEvent {
     // (undocumented)
     static $kind: string;
-    constructor(actions?: Dialog[], condtion?: string);
+    constructor(actions?: Dialog[], condition?: string);
 }
 
 // @public
@@ -1926,7 +1927,9 @@ export class PropertySchema {
     get children(): PropertySchema[];
     get entities(): string[];
     get expectedOnly(): string[];
+    // (undocumented)
     isArray(): boolean;
+    // (undocumented)
     isEnum(): boolean;
     get name(): string;
     get parent(): PropertySchema | undefined;

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -142,7 +142,7 @@ export interface ActivityTemplateConguration {
     template?: string;
 }
 
-// @public (undocumented)
+// @public
 export class AdaptiveBotComponent extends BotComponent {
     // (undocumented)
     configureServices(services: ServiceCollection, _configuration: Configuration): void;
@@ -1356,7 +1356,7 @@ export class IsDialogActiveFunction extends ExpressionEvaluator {
     static readonly functionName = "isDialogActive";
 }
 
-// @public (undocumented)
+// @public
 export class LanguageGenerationBotComponent extends BotComponent {
     // (undocumented)
     configureServices(services: ServiceCollection, _configuration: Configuration): void;
@@ -1703,7 +1703,6 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
     static $kind: string;
     constructor(condition?: string, actions?: Dialog[]);
     actions: Dialog[];
-    // (undocumented)
     protected get actionScope(): ActionScope;
     addExternalCondition(condition: string): void;
     condition: BoolExpression;

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -28,6 +28,12 @@
     }
   },
   "dependencies": {
+    "@microsoft/recognizers-text-sequence": "~1.1.4",
+    "@microsoft/recognizers-text": "~1.1.4",
+    "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+    "@microsoft/recognizers-text-number": "~1.1.4",
+    "@microsoft/recognizers-text-choice": "~1.1.4",
+    "@microsoft/recognizers-text-date-time": "~1.1.4",
     "@microsoft/recognizers-text-suite": "1.1.4",
     "adaptive-expressions": "4.1.6",
     "botbuilder": "4.1.6",
@@ -39,12 +45,6 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@microsoft/recognizers-text": "~1.1.4",
-    "@microsoft/recognizers-text-choice": "~1.1.4",
-    "@microsoft/recognizers-text-date-time": "~1.1.4",
-    "@microsoft/recognizers-text-number": "~1.1.4",
-    "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
-    "@microsoft/recognizers-text-sequence": "~1.1.4",
     "@types/node-fetch": "^2.5.3"
   },
   "scripts": {

--- a/libraries/botbuilder-dialogs-adaptive/src/actionChangeList.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actionChangeList.ts
@@ -22,6 +22,7 @@ export interface ActionChangeList {
 
     /**
      * Turn state associated with the change.
+     *
      * @remarks
      * The current turn state will be update when the plan change is applied.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
@@ -20,6 +20,7 @@ export class ActionContext extends DialogContext {
 
     /**
      * Initializes a new instance of the [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) class
+     *
      * @param dialogs The dialog set to create the action context for.
      * @param parentDialogContext Parent dialog context.
      * @param state Current dialog state.
@@ -45,6 +46,8 @@ export class ActionContext extends DialogContext {
 
     /**
      * Gets list of changes that are queued to be applied.
+     *
+     * @returns The list of changes queued.
      */
     public get changes(): ActionChangeList[] {
         return this.context.turnState.get(this._changeKey) || [];
@@ -52,6 +55,7 @@ export class ActionContext extends DialogContext {
 
     /**
      * Queues up a set of changes that will be applied when applyChanges() is called.
+     *
      * @param changes Plan changes to queue up.
      */
     public queueChanges(changes: ActionChangeList): void {
@@ -62,6 +66,8 @@ export class ActionContext extends DialogContext {
 
     /**
      * Applies any queued up changes.
+     *
+     * @returns True if succeed otherwise false
      */
     public async applyChanges(): Promise<boolean> {
         // Retrieve queued change list

--- a/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
@@ -67,7 +67,7 @@ export class ActionContext extends DialogContext {
     /**
      * Applies any queued up changes.
      *
-     * @returns True if succeed otherwise false
+     * @returns True if there were any changes to apply.
      */
     public async applyChanges(): Promise<boolean> {
         // Retrieve queued change list

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
@@ -122,12 +122,12 @@ import {
 } from './recognizers';
 
 /**
- *
+ * [BotComponent](xref:botbuilder-core.BotComponent) for adaptive components.
  */
 export class AdaptiveBotComponent extends BotComponent {
     /**
-     * @param services A list of services.
-     * @param _configuration The configuration.
+     * @param services Services Collection to register.
+     * @param _configuration Configuration for the bot component.
      */
     configureServices(services: ServiceCollection, _configuration: Configuration): void {
         Expression.functions.add(IsDialogActiveFunction.functionName, new IsDialogActiveFunction());

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
@@ -121,7 +121,14 @@ import {
     UrlEntityRecognizer,
 } from './recognizers';
 
+/**
+ *
+ */
 export class AdaptiveBotComponent extends BotComponent {
+    /**
+     * @param services A list of services.
+     * @param _configuration The configuration.
+     */
     configureServices(services: ServiceCollection, _configuration: Configuration): void {
         Expression.functions.add(IsDialogActiveFunction.functionName, new IsDialogActiveFunction());
         Expression.functions.add(IsDialogActiveFunction.functionAlias, new IsDialogActiveFunction());

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -147,6 +147,9 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
      */
     public defaultResultProperty = 'dialog.result';
 
+    /**
+     *
+     */
     public set schema(value: object) {
         this.dialogSchema = new SchemaHelper(value);
     }
@@ -160,6 +163,10 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         return this.dialogSchema ? this.dialogSchema.schema : undefined;
     }
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof AdaptiveDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'recognizer':
@@ -249,7 +256,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     }
 
     protected onComputeId(): string {
-        return `AdaptiveDialog[]`;
+        return 'AdaptiveDialog[]';
     }
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -148,14 +148,14 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     public defaultResultProperty = 'dialog.result';
 
     /**
-     *
+     * Sets the JSON Schema for the dialog.
      */
     public set schema(value: object) {
         this.dialogSchema = new SchemaHelper(value);
     }
 
     /**
-     * JSON Schema for the dialog.
+     * Gets the JSON Schema for the dialog.
      *
      * @returns The dialog schema.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onBeginDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onBeginDialog.ts
@@ -17,6 +17,7 @@ export class OnBeginDialog extends OnDialogEvent {
 
     /**
      * Initializes a new instance of the [OnBeginDialog](xref:botbuilder-dialogs-adaptive.OnBeginDialog) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCancelDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCancelDialog.ts
@@ -17,10 +17,11 @@ export class OnCancelDialog extends OnDialogEvent {
 
     /**
      * Initializes a new instance of the [OnCancelDialog](xref:botbuilder-dialogs-adaptive.OnCancelDialog) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */
-    public constructor(actions: Dialog[] = [], condtion?: string) {
-        super(AdaptiveEvents.cancelDialog, actions, condtion);
+    public constructor(actions: Dialog[] = [], condition?: string) {
+        super(AdaptiveEvents.cancelDialog, actions, condition);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
@@ -92,7 +92,9 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * @protected
-     * @returns The action scope.
+     * Gets the action scope.
+     *
+     * @returns The scope obtained from the action.
      */
     protected get actionScope(): ActionScope {
         if (!this._actionScope) {
@@ -191,7 +193,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
     /**
      * Get child dialog dependencies so they can be added to the containers dialogset.
      *
-     * @returns The dependencies.
+     * @returns A list of [Dialog](xref:botbuilder-dialogs.Dialog).
      */
     public getDependencies(): Dialog[] {
         return [this.actionScope];

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
@@ -55,6 +55,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
     /**
      * Evaluates the rule and returns a predicted set of changes that should be applied to the
      * current plan.
+     *
      * @param planning Planning context object for the current conversation.
      * @param event The current event being evaluated.
      * @param preBubble If `true`, the leading edge of the event is being evaluated.
@@ -91,6 +92,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * @protected
+     * @returns The action scope.
      */
     protected get actionScope(): ActionScope {
         if (!this._actionScope) {
@@ -101,6 +103,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * Create a new `OnCondition` instance.
+     *
      * @param condition (Optional) The condition which needs to be met for the actions to be executed.
      * @param actions (Optional) The actions to add to the plan when the rule constraints are met.
      */
@@ -110,6 +113,10 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
         this.actions = actions;
     }
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof OnConditionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'condition':
@@ -138,6 +145,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * Compute the current value of the priority expression and return it.
+     *
      * @param actionContext Context to use for evaluation.
      * @returns Computed priority.
      */
@@ -151,6 +159,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * Add external condition to the OnCondition
+     *
      * @param condition External constraint to add, it will be AND'ed to all other constraints.
      */
     public addExternalCondition(condition: string): void {
@@ -167,6 +176,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * Method called to execute the condition's actions.
+     *
      * @param actionContext Context.
      * @returns A promise with plan change list.
      */
@@ -180,6 +190,8 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
 
     /**
      * Get child dialog dependencies so they can be added to the containers dialogset.
+     *
+     * @returns The dependencies.
      */
     public getDependencies(): Dialog[] {
         return [this.actionScope];

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onConversationUpdateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onConversationUpdateActivity.ts
@@ -17,6 +17,7 @@ export class OnConversationUpdateActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnConversationUpdateActivity](xref:botbuilder-dialogs-adaptive.OnConversationUpdateActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
@@ -26,6 +26,7 @@ export class OnDialogEvent extends OnCondition implements OnDialogEventConfigura
 
     /**
      * Creates a new `OnDialogEvent` instance.
+     *
      * @param event (Optional) The event to fire on.
      * @param actions (Optional) The actions to add to the plan when the rule constraints are met.
      * @param condition (Optional) The condition which needs to be met for the actions to be executed.

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onEndOfActions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onEndOfActions.ts
@@ -17,7 +17,7 @@ export class OnEndOfActions extends OnDialogEvent {
 
     /**
      * Creates a new `OnEndOfActions` instance.
-     * @param event (Optional) The event to fire on.
+     *
      * @param actions (Optional) The actions to add to the plan when the rule constraints are met.
      * @param condition (Optional) The condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onEndOfConversationActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onEndOfConversationActivity.ts
@@ -17,6 +17,7 @@ export class OnEndOfConversationActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnEndOfConversationActivity](xref:botbuilder-dialogs-adaptive.OnEndOfConversationActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onError.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onError.ts
@@ -20,6 +20,7 @@ export class OnError extends OnDialogEvent {
 
     /**
      * Initializes a new instance of the [OnError](xref:botbuilder-dialogs-adaptive.OnError) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */
@@ -29,6 +30,7 @@ export class OnError extends OnDialogEvent {
 
     /**
      * Called when a change list is created.
+     *
      * @param actionContext [ActionContext](xref:botbuilder-dialogs-adaptive.ActionContext) to use for evaluation.
      * @param dialogOptions Optional. Object with dialog options.
      * @returns An [ActionChangeList](xref:botbuilder-dialogs-adaptive.ActionChangeList) with the list of actions.

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onEventActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onEventActivity.ts
@@ -17,6 +17,7 @@ export class OnEventActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnEventActivity](xref:botbuilder-dialogs-adaptive.OnEventActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onHandoffActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onHandoffActivity.ts
@@ -17,6 +17,7 @@ export class OnHandoffActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnHandoffActivity](xref:botbuilder-dialogs-adaptive.OnHandoffActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onInstallationUpdateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onInstallationUpdateActivity.ts
@@ -18,6 +18,7 @@ export class OnInstallationUpdateActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnInstallationUpdateActivity](xref:botbuilder-dialogs-adaptive.OnInstallationUpdateActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
@@ -39,6 +39,7 @@ export class OnIntent extends OnDialogEvent implements OnIntentConfiguration {
 
     /**
      * Creates a new `OnIntent` instance.
+     *
      * @param intent (Optional) Intent to match on.
      * @param entities (Optional) Entities which must be recognized for this rule to trigger.
      * @param actions (Optional) The actions to add to the plan when the rule constraints are met.

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onInvokeActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onInvokeActivity.ts
@@ -17,6 +17,7 @@ export class OnInvokeActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnInvokeActivity](xref:botbuilder-dialogs-adaptive.OnInvokeActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageActivity.ts
@@ -17,6 +17,7 @@ export class OnMessageActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnMessageActivity](xref:botbuilder-dialogs-adaptive.OnMessageActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageDeleteActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageDeleteActivity.ts
@@ -17,6 +17,7 @@ export class OnMessageDeleteActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnMessageDeleteActivity](xref:botbuilder-dialogs-adaptive.OnMessageDeleteActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageReactionActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageReactionActivity.ts
@@ -17,6 +17,7 @@ export class OnMessageReactionActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnMessageReactionActivity](xref:botbuilder-dialogs-adaptive.OnMessageReactionActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageUpdateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onMessageUpdateActivity.ts
@@ -17,6 +17,7 @@ export class OnMessageUpdateActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnMessageUpdateActivity](xref:botbuilder-dialogs-adaptive.OnMessageUpdateActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onQnAMatch.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onQnAMatch.ts
@@ -18,6 +18,7 @@ export class OnQnAMatch extends OnIntent {
 
     /**
      * Initializes a new instance of the [OnQnAMatch](xref:botbuilder-dialogs-adaptive.OnQnAMatch) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onRepromptDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onRepromptDialog.ts
@@ -17,6 +17,7 @@ export class OnRepromptDialog extends OnDialogEvent {
 
     /**
      * Initializes a new instance of the [OnRepromptDialog](xref:botbuilder-dialogs-adaptive.OnRepromptDialog) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onTypingActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onTypingActivity.ts
@@ -17,6 +17,7 @@ export class OnTypingActivity extends OnActivity {
 
     /**
      * Initializes a new instance of the [OnTypingActivity](xref:botbuilder-dialogs-adaptive.OnTypingActivity) class.
+     *
      * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onUnknownIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onUnknownIntent.ts
@@ -11,6 +11,7 @@ import { OnDialogEvent } from './onDialogEvent';
 
 /**
  * Actions triggered when a UnknownIntent event has been emitted by the recognizer.
+ *
  * @remarks
  * A message is considered unhandled if there were no other conditions triggered by the message and
  * there is no active plan being executed.
@@ -25,6 +26,7 @@ export class OnUnknownIntent extends OnDialogEvent {
 
     /**
      * Creates a new `OnUnknownIntent` instance.
+     *
      * @param actions (Optional) The actions to add to the plan when the rule constraints are met.
      * @param condition (Optional) The condition which needs to be met for the actions to be executed.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
@@ -17,6 +17,7 @@ export class DynamicBeginDialogDeserializer
     implements CustomDeserializer<DynamicBeginDialog, BeginDialogConfiguration> {
     /**
      * Intializes an instance of `DynamicBeginDialogDeserializer`.
+     *
      * @param _resourceExplorer The `ResourceExplorer` used by the deserializer.
      * @param _resourceId The resource id of the dynamic dialog.
      */
@@ -24,6 +25,7 @@ export class DynamicBeginDialogDeserializer
 
     /**
      * The method that loads the configuration object to a `DynamicBeginDialog` object.
+     *
      * @param config The configuration object to deserialize.
      * @param type The object type that the configuration will be deserialized to.
      * @returns A `DynamicBeginDialog` object created from the configuration.

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
@@ -95,7 +95,9 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
     public expectedProperties: string[];
 
     /**
-     * @param assignment The assigment
+     * Initializes a new instance of the [EntityAssignment](xref:botbuilder-dialogs-adaptive.EntityAssignment) class.
+     *
+     * @param assignment The entity assignment properties to set for this instance.
      */
     constructor(assignment: Partial<EntityAssignmentConfiguration>) {
         // Some properties are defined by `<prop> ?? undefined` in order to pass object equality checks.
@@ -151,7 +153,7 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
     /**
      * Print an assignment as a string.
      *
-     * @returns The assigment as string.
+     * @returns A string that represents the current object.
      */
     public toString(): string {
         return `${this.isExpected ? '+' : ''}${this.event}: ${this.property} = ${this.operation}(${EntityInfo.toString(

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { EntityInfo } from './entityInfo';
 
 export interface EntityAssignmentConfiguration {
@@ -94,6 +94,9 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
      */
     public expectedProperties: string[];
 
+    /**
+     * @param assignment The assigment
+     */
     constructor(assignment: Partial<EntityAssignmentConfiguration>) {
         // Some properties are defined by `<prop> ?? undefined` in order to pass object equality checks.
         // Specifically, lodash's isEqual() will treat `{ a: undefined }` as not equal to `{ }`, so we explicitly add
@@ -113,6 +116,8 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
 
     /**
      * Gets the alternative entity assignments.
+     *
+     * @returns The alternative entity assigment.
      */
     public get alternatives(): EntityAssignment[] {
         const alternatives = [];
@@ -145,6 +150,8 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
 
     /**
      * Print an assignment as a string.
+     *
+     * @returns The assigment as string.
      */
     public toString(): string {
         return `${this.isExpected ? '+' : ''}${this.event}: ${this.property} = ${this.operation}(${EntityInfo.toString(

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
@@ -8,6 +8,9 @@
 import { AdaptiveEvents } from './adaptiveEvents';
 import { EntityAssignment } from './entityAssignment';
 
+/**
+ *
+ */
 export class EntityAssignmentComparer {
     private static eventPreference = [
         AdaptiveEvents.assignEntity,
@@ -15,8 +18,16 @@ export class EntityAssignmentComparer {
         AdaptiveEvents.chooseEntity,
     ];
 
+    /**
+     * @param operationPreference The operation preference.
+     */
     constructor(private operationPreference: string[]) {}
 
+    /**
+     * @param x First entity assigment to compare.
+     * @param y Second entity assigment to compare.
+     * @returns Result of the comparison.
+     */
     public compare(x: Partial<EntityAssignment>, y: Partial<EntityAssignment>): number {
         // Order by event.
         let comparison: number =

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
@@ -9,7 +9,14 @@ import { AdaptiveEvents } from './adaptiveEvents';
 import { EntityAssignment } from './entityAssignment';
 
 /**
- *
+ * Compare two entity assignments to determine their relative priority.
+
+ * @remarks
+ * Compare by event: assignEntity, chooseProperty, chooseEntity
+ * Then by operations in order from schema (usually within assignEntity).
+ * Then by unexpected before expected.
+ * Then by oldest turn first.
+ * Then by minimum position in utterance.
  */
 export class EntityAssignmentComparer {
     private static eventPreference = [
@@ -19,14 +26,18 @@ export class EntityAssignmentComparer {
     ];
 
     /**
-     * @param operationPreference The operation preference.
+     * Initializes a new instance of the [EntityAssignmentComparer](xref:botbuilder-dialogs-adaptive.EntityAssignmentComparer) class.
+     *
+     * @param operationPreference Preference on operations.
      */
     constructor(private operationPreference: string[]) {}
 
     /**
+     * Compares [EntityAssignment](xref:botbuilder-dialogs-adaptive.EntityAssignment) x against y to determine its relative priority.
+     *
      * @param x First entity assigment to compare.
      * @param y Second entity assigment to compare.
-     * @returns Result of the comparison.
+     * @returns Numerical value representing x's relative priority.
      */
     public compare(x: Partial<EntityAssignment>, y: Partial<EntityAssignment>): number {
         // Order by event.

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignments.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignments.ts
@@ -23,7 +23,9 @@ export interface EntityAssignmentsConfiguration {
  */
 export class EntityAssignments implements EntityAssignmentsConfiguration {
     /**
-     * @param assignments Entities to assign.
+     * Initializes a new instance of the [EntityAssignments](xref:botbuilder-dialogs-adaptive.EntityAssignments) class.
+     *
+     * @param assignments A list of [EntityAssignments](xref:botbuilder-dialogs-adaptive.EntityAssignments) to use.
      */
     constructor(public assignments: EntityAssignment[] = []) {}
 
@@ -31,7 +33,7 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
      * Read entity event queue from memory.
      *
      * @param actionContext Memory context.
-     * @returns The entity assigments.
+     * @returns Entity event queue.
      */
     public static read(actionContext: ActionContext): EntityAssignments {
         const queuesObject = actionContext.state.getValue(events, new EntityAssignments());
@@ -51,6 +53,8 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
     }
 
     /**
+     * Gets the next entity event to surface.
+     *
      * @returns The next entity event to surface.
      */
     public get nextAssignment(): EntityAssignment {
@@ -65,7 +69,7 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
      * Remove the current event and update the memory.
      *
      * @param actionContext Memory context.
-     * @returns The assigment.
+     * @returns Removed event.
      */
     public dequeue(actionContext: ActionContext): EntityAssignment {
         const assignment = this.assignments.shift();

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignments.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignments.ts
@@ -17,15 +17,21 @@ export interface EntityAssignmentsConfiguration {
 
 /**
  * Tracks entity related events to surface.
+ *
  * @remarks When processing entities possible ambiguities are identified and when resolved they turn into assign events.
  * This tracking persists across multiple input utterances.
  */
 export class EntityAssignments implements EntityAssignmentsConfiguration {
+    /**
+     * @param assignments Entities to assign.
+     */
     constructor(public assignments: EntityAssignment[] = []) {}
 
     /**
      * Read entity event queue from memory.
+     *
      * @param actionContext Memory context.
+     * @returns The entity assigments.
      */
     public static read(actionContext: ActionContext): EntityAssignments {
         const queuesObject = actionContext.state.getValue(events, new EntityAssignments());
@@ -37,6 +43,7 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
 
     /**
      * Write state into memory.
+     *
      * @param actionContext Memory context.
      */
     public write(actionContext: ActionContext): void {
@@ -44,7 +51,7 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
     }
 
     /**
-     * Returns the next entity event to surface.
+     * @returns The next entity event to surface.
      */
     public get nextAssignment(): EntityAssignment {
         if (this.assignments.length > 0) {
@@ -56,7 +63,9 @@ export class EntityAssignments implements EntityAssignmentsConfiguration {
 
     /**
      * Remove the current event and update the memory.
+     *
      * @param actionContext Memory context.
+     * @returns The assigment.
      */
     public dequeue(actionContext: ActionContext): EntityAssignment {
         const assignment = this.assignments.shift();

--- a/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
@@ -89,7 +89,9 @@ export interface NormalizedEntityInfos {
 export class EntityInfo {
     /**
      * Print an entity as a string.
+     *
      * @param source Source entity.
+     * @returns A string representing the entity.
      */
     public static toString(source: Partial<EntityInfo>): string {
         return `${source.name}:${source.value} P${source.priority} ${source.score} ${source.coverage}`;
@@ -97,8 +99,10 @@ export class EntityInfo {
 
     /**
      * Returns true if entities share text in utterance.
+     *
      * @param source Source entity.
      * @param entity Entity to compare.
+     * @returns True if entities share text in utterance, otherwise false.
      */
     public static overlaps(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
         return source.start <= entity.end && source.end >= entity.start;
@@ -106,8 +110,10 @@ export class EntityInfo {
 
     /**
      * Returns true if entities come from exactly the same text in the utterance.
+     *
      * @param source Source entity.
      * @param entity Entity to compare.
+     * @returns True if entities come from the exactly same text in utterance, otherwise false.
      */
     public static alternative(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
         return source.start == entity.start && source.end == entity.end;
@@ -115,8 +121,10 @@ export class EntityInfo {
 
     /**
      * Returns true entity text completely includes another entity text.
+     *
      * @param source Source entity.
      * @param entity Entity to compare.
+     * @returns True if the entity text completely includes another entity text, otherwise false.
      */
     public static covers(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
         return (
@@ -128,19 +136,23 @@ export class EntityInfo {
 
     /**
      * Returns true if entities share the same root.
+     *
      * @param source Source entity.
      * @param entity Entity to compare.
+     * @returns True if entities share the same root, otherwise false.
      */
-     public static sharesRoot(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
+    public static sharesRoot(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
         return source.rootEntity === entity.rootEntity;
     }
 
     /**
      * Returns true if entities are the same.
+     *
      * @param source Source entity.
      * @param entity Entity to compare.
+     * @returns True if entities are the same, otherwise false.
      */
-     public static isSameEntity(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
+    public static isSameEntity(source: Partial<EntityInfo>, entity: Partial<EntityInfo>): boolean {
         return EntityInfo.sharesRoot(source, entity) && EntityInfo.alternative(source, entity);
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
@@ -91,7 +91,7 @@ export class EntityInfo {
      * Print an entity as a string.
      *
      * @param source Source entity.
-     * @returns A string representing the entity.
+     * @returns A string that represents the current object.
      */
     public static toString(source: Partial<EntityInfo>): string {
         return `${source.name}:${source.value} P${source.priority} ${source.score} ${source.coverage}`;

--- a/libraries/botbuilder-dialogs-adaptive/src/jsonExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/jsonExtensions.ts
@@ -11,6 +11,7 @@ import { ValueExpression } from 'adaptive-expressions';
 
 /**
  * Replaces the binding paths in a JSON value with the evaluated results recursively.
+ *
  * @param state A scope for looking up variables.
  * @param unit An object.
  * @returns Deep data binding result.
@@ -45,6 +46,7 @@ export function replaceJsonRecursively(state: DialogStateManager, unit: object):
 
 /**
  * Evaluate ValueExpression according the value type.
+ *
  * @param state Input ValueExpression
  * @param valExpr A scope for looking up variables.
  * @returns Deep data binding result.

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
@@ -6,7 +6,14 @@ import { BotComponent } from 'botbuilder';
 import { ComponentDeclarativeTypes } from 'botbuilder-dialogs-declarative';
 import { Configuration, ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core';
 
+/**
+ *
+ */
 export class LanguageGenerationBotComponent extends BotComponent {
+    /**
+     * @param services The list of services.
+     * @param _configuration The configuration.
+     */
     configureServices(services: ServiceCollection, _configuration: Configuration): void {
         services.composeFactory<ComponentDeclarativeTypes[]>('declarativeTypes', (declarativeTypes) =>
             declarativeTypes.concat({

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
@@ -7,12 +7,12 @@ import { ComponentDeclarativeTypes } from 'botbuilder-dialogs-declarative';
 import { Configuration, ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core';
 
 /**
- *
+ * ComponentRegistration class for language generation resources.
  */
 export class LanguageGenerationBotComponent extends BotComponent {
     /**
-     * @param services The list of services.
-     * @param _configuration The configuration.
+     * @param services Services Collection to register.
+     * @param _configuration Configuration for the bot component.
      */
     configureServices(services: ServiceCollection, _configuration: Configuration): void {
         services.composeFactory<ComponentDeclarativeTypes[]>('declarativeTypes', (declarativeTypes) =>

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGenerator.ts
@@ -14,6 +14,7 @@ import { DialogContext } from 'botbuilder-dialogs';
 export interface LanguageGenerator<T = unknown, D = Record<string, unknown>> {
     /**
      * Method to bind data to string.
+     *
      * @param dialogContext DialogContext.
      * @param template Template.
      * @param data Data to bind to.

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -40,6 +40,7 @@ export class LanguageGeneratorExtensions {
 
     /**
      * Register default LG file or a language generator as default language generator.
+     *
      * @param dialogManager The dialog manager to add language generator to.
      * @param lg LG resource id (default: main.lg) or language generator to be added.
      * @returns dialog manager with language generator.
@@ -72,6 +73,7 @@ export class LanguageGeneratorExtensions {
 
     /**
      * Register language policy as default policy.
+     *
      * @param dialogManager The dialog manager to add language policy to.
      * @param policy Policy to use.
      * @returns dialog manager with language policy.

--- a/libraries/botbuilder-dialogs-adaptive/src/languagePolicy.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languagePolicy.ts
@@ -14,6 +14,7 @@ import { Converter } from 'botbuilder-dialogs';
 export class LanguagePolicy extends Map<string, string[]> {
     /**
      * Initializes a new instance of the [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) class.
+     *
      * @param defaultLanguages Default languages to use.
      */
     public constructor(...defaultLanguages: string[]) {
@@ -873,6 +874,7 @@ export class LanguagePolicy extends Map<string, string[]> {
 
     /**
      * Walk through all of the cultures and create a dictionary map with most specific to least specific.
+     *
      * @param defaultLanguages Default languages to use.
      * @returns A Map object with a string array for each key.
      * @example Example output "en-us" will generate fallback rule like this:
@@ -918,6 +920,7 @@ export class LanguagePolicy extends Map<string, string[]> {
 export class LanguagePolicyConverter implements Converter<Record<string, string[]>, LanguagePolicy> {
     /**
      * Converts an object to a [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) instance.
+     *
      * @param value Object.
      * @returns A new [LanguagePolicy](xref:botbuilder-dialogs-adaptive.LanguagePolicy) instance.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/languageResourceLoader.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageResourceLoader.ts
@@ -21,7 +21,9 @@ export class LanguageResourceLoader {
 
     /**
      * Group LG resource by locale.
+     *
      * @param resourceExplorer The resource explorer to use.
+     * @returns The dictionary of grouped locale.
      */
     public static groupByLocale(resourceExplorer: ResourceExplorer): Map<string, Resource[]> {
         const resourceMapping: Map<string, Resource[]> = new Map<string, Resource[]>();
@@ -73,7 +75,9 @@ export class LanguageResourceLoader {
 
     /**
      * Parse LG file name into prefix and language.
+     *
      * @param lgFileName LG input file name.
+     * @returns The name and language.
      */
     public static parseLGFileName(lgFileName: string): { prefix: string; language: string } {
         if (lgFileName === undefined || !lgFileName.endsWith('.' + this.lgSuffix)) {
@@ -91,8 +95,10 @@ export class LanguageResourceLoader {
 
     /**
      * Get the fallback locale from optional locales.
+     *
      * @param locale Current locale
      * @param optionalLocales Optional locales.
+     * @returns The final locale.
      */
     public static fallbackLocale(locale: string, optionalLocales: string[]): string {
         if (optionalLocales === undefined) {

--- a/libraries/botbuilder-dialogs-adaptive/src/propertySchema.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/propertySchema.ts
@@ -17,6 +17,7 @@ export class PropertySchema {
 
     /**
      * Creates a new `PropertySchema` instance.
+     *
      * @param path Path to this property.
      * @param schema JSON schema fragment for this property.
      * @param children Optional. Child properties.
@@ -32,6 +33,7 @@ export class PropertySchema {
 
     /**
      * Path to schema.
+     *
      * @remarks
      * Contains `[]` for arrays and `.` for path segments.
      */
@@ -44,6 +46,8 @@ export class PropertySchema {
 
     /**
      * Parent property schema if any.
+     *
+     * @returns The parent property schema if any.
      */
     public get parent(): PropertySchema | undefined {
         return this._parent;
@@ -51,6 +55,8 @@ export class PropertySchema {
 
     /**
      * Child properties if there are any.
+     *
+     * @returns The child properties if there are any.
      */
     public get children(): PropertySchema[] {
         return this._children;
@@ -58,6 +64,8 @@ export class PropertySchema {
 
     /**
      * List of entity names.
+     *
+     * @returns A list of entity names.
      */
     public get entities(): string[] {
         return this._entities;
@@ -65,6 +73,8 @@ export class PropertySchema {
 
     /**
      * List of expected only entity names.
+     *
+     * @returns A List of expected only entity names.
      */
     public get expectedOnly(): string[] {
         return this._expectedOnly;
@@ -72,8 +82,10 @@ export class PropertySchema {
 
     /**
      * Name for this property.
+     *
      * @remarks
      * Array brackets `[]` will have been removed.
+     * @returns The name for this property.
      */
     public get name(): string {
         const segments = this.path.split('.');
@@ -82,20 +94,22 @@ export class PropertySchema {
 
     /**
      * JSON Schema type.
+     *
+     * @returns The JSON Schema type.
      */
     public get type(): string {
         return this.schema['type'];
     }
 
     /**
-     * Returns `true` if the property is an array.
+     * @returns `true` if the property is an array.
      */
     public isArray(): boolean {
         return this.path.endsWith('[]');
     }
 
     /**
-     * Returns `true` if the property is an enum.
+     * @returns `true` if the property is an enum.
      */
     public isEnum(): boolean {
         return !!this.schema['enum'];

--- a/libraries/botbuilder-dialogs-adaptive/src/resourceExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/resourceExtensions.ts
@@ -20,6 +20,7 @@ export const resourceExplorerKey = Symbol('ResourceExplorer');
 export class ResourceExtensions {
     /**
      * Register ResourceExplorer into DialogManager.
+     *
      * @param dialogManager The dialog manager to add resource explorer to.
      * @param resourceExplorer The resource explorer to be added.
      * @returns dialog manager with resource explorer.

--- a/libraries/botbuilder-dialogs-adaptive/src/schemaHelper.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/schemaHelper.ts
@@ -13,6 +13,7 @@ import { PropertySchema } from './propertySchema';
 export class SchemaHelper {
     /**
      * Creates a new `SchemaHelper` instance.
+     *
      * @param schema JSON schema to parse.
      */
     public constructor(schema: object) {
@@ -32,6 +33,8 @@ export class SchemaHelper {
 
     /**
      * List of required property names.
+     *
+     * @returns The list of required property names.
      */
     public get required(): string[] {
         return this.schema['required'] || [];
@@ -39,7 +42,9 @@ export class SchemaHelper {
 
     /**
      * Returns the schema object for a given property path.
+     *
      * @param path Path of the properties schema to return.
+     * @returns the schema object for a given property path.
      */
     public pathToSchema(path: string): PropertySchema | undefined {
         let property: PropertySchema = undefined;
@@ -70,7 +75,7 @@ export class SchemaHelper {
             } else if (typeof items == 'object') {
                 // Copy parent $ properties like $entities
                 for (const name in schema) {
-                    if (schema.hasOwnProperty(name) && name.startsWith('$')) {
+                    if (Object.prototype.hasOwnProperty.call(schema, name) && name.startsWith('$')) {
                         items[name] = schema[name];
                     }
                 }
@@ -87,7 +92,7 @@ export class SchemaHelper {
         if (type == 'object') {
             const properties = schema['properties'] || {};
             for (const name in properties) {
-                if (properties.hasOwnProperty(name) && !name.startsWith('$')) {
+                if (Object.prototype.hasOwnProperty.call(properties, name) && !name.startsWith('$')) {
                     const newPath = path == '' ? name : `${path}.${name}`;
                     children.push(this.createProperty(properties[name], newPath));
                 }

--- a/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
@@ -25,8 +25,10 @@ export const skillConversationIdFactoryKey = Symbol('SkillConversationIdFactory'
 export class SkillExtensions {
     /**
      * Configures the skill client to use.
+     *
      * @param dialogManager The dialog manager to add skill client to.
      * @param skillClient The skill client to be added.
+     * @returns The dialog manager based on the skill client.
      */
     public static useSkillClient(dialogManager: DialogManager, skillClient: BotFrameworkClient): DialogManager {
         dialogManager.initialTurnState.set(skillClientKey, skillClient);
@@ -35,8 +37,10 @@ export class SkillExtensions {
 
     /**
      * Configures the skill conversation id factory to use.
+     *
      * @param dialogManager The dialog manager to add skill conversation id factory to.
      * @param skillConversationIdFactory The skill conversation id factory to be added.
+     * @returns The dialog manager based on the skill factory.
      */
     public static useSkillConversationIdFactory(
         dialogManager: DialogManager,

--- a/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
@@ -28,7 +28,7 @@ export class SkillExtensions {
      *
      * @param dialogManager The dialog manager to add skill client to.
      * @param skillClient The skill client to be added.
-     * @returns The dialog manager based on the skill client.
+     * @returns The existing dialog manager object with the new skill client state.
      */
     public static useSkillClient(dialogManager: DialogManager, skillClient: BotFrameworkClient): DialogManager {
         dialogManager.initialTurnState.set(skillClientKey, skillClient);
@@ -40,7 +40,7 @@ export class SkillExtensions {
      *
      * @param dialogManager The dialog manager to add skill conversation id factory to.
      * @param skillConversationIdFactory The skill conversation id factory to be added.
-     * @returns The dialog manager based on the skill factory.
+     * @returns The existing dialog manager object with the new skill conversation factory state.
      */
     public static useSkillConversationIdFactory(
         dialogManager: DialogManager,

--- a/libraries/botbuilder-dialogs-adaptive/src/telemetryExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/telemetryExtensions.ts
@@ -12,6 +12,7 @@ import { DialogManager, DialogTurnStateConstants } from 'botbuilder-dialogs';
 /**
  * Extension methods for telemetry.
  * Configures the telemetry client to use.
+ *
  * @param dialogManager DialogManager to configure.
  * @param telemetryClient BotTelemetryClient instance to use.
  * @returns DialogManager.

--- a/libraries/botbuilder-dialogs-adaptive/src/triggerSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/triggerSelector.ts
@@ -15,6 +15,7 @@ import { OnCondition } from './conditions';
 export abstract class TriggerSelector extends Configurable {
     /**
      * Initialize the selector with the set of rules.
+     *
      * @param conditionHandlers Possible rules to match.
      * @param evaluate True if rules should be evaluated on select.
      */
@@ -22,6 +23,7 @@ export abstract class TriggerSelector extends Configurable {
 
     /**
      * Select the best rule to execute.
+     *
      * @param actionContext Dialog context for evaluation.
      */
     public abstract select(actionContext: ActionContext): Promise<OnCondition[]>;

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -2,653 +2,654 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, TurnContext, TurnContextStateCollection } from 'botbuilder-core';
-import { Choice } from './choices';
-import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogEvent } from './dialog';
-import { DialogSet } from './dialogSet';
-import { PromptOptions } from './prompts';
-import { DialogStateManager, TurnPath } from './memory';
-import { DialogContainer } from './dialogContainer';
-import { DialogEvents } from './dialogEvents';
-import { DialogManager } from './dialogManager';
-import { DialogTurnStateConstants } from './dialogTurnStateConstants';
-import { DialogContextError } from './dialogContextError';
-
-/**
- * Wraps a promise in a try-catch that automatically enriches errors with extra dialog context.
- *
- * @param dialogContext source dialog context from which enriched error properties are sourced
- * @param promise a promise to await inside a try-catch for error enrichment
- */
-const wrapErrors = async <T>(dialogContext: DialogContext, promise: Promise<T>): Promise<T> => {
-    try {
-        return await promise;
-    } catch (err) {
-        if (err instanceof DialogContextError) {
-            throw err;
-        } else {
-            throw new DialogContextError(err, dialogContext);
-        }
-    }
-};
-
-/**
- * @private
- */
-const ACTIVITY_RECEIVED_EMITTED = Symbol('ActivityReceivedEmitted');
-
-/**
- * Contains dialog state, information about the state of the dialog stack, for a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
- *
- * @remarks
- * State is read from and saved to storage each turn, and state cache for the turn is managed through
- * the [TurnContext](xref:botbuilder-core.TurnContext).
- *
- * For more information, see the articles on
- * [Managing state](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-state) and
- * [Dialogs library](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-dialog).
- */
-export interface DialogState {
-    /**
-     * Contains state information for each [Dialog](xref:botbuilder-dialogs.Dialog) on the stack.
-     */
-    dialogStack: DialogInstance[];
-}
-
-/**
- * The context for the current dialog turn with respect to a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
- *
- * @remarks
- * This includes the turn context, information about the dialog set, and the state of the dialog stack.
- *
- * From code outside of a dialog in the set, use [DialogSet.createContext](xref:botbuilder-dialogs.DialogSet.createContext)
- * to create the dialog context. Then use the methods of the dialog context to manage the progression of dialogs in the set.
- *
- * When you implement a dialog, the dialog context is a parameter available to the various methods you override or implement.
- *
- * For example:
- * ```JavaScript
- * const dc = await dialogs.createContext(turnContext);
- * const result = await dc.continueDialog();
- * ```
- */
-export class DialogContext {
-    /**
-     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
-     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-     * @remarks
-     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-     */
-    public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
-
-    /**
-     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-     * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
-     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-     * @remarks
-     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-     */
-    public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
-
-    /**
-     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
-     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-     * @remarks Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-     */
-    public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
-        this.dialogs = dialogs;
-        if (contextOrDC instanceof DialogContext) {
-            this.context = contextOrDC.context;
-            this.parent = contextOrDC;
-            if (this.parent.services) {
-                this.parent.services.forEach((value, key): void => {
-                    this.services.set(key, value);
-                });
-            }
-        } else {
-            this.context = contextOrDC;
-        }
-        if (!Array.isArray(state.dialogStack)) {
-            state.dialogStack = [];
-        }
-        this.stack = state.dialogStack;
-        this.state = new DialogStateManager(this);
-        this.state.setValue(TurnPath.activity, this.context.activity);
-    }
-
-    /**
-     * Gets the dialogs that can be called directly from this context.
-     */
-    public dialogs: DialogSet;
-
-    /**
-     * Gets the context object for the turn.
-     */
-    public context: TurnContext;
-
-    /**
-     * Gets the current dialog stack.
-     */
-    public stack: DialogInstance[];
-
-    /**
-     * The parent dialog context for this dialog context, or `undefined` if this context doesn't have a parent.
-     *
-     * @remarks
-     * When it attempts to start a dialog, the dialog context searches for the [Dialog.id](xref:botbuilder-dialogs.Dialog.id)
-     * in its [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs). If the dialog to start is not found
-     * in this dialog context, it searches in its parent dialog context, and so on.
-     */
-    public parent: DialogContext | undefined;
-
-    /**
-     * Returns dialog context for child if the active dialog is a container.
-     */
-    public get child(): DialogContext | undefined {
-        const instance = this.activeDialog;
-        if (instance != undefined) {
-            // Is active dialog a container?
-            const dialog = this.findDialog(instance.id);
-            if (dialog instanceof DialogContainer) {
-                return dialog.createChildContext(this);
-            }
-        }
-
-        return undefined;
-    }
-
-    /**
-     * Returns the state information for the dialog on the top of the dialog stack, or `undefined` if
-     * the stack is empty.
-     */
-    public get activeDialog(): DialogInstance | undefined {
-        return this.stack.length > 0 ? this.stack[this.stack.length - 1] : undefined;
-    }
-
-    /**
-     * Gets the DialogStateManager which manages view of all memory scopes.
-     */
-    public state: DialogStateManager;
-
-    /**
-     * Gets the services collection which is contextual to this dialog context.
-     */
-    public services: TurnContextStateCollection = new TurnContextStateCollection();
-
-    /**
-     * Returns the current dialog manager instance. This property is obsolete.
-     *
-     * @obsolete This property serves no function.
-     */
-    public get dialogManager(): DialogManager {
-        return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
-    }
-
-    /**
-     * Obtain the CultureInfo in DialogContext.
-     * @returns a locale string.
-     */
-    public getLocale(): string {
-        const _turnLocaleProperty = 'turn.locale';
-
-        const turnLocaleValue = this.state.getValue(_turnLocaleProperty);
-        if (turnLocaleValue) {
-            return turnLocaleValue;
-        }
-
-        const locale = this.context.activity?.locale;
-        if (locale !== undefined) {
-            return locale;
-        }
-
-        return Intl.DateTimeFormat().resolvedOptions().locale;
-    }
-
-    /**
-     * Starts a dialog instance and pushes it onto the dialog stack.
-     * Creates a new instance of the dialog and pushes it onto the stack.
-     *
-     * @param dialogId ID of the dialog to start.
-     * @param options Optional. Arguments to pass into the dialog when it starts.
-     *
-     * @remarks
-     * If there's already an active dialog on the stack, that dialog will be paused until
-     * it is again the top dialog on the stack.
-     *
-     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-     * the status of the dialog stack after this method completes.
-     *
-     * This method throws an exception if the requested dialog can't be found in this dialog context
-     * or any of its ancestors.
-     *
-     * For example:
-     * ```JavaScript
-     * const result = await dc.beginDialog('greeting', { name: user.name });
-     * ```
-     *
-     * **See also**
-     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-     * - [prompt](xref:botbuilder-dialogs.DialogContext.prompt)
-     * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
-     * - [Dialog.beginDialog](xref:botbuilder-dialogs.Dialog.beginDialog)
-     */
-    public async beginDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
-        // Lookup dialog
-        const dialog: Dialog<{}> = this.findDialog(dialogId);
-        if (!dialog) {
-            throw new DialogContextError(
-                `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
-                this
-            );
-        }
-
-        // Push new instance onto stack.
-        const instance: DialogInstance<any> = {
-            id: dialogId,
-            state: {},
-        };
-        this.stack.push(instance);
-
-        // Call dialogs begin() method.
-        return wrapErrors(this, dialog.beginDialog(this, options));
-    }
-
-    /**
-     * Cancels all dialogs on the dialog stack, and clears stack.
-     *
-     * @param cancelParents Optional. If `true` all parent dialogs will be cancelled as well.
-     * @param eventName Optional. Name of a custom event to raise as dialogs are cancelled. This defaults to [cancelDialog](xref:botbuilder-dialogs.DialogEvents.cancelDialog).
-     * @param eventValue Optional. Value to pass along with custom cancellation event.
-     *
-     * @remarks
-     * This calls each dialog's [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog) method before
-     * removing the dialog from the stack.
-     *
-     * If there were any dialogs on the stack initially, the [status](xref:botbuilder-dialogs.DialogTurnResult.status)
-     * of the return value is [cancelled](xref:botbuilder-dialogs.DialogTurnStatus.cancelled); otherwise, it's
-     * [empty](xref:botbuilder-dialogs.DialogTurnStatus.empty).
-     *
-     * This example clears a dialog stack, `dc`, before starting a 'bookFlight' dialog.
-     * ```JavaScript
-     * await dc.cancelAllDialogs();
-     * return await dc.beginDialog('bookFlight');
-     * ```
-     *
-     * **See also**
-     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-     */
-    public async cancelAllDialogs(
-        cancelParents = false,
-        eventName?: string,
-        eventValue?: any
-    ): Promise<DialogTurnResult> {
-        eventName = eventName || DialogEvents.cancelDialog;
-        if (this.stack.length > 0 || this.parent != undefined) {
-            // Cancel all local and parent dialogs while checking for interception
-            let notify = false;
-            let dc: DialogContext = this;
-            while (dc != undefined) {
-                if (dc.stack.length > 0) {
-                    // Check to see if the dialog wants to handle the event
-                    // - We skip notifying the first dialog which actually called cancelAllDialogs()
-                    if (notify) {
-                        const handled = await dc.emitEvent(eventName, eventValue, false, false);
-                        if (handled) {
-                            break;
-                        }
-                    }
-
-                    // End the active dialog
-                    await dc.endActiveDialog(DialogReason.cancelCalled);
-                } else {
-                    dc = cancelParents ? dc.parent : undefined;
-                }
-
-                notify = true;
-            }
-
-            return { status: DialogTurnStatus.cancelled };
-        } else {
-            return { status: DialogTurnStatus.empty };
-        }
-    }
-
-    /**
-     * Searches for a dialog with a given ID.
-     *
-     * @param dialogId ID of the dialog to search for.
-     *
-     * @remarks
-     * If the dialog to start is not found in the [DialogSet](xref:botbuilder-dialogs.DialogSet) associated
-     * with this dialog context, it attempts to find the dialog in its parent dialog context.
-     *
-     * **See also**
-     * - [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs)
-     * - [parent](xref:botbuilder-dialogs.DialogContext.parent)
-     */
-    public findDialog(dialogId: string): Dialog | undefined {
-        let dialog = this.dialogs.find(dialogId);
-        if (!dialog && this.parent) {
-            dialog = this.parent.findDialog(dialogId);
-        }
-        return dialog;
-    }
-
-    /**
-     * Helper function to simplify formatting the options for calling a prompt dialog.
-     * @param dialogId ID of the prompt dialog to start.
-     * @param promptOrOptions The text of the initial prompt to send the user,
-     *      the activity to send as the initial prompt, or
-     *      the object with which to format the prompt dialog.
-     * @param choices Optional. Array of choices for the user to choose from,
-     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     *
-     * @remarks
-     * This helper method formats the object to use as the `options` parameter, and then calls
-     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
-     *
-     * ```JavaScript
-     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-     * ```
-     */
-    public async prompt(
-        dialogId: string,
-        promptOrOptions: string | Partial<Activity> | PromptOptions
-    ): Promise<DialogTurnResult>;
-
-    /**
-     * Helper function to simplify formatting the options for calling a prompt dialog.
-     * @param dialogId ID of the prompt dialog to start.
-     * @param promptOrOptions The text of the initial prompt to send the user,
-     * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
-     * the object with which to format the prompt dialog.
-     * @param choices Optional. Array of choices for the user to choose from,
-     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     * @remarks
-     * This helper method formats the object to use as the `options` parameter, and then calls
-     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
-     *
-     * ```JavaScript
-     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-     * ```
-     */
-    public async prompt(
-        dialogId: string,
-        promptOrOptions: string | Partial<Activity> | PromptOptions,
-        choices: (string | Choice)[]
-    ): Promise<DialogTurnResult>;
-
-    /**
-     * Helper function to simplify formatting the options for calling a prompt dialog.
-     * @param dialogId ID of the prompt dialog to start.
-     * @param promptOrOptions The text of the initial prompt to send the user,
-     * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
-     * @param choices Optional. Array of choices for the user to choose from,
-     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-     * @remarks This helper method formats the object to use as the `options` parameter, and then calls
-     * beginDialog to start the specified prompt dialog.
-     *
-     * ```JavaScript
-     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-     * ```
-     */
-    public async prompt(
-        dialogId: string,
-        promptOrOptions: string | Partial<Activity>,
-        choices?: (string | Choice)[]
-    ): Promise<DialogTurnResult> {
-        let options: PromptOptions;
-        if (
-            (typeof promptOrOptions === 'object' && (promptOrOptions as Activity).type !== undefined) ||
-            typeof promptOrOptions === 'string'
-        ) {
-            options = { prompt: promptOrOptions as string | Partial<Activity> };
-        } else {
-            options = { ...(promptOrOptions as PromptOptions) };
-        }
-
-        if (choices) {
-            options.choices = choices;
-        }
-
-        return wrapErrors(this, this.beginDialog(dialogId, options));
-    }
-
-    /**
-     * Continues execution of the active dialog, if there is one, by passing this dialog context to its
-     * [Dialog.continueDialog](xref:botbuilder-dialogs.Dialog.continueDialog) method.
-     *
-     * @remarks
-     * After the call completes, you can check the turn context's [responded](xref:botbuilder-core.TurnContext.responded)
-     * property to determine if the dialog sent a reply to the user.
-     *
-     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-     * the status of the dialog stack after this method completes.
-     *
-     * Typically, you would call this from within your bot's turn handler.
-     *
-     * For example:
-     * ```JavaScript
-     * const result = await dc.continueDialog();
-     * if (result.status == DialogTurnStatus.empty && dc.context.activity.type == ActivityTypes.message) {
-     *     // Send fallback message
-     *     await dc.context.sendActivity(`I'm sorry. I didn't understand.`);
-     * }
-     * ```
-     */
-    public async continueDialog(): Promise<DialogTurnResult> {
-        // if we are continuing and haven't emitted the activityReceived event, emit it
-        // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
-        if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
-            this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true);
-
-            // Dispatch "activityReceived" event
-            // - This fired from teh leaf and will queue up any interruptions.
-            await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true);
-        }
-
-        // Check for a dialog on the stack
-        const instance: DialogInstance<any> = this.activeDialog;
-        if (instance) {
-            // Lookup dialog
-            const dialog: Dialog<{}> = this.findDialog(instance.id);
-            if (!dialog) {
-                throw new DialogContextError(
-                    `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                    this
-                );
-            }
-
-            // Continue execution of dialog
-            return wrapErrors(this, dialog.continueDialog(this));
-        } else {
-            return { status: DialogTurnStatus.empty };
-        }
-    }
-
-    /**
-     * Ends a dialog and pops it off the stack. Returns an optional result to the dialog's parent.
-     *
-     * @param result Optional. A result to pass to the parent logic. This might be the next dialog
-     *      on the stack, or if this was the last dialog on the stack, a parent dialog context or
-     *      the bot's turn handler.
-     *
-     * @remarks
-     * The _parent_ dialog is the next dialog on the dialog stack, if there is one. This method
-     * calls the parent's [Dialog.resumeDialog](xref:botbuilder-dialogs.Dialog.resumeDialog) method,
-     * passing the result returned by the ending dialog. If there is no parent dialog, the turn ends
-     * and the result is available to the bot through the returned object's
-     * [result](xref:botbuilder-dialogs.DialogTurnResult.result) property.
-     *
-     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-     * the status of the dialog stack after this method completes.
-     *
-     * Typically, you would call this from within the logic for a specific dialog to signal back to
-     * the dialog context that the dialog has completed, the dialog should be removed from the stack,
-     * and the parent dialog should resume.
-     *
-     * For example:
-     * ```JavaScript
-     * return await dc.endDialog(returnValue);
-     * ```
-     *
-     * **See also**
-     * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
-     * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
-     * - [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog)
-     */
-    public async endDialog(result?: any): Promise<DialogTurnResult> {
-        // End the active dialog
-        await this.endActiveDialog(DialogReason.endCalled, result);
-
-        // Resume parent dialog
-        const instance: DialogInstance<any> = this.activeDialog;
-        if (instance) {
-            // Lookup dialog
-            const dialog: Dialog<{}> = this.findDialog(instance.id);
-            if (!dialog) {
-                throw new DialogContextError(
-                    `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                    this
-                );
-            }
-
-            // Return result to previous dialog
-            return wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result));
-        } else {
-            // Signal completion
-            return { status: DialogTurnStatus.complete, result: result };
-        }
-    }
-
-    /**
-     * Ends the active dialog and starts a new dialog in its place.
-     *
-     * @param dialogId ID of the dialog to start.
-     * @param options Optional. Arguments to pass into the new dialog when it starts.
-     *
-     * @remarks
-     * This is particularly useful for creating a loop or redirecting to another dialog.
-     *
-     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-     * the status of the dialog stack after this method completes.
-     *
-     * This method is similar to ending the current dialog and immediately beginning the new one.
-     * However, the parent dialog is neither resumed nor otherwise notified.
-     *
-     * **See also**
-     * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
-     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-     */
-    public async replaceDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
-        // End the active dialog
-        await this.endActiveDialog(DialogReason.replaceCalled);
-
-        // Start replacement dialog
-        return this.beginDialog(dialogId, options);
-    }
-
-    /**
-     * Requests the active dialog to re-prompt the user for input.
-     *
-     * @remarks
-     * This calls the active dialog's [repromptDialog](xref:botbuilder-dialogs.Dialog.repromptDialog) method.
-     *
-     * For example:
-     * ```JavaScript
-     * await dc.repromptDialog();
-     * ```
-     */
-    public async repromptDialog(): Promise<void> {
-        // Try raising event first
-        const handled = await this.emitEvent(DialogEvents.repromptDialog, undefined, false, false);
-        if (!handled) {
-            // Check for a dialog on the stack
-            const instance: DialogInstance<any> = this.activeDialog;
-            if (instance) {
-                // Lookup dialog
-                const dialog: Dialog<{}> = this.findDialog(instance.id);
-                if (!dialog) {
-                    throw new DialogContextError(
-                        `DialogContext.repromptDialog(): Can't find a dialog with an id of '${instance.id}'.`,
-                        this
-                    );
-                }
-
-                // Ask dialog to re-prompt if supported
-                await wrapErrors(this, dialog.repromptDialog(this.context, instance));
-            }
-        }
-    }
-
-    /**
-     * Searches for a dialog with a given ID.
-     * @remarks
-     * Emits a named event for the current dialog, or someone who started it, to handle.
-     * @param name Name of the event to raise.
-     * @param value Optional. Value to send along with the event.
-     * @param bubble Optional. Flag to control whether the event should be bubbled to its parent if not handled locally. Defaults to a value of `true`.
-     * @param fromLeaf Optional. Whether the event is emitted from a leaf node.
-     * @returns `true` if the event was handled.
-     */
-    public async emitEvent(name: string, value?: any, bubble = true, fromLeaf = false): Promise<boolean> {
-        // Initialize event
-        const dialogEvent: DialogEvent = {
-            bubble: bubble,
-            name: name,
-            value: value,
-        };
-
-        // Find starting dialog
-        let dc: DialogContext = this;
-        if (fromLeaf) {
-            while (true) {
-                const childDc = dc.child;
-                if (childDc != undefined) {
-                    dc = childDc;
-                } else {
-                    break;
-                }
-            }
-        }
-
-        // Dispatch to active dialog first
-        // - The active dialog will decide if it should bubble the event to its parent.
-        const instance = dc.activeDialog;
-        if (instance != undefined) {
-            const dialog = dc.findDialog(instance.id);
-            if (dialog != undefined) {
-                return wrapErrors(this, dialog.onDialogEvent(dc, dialogEvent));
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @private
-     * @param reason
-     * @param result
-     */
-    private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
-        const instance: DialogInstance<any> = this.activeDialog;
-        if (instance) {
-            // Lookup dialog
-            const dialog: Dialog<{}> = this.findDialog(instance.id);
-            if (dialog) {
-                // Notify dialog of end
-                await wrapErrors(this, dialog.endDialog(this.context, instance, reason));
-            }
-
-            // Pop dialog off stack
-            this.stack.pop();
-
-            this.state.setValue(TurnPath.lastResult, result);
-        }
-    }
-}
+ import { Activity, TurnContext, TurnContextStateCollection } from 'botbuilder-core';
+ import { Choice } from './choices';
+ import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogEvent } from './dialog';
+ import { DialogSet } from './dialogSet';
+ import { PromptOptions } from './prompts';
+ import { DialogStateManager, TurnPath } from './memory';
+ import { DialogContainer } from './dialogContainer';
+ import { DialogEvents } from './dialogEvents';
+ import { DialogManager } from './dialogManager';
+ import { DialogTurnStateConstants } from './dialogTurnStateConstants';
+ import { DialogContextError } from './dialogContextError';
+ 
+ /**
+  * Wraps a promise in a try-catch that automatically enriches errors with extra dialog context.
+  *
+  * @param dialogContext source dialog context from which enriched error properties are sourced
+  * @param promise a promise to await inside a try-catch for error enrichment
+  */
+ const wrapErrors = async <T>(dialogContext: DialogContext, promise: Promise<T>): Promise<T> => {
+     try {
+         return await promise;
+     } catch (err) {
+         if (err instanceof DialogContextError) {
+             throw err;
+         } else {
+             throw new DialogContextError(err, dialogContext);
+         }
+     }
+ };
+ 
+ /**
+  * @private
+  */
+ const ACTIVITY_RECEIVED_EMITTED = Symbol('ActivityReceivedEmitted');
+ 
+ /**
+  * Contains dialog state, information about the state of the dialog stack, for a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
+  *
+  * @remarks
+  * State is read from and saved to storage each turn, and state cache for the turn is managed through
+  * the [TurnContext](xref:botbuilder-core.TurnContext).
+  *
+  * For more information, see the articles on
+  * [Managing state](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-state) and
+  * [Dialogs library](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-dialog).
+  */
+ export interface DialogState {
+     /**
+      * Contains state information for each [Dialog](xref:botbuilder-dialogs.Dialog) on the stack.
+      */
+     dialogStack: DialogInstance[];
+ }
+ 
+ /**
+  * The context for the current dialog turn with respect to a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
+  *
+  * @remarks
+  * This includes the turn context, information about the dialog set, and the state of the dialog stack.
+  *
+  * From code outside of a dialog in the set, use [DialogSet.createContext](xref:botbuilder-dialogs.DialogSet.createContext)
+  * to create the dialog context. Then use the methods of the dialog context to manage the progression of dialogs in the set.
+  *
+  * When you implement a dialog, the dialog context is a parameter available to the various methods you override or implement.
+  *
+  * For example:
+  * ```JavaScript
+  * const dc = await dialogs.createContext(turnContext);
+  * const result = await dc.continueDialog();
+  * ```
+  */
+ export class DialogContext {
+     /**
+      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
+      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+      * @remarks
+      * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+      */
+     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
+ 
+     /**
+      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+      * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
+      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+      * @remarks
+      * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+      */
+     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
+ 
+     /**
+      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
+      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+      * @remarks Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+      */
+     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
+         this.dialogs = dialogs;
+         if (contextOrDC instanceof DialogContext) {
+             this.context = contextOrDC.context;
+             this.parent = contextOrDC;
+             if (this.parent.services) {
+                 this.parent.services.forEach((value, key): void => {
+                     this.services.set(key, value);
+                 });
+             }
+         } else {
+             this.context = contextOrDC;
+         }
+         if (!Array.isArray(state.dialogStack)) {
+             state.dialogStack = [];
+         }
+         this.stack = state.dialogStack;
+         this.state = new DialogStateManager(this);
+         this.state.setValue(TurnPath.activity, this.context.activity);
+     }
+ 
+     /**
+      * Gets the dialogs that can be called directly from this context.
+      */
+     public dialogs: DialogSet;
+ 
+     /**
+      * Gets the context object for the turn.
+      */
+     public context: TurnContext;
+ 
+     /**
+      * Gets the current dialog stack.
+      */
+     public stack: DialogInstance[];
+ 
+     /**
+      * The parent dialog context for this dialog context, or `undefined` if this context doesn't have a parent.
+      *
+      * @remarks
+      * When it attempts to start a dialog, the dialog context searches for the [Dialog.id](xref:botbuilder-dialogs.Dialog.id)
+      * in its [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs). If the dialog to start is not found
+      * in this dialog context, it searches in its parent dialog context, and so on.
+      */
+     public parent: DialogContext | undefined;
+ 
+     /**
+      * Returns dialog context for child if the active dialog is a container.
+      */
+     public get child(): DialogContext | undefined {
+         const instance = this.activeDialog;
+         if (instance != undefined) {
+             // Is active dialog a container?
+             const dialog = this.findDialog(instance.id);
+             if (dialog instanceof DialogContainer) {
+                 return dialog.createChildContext(this);
+             }
+         }
+ 
+         return undefined;
+     }
+ 
+     /**
+      * Returns the state information for the dialog on the top of the dialog stack, or `undefined` if
+      * the stack is empty.
+      */
+     public get activeDialog(): DialogInstance | undefined {
+         return this.stack.length > 0 ? this.stack[this.stack.length - 1] : undefined;
+     }
+ 
+     /**
+      * Gets the DialogStateManager which manages view of all memory scopes.
+      */
+     public state: DialogStateManager;
+ 
+     /**
+      * Gets the services collection which is contextual to this dialog context.
+      */
+     public services: TurnContextStateCollection = new TurnContextStateCollection();
+ 
+     /**
+      * Returns the current dialog manager instance. This property is obsolete.
+      *
+      * @obsolete This property serves no function.
+      */
+     public get dialogManager(): DialogManager {
+         return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
+     }
+ 
+     /**
+      * Obtain the CultureInfo in DialogContext.
+      * @returns a locale string.
+      */
+     public getLocale(): string {
+         const _turnLocaleProperty = 'turn.locale';
+ 
+         const turnLocaleValue = this.state.getValue(_turnLocaleProperty);
+         if (turnLocaleValue) {
+             return turnLocaleValue;
+         }
+ 
+         const locale = this.context.activity?.locale;
+         if (locale !== undefined) {
+             return locale;
+         }
+ 
+         return Intl.DateTimeFormat().resolvedOptions().locale;
+     }
+ 
+     /**
+      * Starts a dialog instance and pushes it onto the dialog stack.
+      * Creates a new instance of the dialog and pushes it onto the stack.
+      *
+      * @param dialogId ID of the dialog to start.
+      * @param options Optional. Arguments to pass into the dialog when it starts.
+      *
+      * @remarks
+      * If there's already an active dialog on the stack, that dialog will be paused until
+      * it is again the top dialog on the stack.
+      *
+      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+      * the status of the dialog stack after this method completes.
+      *
+      * This method throws an exception if the requested dialog can't be found in this dialog context
+      * or any of its ancestors.
+      *
+      * For example:
+      * ```JavaScript
+      * const result = await dc.beginDialog('greeting', { name: user.name });
+      * ```
+      *
+      * **See also**
+      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+      * - [prompt](xref:botbuilder-dialogs.DialogContext.prompt)
+      * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
+      * - [Dialog.beginDialog](xref:botbuilder-dialogs.Dialog.beginDialog)
+      */
+     public async beginDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
+         // Lookup dialog
+         const dialog: Dialog<{}> = this.findDialog(dialogId);
+         if (!dialog) {
+             throw new DialogContextError(
+                 `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
+                 this
+             );
+         }
+ 
+         // Push new instance onto stack.
+         const instance: DialogInstance<any> = {
+             id: dialogId,
+             state: {},
+         };
+         this.stack.push(instance);
+ 
+         // Call dialogs begin() method.
+         return wrapErrors(this, dialog.beginDialog(this, options));
+     }
+ 
+     /**
+      * Cancels all dialogs on the dialog stack, and clears stack.
+      *
+      * @param cancelParents Optional. If `true` all parent dialogs will be cancelled as well.
+      * @param eventName Optional. Name of a custom event to raise as dialogs are cancelled. This defaults to [cancelDialog](xref:botbuilder-dialogs.DialogEvents.cancelDialog).
+      * @param eventValue Optional. Value to pass along with custom cancellation event.
+      *
+      * @remarks
+      * This calls each dialog's [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog) method before
+      * removing the dialog from the stack.
+      *
+      * If there were any dialogs on the stack initially, the [status](xref:botbuilder-dialogs.DialogTurnResult.status)
+      * of the return value is [cancelled](xref:botbuilder-dialogs.DialogTurnStatus.cancelled); otherwise, it's
+      * [empty](xref:botbuilder-dialogs.DialogTurnStatus.empty).
+      *
+      * This example clears a dialog stack, `dc`, before starting a 'bookFlight' dialog.
+      * ```JavaScript
+      * await dc.cancelAllDialogs();
+      * return await dc.beginDialog('bookFlight');
+      * ```
+      *
+      * **See also**
+      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+      */
+     public async cancelAllDialogs(
+         cancelParents = false,
+         eventName?: string,
+         eventValue?: any
+     ): Promise<DialogTurnResult> {
+         eventName = eventName || DialogEvents.cancelDialog;
+         if (this.stack.length > 0 || this.parent != undefined) {
+             // Cancel all local and parent dialogs while checking for interception
+             let notify = false;
+             let dc: DialogContext = this;
+             while (dc != undefined) {
+                 if (dc.stack.length > 0) {
+                     // Check to see if the dialog wants to handle the event
+                     // - We skip notifying the first dialog which actually called cancelAllDialogs()
+                     if (notify) {
+                         const handled = await dc.emitEvent(eventName, eventValue, false, false);
+                         if (handled) {
+                             break;
+                         }
+                     }
+ 
+                     // End the active dialog
+                     await dc.endActiveDialog(DialogReason.cancelCalled);
+                 } else {
+                     dc = cancelParents ? dc.parent : undefined;
+                 }
+ 
+                 notify = true;
+             }
+ 
+             return { status: DialogTurnStatus.cancelled };
+         } else {
+             return { status: DialogTurnStatus.empty };
+         }
+     }
+ 
+     /**
+      * Searches for a dialog with a given ID.
+      *
+      * @param dialogId ID of the dialog to search for.
+      *
+      * @remarks
+      * If the dialog to start is not found in the [DialogSet](xref:botbuilder-dialogs.DialogSet) associated
+      * with this dialog context, it attempts to find the dialog in its parent dialog context.
+      *
+      * **See also**
+      * - [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs)
+      * - [parent](xref:botbuilder-dialogs.DialogContext.parent)
+      */
+     public findDialog(dialogId: string): Dialog | undefined {
+         let dialog = this.dialogs.find(dialogId);
+         if (!dialog && this.parent) {
+             dialog = this.parent.findDialog(dialogId);
+         }
+         return dialog;
+     }
+ 
+     /**
+      * Helper function to simplify formatting the options for calling a prompt dialog.
+      * @param dialogId ID of the prompt dialog to start.
+      * @param promptOrOptions The text of the initial prompt to send the user,
+      *      the activity to send as the initial prompt, or
+      *      the object with which to format the prompt dialog.
+      * @param choices Optional. Array of choices for the user to choose from,
+      *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+      *
+      * @remarks
+      * This helper method formats the object to use as the `options` parameter, and then calls
+      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+      *
+      * ```JavaScript
+      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+      * ```
+      */
+     public async prompt(
+         dialogId: string,
+         promptOrOptions: string | Partial<Activity> | PromptOptions
+     ): Promise<DialogTurnResult>;
+ 
+     /**
+      * Helper function to simplify formatting the options for calling a prompt dialog.
+      * @param dialogId ID of the prompt dialog to start.
+      * @param promptOrOptions The text of the initial prompt to send the user,
+      * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
+      * the object with which to format the prompt dialog.
+      * @param choices Optional. Array of choices for the user to choose from,
+      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+      * @remarks
+      * This helper method formats the object to use as the `options` parameter, and then calls
+      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+      *
+      * ```JavaScript
+      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+      * ```
+      */
+     public async prompt(
+         dialogId: string,
+         promptOrOptions: string | Partial<Activity> | PromptOptions,
+         choices: (string | Choice)[]
+     ): Promise<DialogTurnResult>;
+ 
+     /**
+      * Helper function to simplify formatting the options for calling a prompt dialog.
+      * @param dialogId ID of the prompt dialog to start.
+      * @param promptOrOptions The text of the initial prompt to send the user,
+      * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
+      * @param choices Optional. Array of choices for the user to choose from,
+      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+      * @remarks This helper method formats the object to use as the `options` parameter, and then calls
+      * beginDialog to start the specified prompt dialog.
+      *
+      * ```JavaScript
+      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+      * ```
+      */
+     public async prompt(
+         dialogId: string,
+         promptOrOptions: string | Partial<Activity>,
+         choices?: (string | Choice)[]
+     ): Promise<DialogTurnResult> {
+         let options: PromptOptions;
+         if (
+             (typeof promptOrOptions === 'object' && (promptOrOptions as Activity).type !== undefined) ||
+             typeof promptOrOptions === 'string'
+         ) {
+             options = { prompt: promptOrOptions as string | Partial<Activity> };
+         } else {
+             options = { ...(promptOrOptions as PromptOptions) };
+         }
+ 
+         if (choices) {
+             options.choices = choices;
+         }
+ 
+         return wrapErrors(this, this.beginDialog(dialogId, options));
+     }
+ 
+     /**
+      * Continues execution of the active dialog, if there is one, by passing this dialog context to its
+      * [Dialog.continueDialog](xref:botbuilder-dialogs.Dialog.continueDialog) method.
+      *
+      * @remarks
+      * After the call completes, you can check the turn context's [responded](xref:botbuilder-core.TurnContext.responded)
+      * property to determine if the dialog sent a reply to the user.
+      *
+      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+      * the status of the dialog stack after this method completes.
+      *
+      * Typically, you would call this from within your bot's turn handler.
+      *
+      * For example:
+      * ```JavaScript
+      * const result = await dc.continueDialog();
+      * if (result.status == DialogTurnStatus.empty && dc.context.activity.type == ActivityTypes.message) {
+      *     // Send fallback message
+      *     await dc.context.sendActivity(`I'm sorry. I didn't understand.`);
+      * }
+      * ```
+      */
+     public async continueDialog(): Promise<DialogTurnResult> {
+         // if we are continuing and haven't emitted the activityReceived event, emit it
+         // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
+         if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
+             this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true);
+ 
+             // Dispatch "activityReceived" event
+             // - This fired from teh leaf and will queue up any interruptions.
+             await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true);
+         }
+ 
+         // Check for a dialog on the stack
+         const instance: DialogInstance<any> = this.activeDialog;
+         if (instance) {
+             // Lookup dialog
+             const dialog: Dialog<{}> = this.findDialog(instance.id);
+             if (!dialog) {
+                 throw new DialogContextError(
+                     `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                     this
+                 );
+             }
+ 
+             // Continue execution of dialog
+             return wrapErrors(this, dialog.continueDialog(this));
+         } else {
+             return { status: DialogTurnStatus.empty };
+         }
+     }
+ 
+     /**
+      * Ends a dialog and pops it off the stack. Returns an optional result to the dialog's parent.
+      *
+      * @param result Optional. A result to pass to the parent logic. This might be the next dialog
+      *      on the stack, or if this was the last dialog on the stack, a parent dialog context or
+      *      the bot's turn handler.
+      *
+      * @remarks
+      * The _parent_ dialog is the next dialog on the dialog stack, if there is one. This method
+      * calls the parent's [Dialog.resumeDialog](xref:botbuilder-dialogs.Dialog.resumeDialog) method,
+      * passing the result returned by the ending dialog. If there is no parent dialog, the turn ends
+      * and the result is available to the bot through the returned object's
+      * [result](xref:botbuilder-dialogs.DialogTurnResult.result) property.
+      *
+      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+      * the status of the dialog stack after this method completes.
+      *
+      * Typically, you would call this from within the logic for a specific dialog to signal back to
+      * the dialog context that the dialog has completed, the dialog should be removed from the stack,
+      * and the parent dialog should resume.
+      *
+      * For example:
+      * ```JavaScript
+      * return await dc.endDialog(returnValue);
+      * ```
+      *
+      * **See also**
+      * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
+      * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
+      * - [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog)
+      */
+     public async endDialog(result?: any): Promise<DialogTurnResult> {
+         // End the active dialog
+         await this.endActiveDialog(DialogReason.endCalled, result);
+ 
+         // Resume parent dialog
+         const instance: DialogInstance<any> = this.activeDialog;
+         if (instance) {
+             // Lookup dialog
+             const dialog: Dialog<{}> = this.findDialog(instance.id);
+             if (!dialog) {
+                 throw new DialogContextError(
+                     `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                     this
+                 );
+             }
+ 
+             // Return result to previous dialog
+             return wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result));
+         } else {
+             // Signal completion
+             return { status: DialogTurnStatus.complete, result: result };
+         }
+     }
+ 
+     /**
+      * Ends the active dialog and starts a new dialog in its place.
+      *
+      * @param dialogId ID of the dialog to start.
+      * @param options Optional. Arguments to pass into the new dialog when it starts.
+      *
+      * @remarks
+      * This is particularly useful for creating a loop or redirecting to another dialog.
+      *
+      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+      * the status of the dialog stack after this method completes.
+      *
+      * This method is similar to ending the current dialog and immediately beginning the new one.
+      * However, the parent dialog is neither resumed nor otherwise notified.
+      *
+      * **See also**
+      * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
+      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+      */
+     public async replaceDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
+         // End the active dialog
+         await this.endActiveDialog(DialogReason.replaceCalled);
+ 
+         // Start replacement dialog
+         return this.beginDialog(dialogId, options);
+     }
+ 
+     /**
+      * Requests the active dialog to re-prompt the user for input.
+      *
+      * @remarks
+      * This calls the active dialog's [repromptDialog](xref:botbuilder-dialogs.Dialog.repromptDialog) method.
+      *
+      * For example:
+      * ```JavaScript
+      * await dc.repromptDialog();
+      * ```
+      */
+     public async repromptDialog(): Promise<void> {
+         // Try raising event first
+         const handled = await this.emitEvent(DialogEvents.repromptDialog, undefined, false, false);
+         if (!handled) {
+             // Check for a dialog on the stack
+             const instance: DialogInstance<any> = this.activeDialog;
+             if (instance) {
+                 // Lookup dialog
+                 const dialog: Dialog<{}> = this.findDialog(instance.id);
+                 if (!dialog) {
+                     throw new DialogContextError(
+                         `DialogContext.repromptDialog(): Can't find a dialog with an id of '${instance.id}'.`,
+                         this
+                     );
+                 }
+ 
+                 // Ask dialog to re-prompt if supported
+                 await wrapErrors(this, dialog.repromptDialog(this.context, instance));
+             }
+         }
+     }
+ 
+     /**
+      * Searches for a dialog with a given ID.
+      * @remarks
+      * Emits a named event for the current dialog, or someone who started it, to handle.
+      * @param name Name of the event to raise.
+      * @param value Optional. Value to send along with the event.
+      * @param bubble Optional. Flag to control whether the event should be bubbled to its parent if not handled locally. Defaults to a value of `true`.
+      * @param fromLeaf Optional. Whether the event is emitted from a leaf node.
+      * @returns `true` if the event was handled.
+      */
+     public async emitEvent(name: string, value?: any, bubble = true, fromLeaf = false): Promise<boolean> {
+         // Initialize event
+         const dialogEvent: DialogEvent = {
+             bubble: bubble,
+             name: name,
+             value: value,
+         };
+ 
+         // Find starting dialog
+         let dc: DialogContext = this;
+         if (fromLeaf) {
+             while (true) {
+                 const childDc = dc.child;
+                 if (childDc != undefined) {
+                     dc = childDc;
+                 } else {
+                     break;
+                 }
+             }
+         }
+ 
+         // Dispatch to active dialog first
+         // - The active dialog will decide if it should bubble the event to its parent.
+         const instance = dc.activeDialog;
+         if (instance != undefined) {
+             const dialog = dc.findDialog(instance.id);
+             if (dialog != undefined) {
+                 return wrapErrors(this, dialog.onDialogEvent(dc, dialogEvent));
+             }
+         }
+ 
+         return false;
+     }
+ 
+     /**
+      * @private
+      * @param reason
+      * @param result
+      */
+     private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
+         const instance: DialogInstance<any> = this.activeDialog;
+         if (instance) {
+             // Lookup dialog
+             const dialog: Dialog<{}> = this.findDialog(instance.id);
+             if (dialog) {
+                 // Notify dialog of end
+                 await wrapErrors(this, dialog.endDialog(this.context, instance, reason));
+             }
+ 
+             // Pop dialog off stack
+             this.stack.pop();
+ 
+             this.state.setValue(TurnPath.lastResult, result);
+         }
+     }
+ }
+ 

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -2,654 +2,653 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
- import { Activity, TurnContext, TurnContextStateCollection } from 'botbuilder-core';
- import { Choice } from './choices';
- import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogEvent } from './dialog';
- import { DialogSet } from './dialogSet';
- import { PromptOptions } from './prompts';
- import { DialogStateManager, TurnPath } from './memory';
- import { DialogContainer } from './dialogContainer';
- import { DialogEvents } from './dialogEvents';
- import { DialogManager } from './dialogManager';
- import { DialogTurnStateConstants } from './dialogTurnStateConstants';
- import { DialogContextError } from './dialogContextError';
- 
- /**
-  * Wraps a promise in a try-catch that automatically enriches errors with extra dialog context.
-  *
-  * @param dialogContext source dialog context from which enriched error properties are sourced
-  * @param promise a promise to await inside a try-catch for error enrichment
-  */
- const wrapErrors = async <T>(dialogContext: DialogContext, promise: Promise<T>): Promise<T> => {
-     try {
-         return await promise;
-     } catch (err) {
-         if (err instanceof DialogContextError) {
-             throw err;
-         } else {
-             throw new DialogContextError(err, dialogContext);
-         }
-     }
- };
- 
- /**
-  * @private
-  */
- const ACTIVITY_RECEIVED_EMITTED = Symbol('ActivityReceivedEmitted');
- 
- /**
-  * Contains dialog state, information about the state of the dialog stack, for a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
-  *
-  * @remarks
-  * State is read from and saved to storage each turn, and state cache for the turn is managed through
-  * the [TurnContext](xref:botbuilder-core.TurnContext).
-  *
-  * For more information, see the articles on
-  * [Managing state](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-state) and
-  * [Dialogs library](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-dialog).
-  */
- export interface DialogState {
-     /**
-      * Contains state information for each [Dialog](xref:botbuilder-dialogs.Dialog) on the stack.
-      */
-     dialogStack: DialogInstance[];
- }
- 
- /**
-  * The context for the current dialog turn with respect to a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
-  *
-  * @remarks
-  * This includes the turn context, information about the dialog set, and the state of the dialog stack.
-  *
-  * From code outside of a dialog in the set, use [DialogSet.createContext](xref:botbuilder-dialogs.DialogSet.createContext)
-  * to create the dialog context. Then use the methods of the dialog context to manage the progression of dialogs in the set.
-  *
-  * When you implement a dialog, the dialog context is a parameter available to the various methods you override or implement.
-  *
-  * For example:
-  * ```JavaScript
-  * const dc = await dialogs.createContext(turnContext);
-  * const result = await dc.continueDialog();
-  * ```
-  */
- export class DialogContext {
-     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
-      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-      * @remarks
-      * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-      */
-     public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
- 
-     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-      * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
-      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-      * @remarks
-      * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-      */
-     public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
- 
-     /**
-      * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
-      * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
-      * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
-      * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
-      * @remarks Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
-      */
-     public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
-         this.dialogs = dialogs;
-         if (contextOrDC instanceof DialogContext) {
-             this.context = contextOrDC.context;
-             this.parent = contextOrDC;
-             if (this.parent.services) {
-                 this.parent.services.forEach((value, key): void => {
-                     this.services.set(key, value);
-                 });
-             }
-         } else {
-             this.context = contextOrDC;
-         }
-         if (!Array.isArray(state.dialogStack)) {
-             state.dialogStack = [];
-         }
-         this.stack = state.dialogStack;
-         this.state = new DialogStateManager(this);
-         this.state.setValue(TurnPath.activity, this.context.activity);
-     }
- 
-     /**
-      * Gets the dialogs that can be called directly from this context.
-      */
-     public dialogs: DialogSet;
- 
-     /**
-      * Gets the context object for the turn.
-      */
-     public context: TurnContext;
- 
-     /**
-      * Gets the current dialog stack.
-      */
-     public stack: DialogInstance[];
- 
-     /**
-      * The parent dialog context for this dialog context, or `undefined` if this context doesn't have a parent.
-      *
-      * @remarks
-      * When it attempts to start a dialog, the dialog context searches for the [Dialog.id](xref:botbuilder-dialogs.Dialog.id)
-      * in its [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs). If the dialog to start is not found
-      * in this dialog context, it searches in its parent dialog context, and so on.
-      */
-     public parent: DialogContext | undefined;
- 
-     /**
-      * Returns dialog context for child if the active dialog is a container.
-      */
-     public get child(): DialogContext | undefined {
-         const instance = this.activeDialog;
-         if (instance != undefined) {
-             // Is active dialog a container?
-             const dialog = this.findDialog(instance.id);
-             if (dialog instanceof DialogContainer) {
-                 return dialog.createChildContext(this);
-             }
-         }
- 
-         return undefined;
-     }
- 
-     /**
-      * Returns the state information for the dialog on the top of the dialog stack, or `undefined` if
-      * the stack is empty.
-      */
-     public get activeDialog(): DialogInstance | undefined {
-         return this.stack.length > 0 ? this.stack[this.stack.length - 1] : undefined;
-     }
- 
-     /**
-      * Gets the DialogStateManager which manages view of all memory scopes.
-      */
-     public state: DialogStateManager;
- 
-     /**
-      * Gets the services collection which is contextual to this dialog context.
-      */
-     public services: TurnContextStateCollection = new TurnContextStateCollection();
- 
-     /**
-      * Returns the current dialog manager instance. This property is obsolete.
-      *
-      * @obsolete This property serves no function.
-      */
-     public get dialogManager(): DialogManager {
-         return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
-     }
- 
-     /**
-      * Obtain the CultureInfo in DialogContext.
-      * @returns a locale string.
-      */
-     public getLocale(): string {
-         const _turnLocaleProperty = 'turn.locale';
- 
-         const turnLocaleValue = this.state.getValue(_turnLocaleProperty);
-         if (turnLocaleValue) {
-             return turnLocaleValue;
-         }
- 
-         const locale = this.context.activity?.locale;
-         if (locale !== undefined) {
-             return locale;
-         }
- 
-         return Intl.DateTimeFormat().resolvedOptions().locale;
-     }
- 
-     /**
-      * Starts a dialog instance and pushes it onto the dialog stack.
-      * Creates a new instance of the dialog and pushes it onto the stack.
-      *
-      * @param dialogId ID of the dialog to start.
-      * @param options Optional. Arguments to pass into the dialog when it starts.
-      *
-      * @remarks
-      * If there's already an active dialog on the stack, that dialog will be paused until
-      * it is again the top dialog on the stack.
-      *
-      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-      * the status of the dialog stack after this method completes.
-      *
-      * This method throws an exception if the requested dialog can't be found in this dialog context
-      * or any of its ancestors.
-      *
-      * For example:
-      * ```JavaScript
-      * const result = await dc.beginDialog('greeting', { name: user.name });
-      * ```
-      *
-      * **See also**
-      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-      * - [prompt](xref:botbuilder-dialogs.DialogContext.prompt)
-      * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
-      * - [Dialog.beginDialog](xref:botbuilder-dialogs.Dialog.beginDialog)
-      */
-     public async beginDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
-         // Lookup dialog
-         const dialog: Dialog<{}> = this.findDialog(dialogId);
-         if (!dialog) {
-             throw new DialogContextError(
-                 `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
-                 this
-             );
-         }
- 
-         // Push new instance onto stack.
-         const instance: DialogInstance<any> = {
-             id: dialogId,
-             state: {},
-         };
-         this.stack.push(instance);
- 
-         // Call dialogs begin() method.
-         return wrapErrors(this, dialog.beginDialog(this, options));
-     }
- 
-     /**
-      * Cancels all dialogs on the dialog stack, and clears stack.
-      *
-      * @param cancelParents Optional. If `true` all parent dialogs will be cancelled as well.
-      * @param eventName Optional. Name of a custom event to raise as dialogs are cancelled. This defaults to [cancelDialog](xref:botbuilder-dialogs.DialogEvents.cancelDialog).
-      * @param eventValue Optional. Value to pass along with custom cancellation event.
-      *
-      * @remarks
-      * This calls each dialog's [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog) method before
-      * removing the dialog from the stack.
-      *
-      * If there were any dialogs on the stack initially, the [status](xref:botbuilder-dialogs.DialogTurnResult.status)
-      * of the return value is [cancelled](xref:botbuilder-dialogs.DialogTurnStatus.cancelled); otherwise, it's
-      * [empty](xref:botbuilder-dialogs.DialogTurnStatus.empty).
-      *
-      * This example clears a dialog stack, `dc`, before starting a 'bookFlight' dialog.
-      * ```JavaScript
-      * await dc.cancelAllDialogs();
-      * return await dc.beginDialog('bookFlight');
-      * ```
-      *
-      * **See also**
-      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-      */
-     public async cancelAllDialogs(
-         cancelParents = false,
-         eventName?: string,
-         eventValue?: any
-     ): Promise<DialogTurnResult> {
-         eventName = eventName || DialogEvents.cancelDialog;
-         if (this.stack.length > 0 || this.parent != undefined) {
-             // Cancel all local and parent dialogs while checking for interception
-             let notify = false;
-             let dc: DialogContext = this;
-             while (dc != undefined) {
-                 if (dc.stack.length > 0) {
-                     // Check to see if the dialog wants to handle the event
-                     // - We skip notifying the first dialog which actually called cancelAllDialogs()
-                     if (notify) {
-                         const handled = await dc.emitEvent(eventName, eventValue, false, false);
-                         if (handled) {
-                             break;
-                         }
-                     }
- 
-                     // End the active dialog
-                     await dc.endActiveDialog(DialogReason.cancelCalled);
-                 } else {
-                     dc = cancelParents ? dc.parent : undefined;
-                 }
- 
-                 notify = true;
-             }
- 
-             return { status: DialogTurnStatus.cancelled };
-         } else {
-             return { status: DialogTurnStatus.empty };
-         }
-     }
- 
-     /**
-      * Searches for a dialog with a given ID.
-      *
-      * @param dialogId ID of the dialog to search for.
-      *
-      * @remarks
-      * If the dialog to start is not found in the [DialogSet](xref:botbuilder-dialogs.DialogSet) associated
-      * with this dialog context, it attempts to find the dialog in its parent dialog context.
-      *
-      * **See also**
-      * - [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs)
-      * - [parent](xref:botbuilder-dialogs.DialogContext.parent)
-      */
-     public findDialog(dialogId: string): Dialog | undefined {
-         let dialog = this.dialogs.find(dialogId);
-         if (!dialog && this.parent) {
-             dialog = this.parent.findDialog(dialogId);
-         }
-         return dialog;
-     }
- 
-     /**
-      * Helper function to simplify formatting the options for calling a prompt dialog.
-      * @param dialogId ID of the prompt dialog to start.
-      * @param promptOrOptions The text of the initial prompt to send the user,
-      *      the activity to send as the initial prompt, or
-      *      the object with which to format the prompt dialog.
-      * @param choices Optional. Array of choices for the user to choose from,
-      *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-      *
-      * @remarks
-      * This helper method formats the object to use as the `options` parameter, and then calls
-      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
-      *
-      * ```JavaScript
-      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-      * ```
-      */
-     public async prompt(
-         dialogId: string,
-         promptOrOptions: string | Partial<Activity> | PromptOptions
-     ): Promise<DialogTurnResult>;
- 
-     /**
-      * Helper function to simplify formatting the options for calling a prompt dialog.
-      * @param dialogId ID of the prompt dialog to start.
-      * @param promptOrOptions The text of the initial prompt to send the user,
-      * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
-      * the object with which to format the prompt dialog.
-      * @param choices Optional. Array of choices for the user to choose from,
-      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-      * @remarks
-      * This helper method formats the object to use as the `options` parameter, and then calls
-      * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
-      *
-      * ```JavaScript
-      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-      * ```
-      */
-     public async prompt(
-         dialogId: string,
-         promptOrOptions: string | Partial<Activity> | PromptOptions,
-         choices: (string | Choice)[]
-     ): Promise<DialogTurnResult>;
- 
-     /**
-      * Helper function to simplify formatting the options for calling a prompt dialog.
-      * @param dialogId ID of the prompt dialog to start.
-      * @param promptOrOptions The text of the initial prompt to send the user,
-      * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
-      * @param choices Optional. Array of choices for the user to choose from,
-      * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
-      * @remarks This helper method formats the object to use as the `options` parameter, and then calls
-      * beginDialog to start the specified prompt dialog.
-      *
-      * ```JavaScript
-      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
-      * ```
-      */
-     public async prompt(
-         dialogId: string,
-         promptOrOptions: string | Partial<Activity>,
-         choices?: (string | Choice)[]
-     ): Promise<DialogTurnResult> {
-         let options: PromptOptions;
-         if (
-             (typeof promptOrOptions === 'object' && (promptOrOptions as Activity).type !== undefined) ||
-             typeof promptOrOptions === 'string'
-         ) {
-             options = { prompt: promptOrOptions as string | Partial<Activity> };
-         } else {
-             options = { ...(promptOrOptions as PromptOptions) };
-         }
- 
-         if (choices) {
-             options.choices = choices;
-         }
- 
-         return wrapErrors(this, this.beginDialog(dialogId, options));
-     }
- 
-     /**
-      * Continues execution of the active dialog, if there is one, by passing this dialog context to its
-      * [Dialog.continueDialog](xref:botbuilder-dialogs.Dialog.continueDialog) method.
-      *
-      * @remarks
-      * After the call completes, you can check the turn context's [responded](xref:botbuilder-core.TurnContext.responded)
-      * property to determine if the dialog sent a reply to the user.
-      *
-      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-      * the status of the dialog stack after this method completes.
-      *
-      * Typically, you would call this from within your bot's turn handler.
-      *
-      * For example:
-      * ```JavaScript
-      * const result = await dc.continueDialog();
-      * if (result.status == DialogTurnStatus.empty && dc.context.activity.type == ActivityTypes.message) {
-      *     // Send fallback message
-      *     await dc.context.sendActivity(`I'm sorry. I didn't understand.`);
-      * }
-      * ```
-      */
-     public async continueDialog(): Promise<DialogTurnResult> {
-         // if we are continuing and haven't emitted the activityReceived event, emit it
-         // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
-         if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
-             this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true);
- 
-             // Dispatch "activityReceived" event
-             // - This fired from teh leaf and will queue up any interruptions.
-             await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true);
-         }
- 
-         // Check for a dialog on the stack
-         const instance: DialogInstance<any> = this.activeDialog;
-         if (instance) {
-             // Lookup dialog
-             const dialog: Dialog<{}> = this.findDialog(instance.id);
-             if (!dialog) {
-                 throw new DialogContextError(
-                     `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                     this
-                 );
-             }
- 
-             // Continue execution of dialog
-             return wrapErrors(this, dialog.continueDialog(this));
-         } else {
-             return { status: DialogTurnStatus.empty };
-         }
-     }
- 
-     /**
-      * Ends a dialog and pops it off the stack. Returns an optional result to the dialog's parent.
-      *
-      * @param result Optional. A result to pass to the parent logic. This might be the next dialog
-      *      on the stack, or if this was the last dialog on the stack, a parent dialog context or
-      *      the bot's turn handler.
-      *
-      * @remarks
-      * The _parent_ dialog is the next dialog on the dialog stack, if there is one. This method
-      * calls the parent's [Dialog.resumeDialog](xref:botbuilder-dialogs.Dialog.resumeDialog) method,
-      * passing the result returned by the ending dialog. If there is no parent dialog, the turn ends
-      * and the result is available to the bot through the returned object's
-      * [result](xref:botbuilder-dialogs.DialogTurnResult.result) property.
-      *
-      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-      * the status of the dialog stack after this method completes.
-      *
-      * Typically, you would call this from within the logic for a specific dialog to signal back to
-      * the dialog context that the dialog has completed, the dialog should be removed from the stack,
-      * and the parent dialog should resume.
-      *
-      * For example:
-      * ```JavaScript
-      * return await dc.endDialog(returnValue);
-      * ```
-      *
-      * **See also**
-      * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
-      * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
-      * - [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog)
-      */
-     public async endDialog(result?: any): Promise<DialogTurnResult> {
-         // End the active dialog
-         await this.endActiveDialog(DialogReason.endCalled, result);
- 
-         // Resume parent dialog
-         const instance: DialogInstance<any> = this.activeDialog;
-         if (instance) {
-             // Lookup dialog
-             const dialog: Dialog<{}> = this.findDialog(instance.id);
-             if (!dialog) {
-                 throw new DialogContextError(
-                     `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                     this
-                 );
-             }
- 
-             // Return result to previous dialog
-             return wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result));
-         } else {
-             // Signal completion
-             return { status: DialogTurnStatus.complete, result: result };
-         }
-     }
- 
-     /**
-      * Ends the active dialog and starts a new dialog in its place.
-      *
-      * @param dialogId ID of the dialog to start.
-      * @param options Optional. Arguments to pass into the new dialog when it starts.
-      *
-      * @remarks
-      * This is particularly useful for creating a loop or redirecting to another dialog.
-      *
-      * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
-      * the status of the dialog stack after this method completes.
-      *
-      * This method is similar to ending the current dialog and immediately beginning the new one.
-      * However, the parent dialog is neither resumed nor otherwise notified.
-      *
-      * **See also**
-      * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
-      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
-      */
-     public async replaceDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
-         // End the active dialog
-         await this.endActiveDialog(DialogReason.replaceCalled);
- 
-         // Start replacement dialog
-         return this.beginDialog(dialogId, options);
-     }
- 
-     /**
-      * Requests the active dialog to re-prompt the user for input.
-      *
-      * @remarks
-      * This calls the active dialog's [repromptDialog](xref:botbuilder-dialogs.Dialog.repromptDialog) method.
-      *
-      * For example:
-      * ```JavaScript
-      * await dc.repromptDialog();
-      * ```
-      */
-     public async repromptDialog(): Promise<void> {
-         // Try raising event first
-         const handled = await this.emitEvent(DialogEvents.repromptDialog, undefined, false, false);
-         if (!handled) {
-             // Check for a dialog on the stack
-             const instance: DialogInstance<any> = this.activeDialog;
-             if (instance) {
-                 // Lookup dialog
-                 const dialog: Dialog<{}> = this.findDialog(instance.id);
-                 if (!dialog) {
-                     throw new DialogContextError(
-                         `DialogContext.repromptDialog(): Can't find a dialog with an id of '${instance.id}'.`,
-                         this
-                     );
-                 }
- 
-                 // Ask dialog to re-prompt if supported
-                 await wrapErrors(this, dialog.repromptDialog(this.context, instance));
-             }
-         }
-     }
- 
-     /**
-      * Searches for a dialog with a given ID.
-      * @remarks
-      * Emits a named event for the current dialog, or someone who started it, to handle.
-      * @param name Name of the event to raise.
-      * @param value Optional. Value to send along with the event.
-      * @param bubble Optional. Flag to control whether the event should be bubbled to its parent if not handled locally. Defaults to a value of `true`.
-      * @param fromLeaf Optional. Whether the event is emitted from a leaf node.
-      * @returns `true` if the event was handled.
-      */
-     public async emitEvent(name: string, value?: any, bubble = true, fromLeaf = false): Promise<boolean> {
-         // Initialize event
-         const dialogEvent: DialogEvent = {
-             bubble: bubble,
-             name: name,
-             value: value,
-         };
- 
-         // Find starting dialog
-         let dc: DialogContext = this;
-         if (fromLeaf) {
-             while (true) {
-                 const childDc = dc.child;
-                 if (childDc != undefined) {
-                     dc = childDc;
-                 } else {
-                     break;
-                 }
-             }
-         }
- 
-         // Dispatch to active dialog first
-         // - The active dialog will decide if it should bubble the event to its parent.
-         const instance = dc.activeDialog;
-         if (instance != undefined) {
-             const dialog = dc.findDialog(instance.id);
-             if (dialog != undefined) {
-                 return wrapErrors(this, dialog.onDialogEvent(dc, dialogEvent));
-             }
-         }
- 
-         return false;
-     }
- 
-     /**
-      * @private
-      * @param reason
-      * @param result
-      */
-     private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
-         const instance: DialogInstance<any> = this.activeDialog;
-         if (instance) {
-             // Lookup dialog
-             const dialog: Dialog<{}> = this.findDialog(instance.id);
-             if (dialog) {
-                 // Notify dialog of end
-                 await wrapErrors(this, dialog.endDialog(this.context, instance, reason));
-             }
- 
-             // Pop dialog off stack
-             this.stack.pop();
- 
-             this.state.setValue(TurnPath.lastResult, result);
-         }
-     }
- }
- 
+import { Activity, TurnContext, TurnContextStateCollection } from 'botbuilder-core';
+import { Choice } from './choices';
+import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogEvent } from './dialog';
+import { DialogSet } from './dialogSet';
+import { PromptOptions } from './prompts';
+import { DialogStateManager, TurnPath } from './memory';
+import { DialogContainer } from './dialogContainer';
+import { DialogEvents } from './dialogEvents';
+import { DialogManager } from './dialogManager';
+import { DialogTurnStateConstants } from './dialogTurnStateConstants';
+import { DialogContextError } from './dialogContextError';
+
+/**
+ * Wraps a promise in a try-catch that automatically enriches errors with extra dialog context.
+ *
+ * @param dialogContext source dialog context from which enriched error properties are sourced
+ * @param promise a promise to await inside a try-catch for error enrichment
+ */
+const wrapErrors = async <T>(dialogContext: DialogContext, promise: Promise<T>): Promise<T> => {
+    try {
+        return await promise;
+    } catch (err) {
+        if (err instanceof DialogContextError) {
+            throw err;
+        } else {
+            throw new DialogContextError(err, dialogContext);
+        }
+    }
+};
+
+/**
+ * @private
+ */
+const ACTIVITY_RECEIVED_EMITTED = Symbol('ActivityReceivedEmitted');
+
+/**
+ * Contains dialog state, information about the state of the dialog stack, for a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
+ *
+ * @remarks
+ * State is read from and saved to storage each turn, and state cache for the turn is managed through
+ * the [TurnContext](xref:botbuilder-core.TurnContext).
+ *
+ * For more information, see the articles on
+ * [Managing state](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-state) and
+ * [Dialogs library](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-dialog).
+ */
+export interface DialogState {
+    /**
+     * Contains state information for each [Dialog](xref:botbuilder-dialogs.Dialog) on the stack.
+     */
+    dialogStack: DialogInstance[];
+}
+
+/**
+ * The context for the current dialog turn with respect to a specific [DialogSet](xref:botbuilder-dialogs.DialogSet).
+ *
+ * @remarks
+ * This includes the turn context, information about the dialog set, and the state of the dialog stack.
+ *
+ * From code outside of a dialog in the set, use [DialogSet.createContext](xref:botbuilder-dialogs.DialogSet.createContext)
+ * to create the dialog context. Then use the methods of the dialog context to manage the progression of dialogs in the set.
+ *
+ * When you implement a dialog, the dialog context is a parameter available to the various methods you override or implement.
+ *
+ * For example:
+ * ```JavaScript
+ * const dc = await dialogs.createContext(turnContext);
+ * const result = await dc.continueDialog();
+ * ```
+ */
+export class DialogContext {
+    /**
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) object for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks
+     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+     */
+    public constructor(dialogs: DialogSet, contextOrDC: TurnContext, state: DialogState);
+
+    /**
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [DialogContext](xref:botbuilder-dialogs.DialogContext) object for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks
+     * Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+     */
+    public constructor(dialogs: DialogSet, contextOrDC: DialogContext, state: DialogState);
+
+    /**
+     * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
+     * @param dialogs The [DialogSet](xref:botbuilder-dialogs.DialogSet) for which to create the dialog context.
+     * @param contextOrDC The [TurnContext](xref:botbuilder-core.TurnContext) or [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of the bot.
+     * @param state The state object to use to read and write [DialogState](xref:botbuilder-dialogs.DialogState) to storage.
+     * @remarks Passing in a [DialogContext](xref:botbuilder-dialogs.DialogContext) instance will clone the dialog context.
+     */
+    public constructor(dialogs: DialogSet, contextOrDC: TurnContext | DialogContext, state: DialogState) {
+        this.dialogs = dialogs;
+        if (contextOrDC instanceof DialogContext) {
+            this.context = contextOrDC.context;
+            this.parent = contextOrDC;
+            if (this.parent.services) {
+                this.parent.services.forEach((value, key): void => {
+                    this.services.set(key, value);
+                });
+            }
+        } else {
+            this.context = contextOrDC;
+        }
+        if (!Array.isArray(state.dialogStack)) {
+            state.dialogStack = [];
+        }
+        this.stack = state.dialogStack;
+        this.state = new DialogStateManager(this);
+        this.state.setValue(TurnPath.activity, this.context.activity);
+    }
+
+    /**
+     * Gets the dialogs that can be called directly from this context.
+     */
+    public dialogs: DialogSet;
+
+    /**
+     * Gets the context object for the turn.
+     */
+    public context: TurnContext;
+
+    /**
+     * Gets the current dialog stack.
+     */
+    public stack: DialogInstance[];
+
+    /**
+     * The parent dialog context for this dialog context, or `undefined` if this context doesn't have a parent.
+     *
+     * @remarks
+     * When it attempts to start a dialog, the dialog context searches for the [Dialog.id](xref:botbuilder-dialogs.Dialog.id)
+     * in its [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs). If the dialog to start is not found
+     * in this dialog context, it searches in its parent dialog context, and so on.
+     */
+    public parent: DialogContext | undefined;
+
+    /**
+     * Returns dialog context for child if the active dialog is a container.
+     */
+    public get child(): DialogContext | undefined {
+        const instance = this.activeDialog;
+        if (instance != undefined) {
+            // Is active dialog a container?
+            const dialog = this.findDialog(instance.id);
+            if (dialog instanceof DialogContainer) {
+                return dialog.createChildContext(this);
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Returns the state information for the dialog on the top of the dialog stack, or `undefined` if
+     * the stack is empty.
+     */
+    public get activeDialog(): DialogInstance | undefined {
+        return this.stack.length > 0 ? this.stack[this.stack.length - 1] : undefined;
+    }
+
+    /**
+     * Gets the DialogStateManager which manages view of all memory scopes.
+     */
+    public state: DialogStateManager;
+
+    /**
+     * Gets the services collection which is contextual to this dialog context.
+     */
+    public services: TurnContextStateCollection = new TurnContextStateCollection();
+
+    /**
+     * Returns the current dialog manager instance. This property is obsolete.
+     *
+     * @obsolete This property serves no function.
+     */
+    public get dialogManager(): DialogManager {
+        return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
+    }
+
+    /**
+     * Obtain the CultureInfo in DialogContext.
+     * @returns a locale string.
+     */
+    public getLocale(): string {
+        const _turnLocaleProperty = 'turn.locale';
+
+        const turnLocaleValue = this.state.getValue(_turnLocaleProperty);
+        if (turnLocaleValue) {
+            return turnLocaleValue;
+        }
+
+        const locale = this.context.activity?.locale;
+        if (locale !== undefined) {
+            return locale;
+        }
+
+        return Intl.DateTimeFormat().resolvedOptions().locale;
+    }
+
+    /**
+     * Starts a dialog instance and pushes it onto the dialog stack.
+     * Creates a new instance of the dialog and pushes it onto the stack.
+     *
+     * @param dialogId ID of the dialog to start.
+     * @param options Optional. Arguments to pass into the dialog when it starts.
+     *
+     * @remarks
+     * If there's already an active dialog on the stack, that dialog will be paused until
+     * it is again the top dialog on the stack.
+     *
+     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+     * the status of the dialog stack after this method completes.
+     *
+     * This method throws an exception if the requested dialog can't be found in this dialog context
+     * or any of its ancestors.
+     *
+     * For example:
+     * ```JavaScript
+     * const result = await dc.beginDialog('greeting', { name: user.name });
+     * ```
+     *
+     * **See also**
+     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+     * - [prompt](xref:botbuilder-dialogs.DialogContext.prompt)
+     * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
+     * - [Dialog.beginDialog](xref:botbuilder-dialogs.Dialog.beginDialog)
+     */
+    public async beginDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
+        // Lookup dialog
+        const dialog: Dialog<{}> = this.findDialog(dialogId);
+        if (!dialog) {
+            throw new DialogContextError(
+                `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
+                this
+            );
+        }
+
+        // Push new instance onto stack.
+        const instance: DialogInstance<any> = {
+            id: dialogId,
+            state: {},
+        };
+        this.stack.push(instance);
+
+        // Call dialogs begin() method.
+        return wrapErrors(this, dialog.beginDialog(this, options));
+    }
+
+    /**
+     * Cancels all dialogs on the dialog stack, and clears stack.
+     *
+     * @param cancelParents Optional. If `true` all parent dialogs will be cancelled as well.
+     * @param eventName Optional. Name of a custom event to raise as dialogs are cancelled. This defaults to [cancelDialog](xref:botbuilder-dialogs.DialogEvents.cancelDialog).
+     * @param eventValue Optional. Value to pass along with custom cancellation event.
+     *
+     * @remarks
+     * This calls each dialog's [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog) method before
+     * removing the dialog from the stack.
+     *
+     * If there were any dialogs on the stack initially, the [status](xref:botbuilder-dialogs.DialogTurnResult.status)
+     * of the return value is [cancelled](xref:botbuilder-dialogs.DialogTurnStatus.cancelled); otherwise, it's
+     * [empty](xref:botbuilder-dialogs.DialogTurnStatus.empty).
+     *
+     * This example clears a dialog stack, `dc`, before starting a 'bookFlight' dialog.
+     * ```JavaScript
+     * await dc.cancelAllDialogs();
+     * return await dc.beginDialog('bookFlight');
+     * ```
+     *
+     * **See also**
+     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+     */
+    public async cancelAllDialogs(
+        cancelParents = false,
+        eventName?: string,
+        eventValue?: any
+    ): Promise<DialogTurnResult> {
+        eventName = eventName || DialogEvents.cancelDialog;
+        if (this.stack.length > 0 || this.parent != undefined) {
+            // Cancel all local and parent dialogs while checking for interception
+            let notify = false;
+            let dc: DialogContext = this;
+            while (dc != undefined) {
+                if (dc.stack.length > 0) {
+                    // Check to see if the dialog wants to handle the event
+                    // - We skip notifying the first dialog which actually called cancelAllDialogs()
+                    if (notify) {
+                        const handled = await dc.emitEvent(eventName, eventValue, false, false);
+                        if (handled) {
+                            break;
+                        }
+                    }
+
+                    // End the active dialog
+                    await dc.endActiveDialog(DialogReason.cancelCalled);
+                } else {
+                    dc = cancelParents ? dc.parent : undefined;
+                }
+
+                notify = true;
+            }
+
+            return { status: DialogTurnStatus.cancelled };
+        } else {
+            return { status: DialogTurnStatus.empty };
+        }
+    }
+
+    /**
+     * Searches for a dialog with a given ID.
+     *
+     * @param dialogId ID of the dialog to search for.
+     *
+     * @remarks
+     * If the dialog to start is not found in the [DialogSet](xref:botbuilder-dialogs.DialogSet) associated
+     * with this dialog context, it attempts to find the dialog in its parent dialog context.
+     *
+     * **See also**
+     * - [dialogs](xref:botbuilder-dialogs.DialogContext.dialogs)
+     * - [parent](xref:botbuilder-dialogs.DialogContext.parent)
+     */
+    public findDialog(dialogId: string): Dialog | undefined {
+        let dialog = this.dialogs.find(dialogId);
+        if (!dialog && this.parent) {
+            dialog = this.parent.findDialog(dialogId);
+        }
+        return dialog;
+    }
+
+    /**
+     * Helper function to simplify formatting the options for calling a prompt dialog.
+     * @param dialogId ID of the prompt dialog to start.
+     * @param promptOrOptions The text of the initial prompt to send the user,
+     *      the activity to send as the initial prompt, or
+     *      the object with which to format the prompt dialog.
+     * @param choices Optional. Array of choices for the user to choose from,
+     *      for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     *
+     * @remarks
+     * This helper method formats the object to use as the `options` parameter, and then calls
+     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+     *
+     * ```JavaScript
+     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+     * ```
+     */
+    public async prompt(
+        dialogId: string,
+        promptOrOptions: string | Partial<Activity> | PromptOptions
+    ): Promise<DialogTurnResult>;
+
+    /**
+     * Helper function to simplify formatting the options for calling a prompt dialog.
+     * @param dialogId ID of the prompt dialog to start.
+     * @param promptOrOptions The text of the initial prompt to send the user,
+     * the [Activity](xref:botframework-schema.Activity) to send as the initial prompt, or
+     * the object with which to format the prompt dialog.
+     * @param choices Optional. Array of choices for the user to choose from,
+     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * @remarks
+     * This helper method formats the object to use as the `options` parameter, and then calls
+     * [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog) to start the specified prompt dialog.
+     *
+     * ```JavaScript
+     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+     * ```
+     */
+    public async prompt(
+        dialogId: string,
+        promptOrOptions: string | Partial<Activity> | PromptOptions,
+        choices: (string | Choice)[]
+    ): Promise<DialogTurnResult>;
+
+    /**
+     * Helper function to simplify formatting the options for calling a prompt dialog.
+     * @param dialogId ID of the prompt dialog to start.
+     * @param promptOrOptions The text of the initial prompt to send the user,
+     * or the [Activity](xref:botframework-schema.Activity) to send as the initial prompt.
+     * @param choices Optional. Array of choices for the user to choose from,
+     * for use with a [ChoicePrompt](xref:botbuilder-dialogs.ChoicePrompt).
+     * @remarks This helper method formats the object to use as the `options` parameter, and then calls
+     * beginDialog to start the specified prompt dialog.
+     *
+     * ```JavaScript
+     * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
+     * ```
+     */
+    public async prompt(
+        dialogId: string,
+        promptOrOptions: string | Partial<Activity>,
+        choices?: (string | Choice)[]
+    ): Promise<DialogTurnResult> {
+        let options: PromptOptions;
+        if (
+            (typeof promptOrOptions === 'object' && (promptOrOptions as Activity).type !== undefined) ||
+            typeof promptOrOptions === 'string'
+        ) {
+            options = { prompt: promptOrOptions as string | Partial<Activity> };
+        } else {
+            options = { ...(promptOrOptions as PromptOptions) };
+        }
+
+        if (choices) {
+            options.choices = choices;
+        }
+
+        return wrapErrors(this, this.beginDialog(dialogId, options));
+    }
+
+    /**
+     * Continues execution of the active dialog, if there is one, by passing this dialog context to its
+     * [Dialog.continueDialog](xref:botbuilder-dialogs.Dialog.continueDialog) method.
+     *
+     * @remarks
+     * After the call completes, you can check the turn context's [responded](xref:botbuilder-core.TurnContext.responded)
+     * property to determine if the dialog sent a reply to the user.
+     *
+     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+     * the status of the dialog stack after this method completes.
+     *
+     * Typically, you would call this from within your bot's turn handler.
+     *
+     * For example:
+     * ```JavaScript
+     * const result = await dc.continueDialog();
+     * if (result.status == DialogTurnStatus.empty && dc.context.activity.type == ActivityTypes.message) {
+     *     // Send fallback message
+     *     await dc.context.sendActivity(`I'm sorry. I didn't understand.`);
+     * }
+     * ```
+     */
+    public async continueDialog(): Promise<DialogTurnResult> {
+        // if we are continuing and haven't emitted the activityReceived event, emit it
+        // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
+        if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
+            this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true);
+
+            // Dispatch "activityReceived" event
+            // - This fired from teh leaf and will queue up any interruptions.
+            await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true);
+        }
+
+        // Check for a dialog on the stack
+        const instance: DialogInstance<any> = this.activeDialog;
+        if (instance) {
+            // Lookup dialog
+            const dialog: Dialog<{}> = this.findDialog(instance.id);
+            if (!dialog) {
+                throw new DialogContextError(
+                    `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                    this
+                );
+            }
+
+            // Continue execution of dialog
+            return wrapErrors(this, dialog.continueDialog(this));
+        } else {
+            return { status: DialogTurnStatus.empty };
+        }
+    }
+
+    /**
+     * Ends a dialog and pops it off the stack. Returns an optional result to the dialog's parent.
+     *
+     * @param result Optional. A result to pass to the parent logic. This might be the next dialog
+     *      on the stack, or if this was the last dialog on the stack, a parent dialog context or
+     *      the bot's turn handler.
+     *
+     * @remarks
+     * The _parent_ dialog is the next dialog on the dialog stack, if there is one. This method
+     * calls the parent's [Dialog.resumeDialog](xref:botbuilder-dialogs.Dialog.resumeDialog) method,
+     * passing the result returned by the ending dialog. If there is no parent dialog, the turn ends
+     * and the result is available to the bot through the returned object's
+     * [result](xref:botbuilder-dialogs.DialogTurnResult.result) property.
+     *
+     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+     * the status of the dialog stack after this method completes.
+     *
+     * Typically, you would call this from within the logic for a specific dialog to signal back to
+     * the dialog context that the dialog has completed, the dialog should be removed from the stack,
+     * and the parent dialog should resume.
+     *
+     * For example:
+     * ```JavaScript
+     * return await dc.endDialog(returnValue);
+     * ```
+     *
+     * **See also**
+     * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
+     * - [replaceDialog](xref:botbuilder-dialogs.DialogContext.replaceDialog)
+     * - [Dialog.endDialog](xref:botbuilder-dialogs.Dialog.endDialog)
+     */
+    public async endDialog(result?: any): Promise<DialogTurnResult> {
+        // End the active dialog
+        await this.endActiveDialog(DialogReason.endCalled, result);
+
+        // Resume parent dialog
+        const instance: DialogInstance<any> = this.activeDialog;
+        if (instance) {
+            // Lookup dialog
+            const dialog: Dialog<{}> = this.findDialog(instance.id);
+            if (!dialog) {
+                throw new DialogContextError(
+                    `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                    this
+                );
+            }
+
+            // Return result to previous dialog
+            return wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result));
+        } else {
+            // Signal completion
+            return { status: DialogTurnStatus.complete, result: result };
+        }
+    }
+
+    /**
+     * Ends the active dialog and starts a new dialog in its place.
+     *
+     * @param dialogId ID of the dialog to start.
+     * @param options Optional. Arguments to pass into the new dialog when it starts.
+     *
+     * @remarks
+     * This is particularly useful for creating a loop or redirecting to another dialog.
+     *
+     * The [status](xref:botbuilder-dialogs.DialogTurnResult.status) of returned object describes
+     * the status of the dialog stack after this method completes.
+     *
+     * This method is similar to ending the current dialog and immediately beginning the new one.
+     * However, the parent dialog is neither resumed nor otherwise notified.
+     *
+     * **See also**
+     * - [beginDialog](xref:botbuilder-dialogs.DialogContext.beginDialog)
+     * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
+     */
+    public async replaceDialog(dialogId: string, options?: object): Promise<DialogTurnResult> {
+        // End the active dialog
+        await this.endActiveDialog(DialogReason.replaceCalled);
+
+        // Start replacement dialog
+        return this.beginDialog(dialogId, options);
+    }
+
+    /**
+     * Requests the active dialog to re-prompt the user for input.
+     *
+     * @remarks
+     * This calls the active dialog's [repromptDialog](xref:botbuilder-dialogs.Dialog.repromptDialog) method.
+     *
+     * For example:
+     * ```JavaScript
+     * await dc.repromptDialog();
+     * ```
+     */
+    public async repromptDialog(): Promise<void> {
+        // Try raising event first
+        const handled = await this.emitEvent(DialogEvents.repromptDialog, undefined, false, false);
+        if (!handled) {
+            // Check for a dialog on the stack
+            const instance: DialogInstance<any> = this.activeDialog;
+            if (instance) {
+                // Lookup dialog
+                const dialog: Dialog<{}> = this.findDialog(instance.id);
+                if (!dialog) {
+                    throw new DialogContextError(
+                        `DialogContext.repromptDialog(): Can't find a dialog with an id of '${instance.id}'.`,
+                        this
+                    );
+                }
+
+                // Ask dialog to re-prompt if supported
+                await wrapErrors(this, dialog.repromptDialog(this.context, instance));
+            }
+        }
+    }
+
+    /**
+     * Searches for a dialog with a given ID.
+     * @remarks
+     * Emits a named event for the current dialog, or someone who started it, to handle.
+     * @param name Name of the event to raise.
+     * @param value Optional. Value to send along with the event.
+     * @param bubble Optional. Flag to control whether the event should be bubbled to its parent if not handled locally. Defaults to a value of `true`.
+     * @param fromLeaf Optional. Whether the event is emitted from a leaf node.
+     * @returns `true` if the event was handled.
+     */
+    public async emitEvent(name: string, value?: any, bubble = true, fromLeaf = false): Promise<boolean> {
+        // Initialize event
+        const dialogEvent: DialogEvent = {
+            bubble: bubble,
+            name: name,
+            value: value,
+        };
+
+        // Find starting dialog
+        let dc: DialogContext = this;
+        if (fromLeaf) {
+            while (true) {
+                const childDc = dc.child;
+                if (childDc != undefined) {
+                    dc = childDc;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Dispatch to active dialog first
+        // - The active dialog will decide if it should bubble the event to its parent.
+        const instance = dc.activeDialog;
+        if (instance != undefined) {
+            const dialog = dc.findDialog(instance.id);
+            if (dialog != undefined) {
+                return wrapErrors(this, dialog.onDialogEvent(dc, dialogEvent));
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @private
+     * @param reason
+     * @param result
+     */
+    private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
+        const instance: DialogInstance<any> = this.activeDialog;
+        if (instance) {
+            // Lookup dialog
+            const dialog: Dialog<{}> = this.findDialog(instance.id);
+            if (dialog) {
+                // Notify dialog of end
+                await wrapErrors(this, dialog.endDialog(this.context, instance, reason));
+            }
+
+            // Pop dialog off stack
+            this.stack.pop();
+
+            this.state.setValue(TurnPath.lastResult, result);
+        }
+    }
+}


### PR DESCRIPTION
Adresses # 2745
#minor

## Description
When reviewing the botbuilder-js project it was found that eslint is showing several warnings for the botbuilder-dialogs-adaptive library.

## Specific Changes

- Replaced strings quotes with the correct one depending of the case
- Replaced hasOwnProperty with Object.prototype.hasOwnProperty.call
- Adjusted formatting
- Limited importing scopes
- Added missing jsdocs documentation for parameters and returns for functions
- Removed unused variables

## Testing
Eslint with no warnings and tests passed
![image](https://user-images.githubusercontent.com/94375175/149823185-f518820c-91ba-4cdc-9776-3e7434225438.png)