### PR TITLE
port: [#3922] Corrected GetConversationMembers to use TeamsInfo helper class rather… (#5874)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -41,6 +41,7 @@
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "botbuilder-lg": "4.1.6",
+    "botframework-connector": "4.1.6",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7"
   },

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getActivityMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getActivityMembers.ts
@@ -117,22 +117,19 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
         }
 
         if (!context.activity.conversation) {
-            throw new Error('{nameof(GetActivityMembers)}.{nameof(GetActivityMembersAsync) : missing conversation');
+            throw new Error('[GetActivityMembers]: Missing conversation');
         }
-        var conversationId = context.activity.conversation.id;
+        const conversationId = context.activity.conversation.id;
 
-        if (typeof conversationId === 'undefined' || conversationId == null) {
-            throw new Error('{nameof(GetActivityMembers)}.{nameof(GetActivityMembersAsync) : missing conversation.id');
+        if (!conversationId || conversationId.trim() === '') {
+            throw new Error('[GetActivityMembers]: Missing conversation.id');
         }
 
         const connectorClient = this.getConnectorClient(context);
-        var accounts = await connectorClient.conversations.getActivityMembers(conversationId, activityId);
+        const accounts = await connectorClient.conversations.getActivityMembers(conversationId, activityId);
         return accounts;
     }
 
-    /**
-     * @private
-     */
     private getConnectorClient(context: TurnContext): ConnectorClient {
         const client =
             context.adapter && 'createConnectorClient' in context.adapter
@@ -144,6 +141,7 @@ export class GetActivityMembers<O extends object = {}> extends Dialog implements
 
         return client;
     }
+
     /**
      * @protected
      * Builds the compute Id for the [Dialog](xref:botbuilder-dialogs.Dialog).

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
@@ -88,26 +88,22 @@ export class GetConversationMembers<O extends object = {}>
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
-        const result = await this.GetMembers(dc.context);
+        const result = await this.getMembers(dc.context);
         dc.state.setValue(this.property.getValue(dc.state), result);
         return await dc.endDialog(result);
     }
 
-    private async GetMembers(context: TurnContext) {
-        var conversationId = context.activity?.conversation?.id;
-        if (conversationId == null) {
-            throw new Error('The GetMembersAsync operation needs a valid conversation Id.');
+    private async getMembers(context: TurnContext) {
+        const conversationId = context.activity?.conversation?.id;
+        if (!conversationId) {
+            throw new Error('[GetConversationMembers]: The getMembers operation needs a valid conversation id.');
         }
 
         const connectorClient = this.getConnectorClient(context);
-
-        var teamMembers = await connectorClient.conversations.getConversationMembers(conversationId);
+        const teamMembers = await connectorClient.conversations.getConversationMembers(conversationId);
         return teamMembers;
     }
 
-    /**
-     * @private
-     */
     private getConnectorClient(context: TurnContext): ConnectorClient {
         const client =
             context.adapter && 'createConnectorClient' in context.adapter

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import type { TurnContext } from 'botbuilder';
+import type { BotFrameworkAdapter, TurnContext } from 'botbuilder';
 import { BoolProperty, StringProperty } from '../properties';
 
 import {
@@ -23,14 +23,7 @@ import {
     DialogContext,
     DialogTurnResult,
 } from 'botbuilder-dialogs';
-
-interface CompatibleAdapter {
-    getConversationMembers(context: TurnContext): unknown;
-}
-
-function isCompatibleAdapter(adapter: unknown): adapter is CompatibleAdapter {
-    return adapter && typeof (adapter as CompatibleAdapter).getConversationMembers === 'function';
-}
+import { ConnectorClient } from 'botframework-connector';
 
 export interface GetConversationMembersConfiguration extends DialogConfiguration {
     property?: StringProperty;
@@ -95,15 +88,36 @@ export class GetConversationMembers<O extends object = {}>
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
+        const result = await this.GetMembers(dc.context);
+        dc.state.setValue(this.property.getValue(dc.state), result);
+        return await dc.endDialog(result);
+    }
 
-        const adapter = dc.context.adapter;
-        if (isCompatibleAdapter(adapter)) {
-            const result = await adapter.getConversationMembers(dc.context);
-            dc.state.setValue(this.property.getValue(dc.state), result);
-            return await dc.endDialog(result);
-        } else {
-            throw new Error('getConversationMembers() not supported by the current adapter.');
+    private async GetMembers(context: TurnContext) {
+        var conversationId = context.activity?.conversation?.id;
+        if (conversationId == null) {
+            throw new Error('The GetMembersAsync operation needs a valid conversation Id.');
         }
+
+        const connectorClient = this.getConnectorClient(context);
+
+        var teamMembers = await connectorClient.conversations.getConversationMembers(conversationId);
+        return teamMembers;
+    }
+
+    /**
+     * @private
+     */
+    private getConnectorClient(context: TurnContext): ConnectorClient {
+        const client =
+            context.adapter && 'createConnectorClient' in context.adapter
+                ? (context.adapter as BotFrameworkAdapter).createConnectorClient(context.activity.serviceUrl)
+                : context.turnState?.get<ConnectorClient>(context.adapter.ConnectorClientKey);
+        if (!client) {
+            throw new Error('This method requires a connector client.');
+        }
+
+        return client;
     }
 
     /**


### PR DESCRIPTION
Fixes # 3922
#minor
## Description
This PR ports the changes in [BotBuider-DotNet](https://github.com/microsoft/botbuilder-dotnet/pull/ 5874)  to Corrected GetConversationMembers in Adaptive.Runtime to use TeamsInfo helper class rather than rely on BotFrameworkAdapter functions that aren't available now that CoreBotAdapter derives from CloudAdapter and not BotFrameworkAdapter.

## Specific Changes
  - getActitivityMemebers.ts
    - Remove BotFrameworkAdapter
    - Create a private function, which gets the connector client and returns the accounts info
  - getConversationsMemebers.ts
    - Remove BotFrameworkAdapter
    - Create a private function, which gets the connector client and returns the conversation's members info


## Testing
These images show the unit tests passing after the changes.
![image](https://user-images.githubusercontent.com/97895605/157265194-21998912-9e30-459d-a786-629720829bff.png)
![image](https://user-images.githubusercontent.com/97895605/157265568-3b804650-fba7-4269-89d3-09626646cb6f.png)
