### PR TITLE
fix: [SSO] Remove 'exchangeToken' validation from OauthPrompt

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -447,16 +447,6 @@ export class OAuthPrompt extends Dialog {
                             'expected by the bots active OAuthPrompt. Ensure these names match when sending the InvokeActivityInvalid ConnectionName in the TokenExchangeInvokeRequest'
                     )
                 );
-            } else if (!('exchangeToken' in context.adapter)) {
-                // Token Exchange not supported in the adapter
-                await context.sendActivity(
-                    this.getTokenExchangeInvokeResponse(
-                        StatusCodes.BAD_GATEWAY,
-                        "The bot's BotAdapter does not support token exchange operations. Ensure the bot's Adapter supports the ExtendedUserTokenProvider interface."
-                    )
-                );
-
-                throw new Error('OAuthPrompt.recognizeToken(): not supported by the current adapter');
             } else {
                 let tokenExchangeResponse: TokenResponse;
                 try {


### PR DESCRIPTION
Fixes # XXX
#minor

## Description
This PR removes an outdated validation for token exchange that was causing the exchange between root and skill bots using CloudAdapter to fail.
This validation was already removed from .NET implementation in [this commit](https://github.com/microsoft/botbuilder-dotnet/commit/c000b4acfb4f236a33d0edb552a21770407c8c1e).

### Detailed Changes
- Updated oauthPrompt' recognizeToken method removing validation for 'exchangeToken'.

## Testing
Here we can see a root and a skill bot properly exchanging the token.
![image](https://user-images.githubusercontent.com/44245136/155727429-72bd0f8f-ba17-4463-bfec-c0eabf6a1321.png)
