### PR TITLE
port: [#XXX] TeamsInfo.sendMessageToTeamsChannel() doesn't return the correct ConversationReference

### DIFF
--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -175,7 +175,7 @@ export class TeamsInfo {
                 null,
                 convoParams,
                 async (turnContext) => {
-                    conversationReference = TurnContext.getConversationReference(context.activity);
+                    conversationReference = TurnContext.getConversationReference(turnContext.activity);
                     newActivityId = turnContext.activity.id;
                 }
             );


### PR DESCRIPTION
Fixes # XXX
#minor

## Description
This PR fixes an issue when calling the `TeamsInfo.sendMessageToTeamsChannel` method and reply to the new message thread, it replies to the first message sent to the bot instead of the new created one.
[DotNet's reference](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs#L309)

## Specific Changes
- Updated `TurnContext.getConversationReference` execution to get the `ConversationReference` from the `turnContext` instead of the original `context`.

## Testing
The following images show the bot working as expected after the applied fix.
![imagen](https://user-images.githubusercontent.com/62260472/156651547-4393c745-2427-4b42-8d5f-b17b5c07c48b.png)