### PR TITLE
port: [#3967] add control property (#5943)

### DIFF
--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -653,13 +653,15 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
             );
         }
 
-        if (name === Evaluator.fromFileFunctionName) {
-            return new ExpressionEvaluator(
-                Evaluator.fromFileFunctionName,
-                FunctionUtils.apply(this.fromFile()),
-                ReturnType.Object,
-                (expr): void => FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.String)
-            );
+        if (Templates.enableFromFile) {
+            if (name === Evaluator.fromFileFunctionName) {
+                return new ExpressionEvaluator(
+                    Evaluator.fromFileFunctionName,
+                    FunctionUtils.apply(this.fromFile()),
+                    ReturnType.Object,
+                    (expr): void => FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.String)
+                );
+            }
         }
 
         if (name === Evaluator.activityAttachmentFunctionName) {

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -613,13 +613,15 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
             );
         }
 
-        if (name === Evaluator.fromFileFunctionName) {
-            return new ExpressionEvaluator(
-                Evaluator.fromFileFunctionName,
-                FunctionUtils.apply(this.fromFile()),
-                ReturnType.Object,
-                (expr): void => FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.String)
-            );
+        if (Templates.enableFromFile) {
+            if (name === Evaluator.fromFileFunctionName) {
+                return new ExpressionEvaluator(
+                    Evaluator.fromFileFunctionName,
+                    FunctionUtils.apply(this.fromFile()),
+                    ReturnType.Object,
+                    (expr): void => FunctionUtils.validateOrder(expr, [ReturnType.String], ReturnType.String)
+                );
+            }
         }
 
         if (name === Evaluator.activityAttachmentFunctionName) {

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -42,6 +42,10 @@ export class Templates implements Iterable<Template> {
      * Temp Template ID for inline content.
      */
     public static readonly inlineTemplateIdPrefix: string = '__temp__';
+    /**
+     * Indicates whether fromFile is allowed in LG templates.
+     */
+    public static enableFromFile: boolean = false;
     private readonly newLineRegex = /(\r?\n)/g;
     private readonly newLine: string = '\r\n';
     private readonly namespaceKey = '@namespace';

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -1675,7 +1675,8 @@ describe('LG', function () {
     });
 
     it('TestFileOperation', function () {
-        const templates = preloaded.FileOperation;
+        Templates.enableFromFile = true;
+        const templates = Templates.parseFile(GetExampleFilePath('FileOperation.lg'));
         let evaled = templates.evaluate('FromFileWithoutEvaluation');
         assert.strictEqual(evaled, 'hi ${name}');
 
@@ -1687,6 +1688,12 @@ describe('LG', function () {
 
         evaled = templates.evaluate('FromFileBinary');
         assert.strictEqual(evaled, 'hi ${name}');
+    });
+
+    it('TestFileOperationDisabled', function () {
+        Templates.enableFromFile = false;
+        const templates = Templates.parseFile(GetExampleFilePath('FileOperation.lg'));
+        assert.throws(() => templates.evaluate('FromFileWithoutEvaluation'), { name: 'Error' });
     });
 
     it('TestImportAlias', function () {


### PR DESCRIPTION
Fixes # 3967

## Description
This PR ports the changes in [BotBuider-DotNet](https://github.com/microsoft/botbuilder-dotnet/pull/ 5943) to add the `enableFromFile` property in the _Templates_ class.

## Specific Changes
- Added `enableFromFile` property in the _Templates_ class.
- Added condition for from file in _customizedEvaluatorLookup_ method of _Evaluator_ and _Expander_ classes. 
- Added unit test for the FileOperationDisabled scenario.

## Testing
This image shows the new tests passing.
![image](https://user-images.githubusercontent.com/44245136/157064033-f9568fca-7352-49b3-ac10-958834f54825.png)

