### PR TITLE
port: [#4064][#6019] Remove redundant project dependencies from AI Recognizers (#6067)

### DIFF
--- a/libraries/botbuilder-ai-orchestrator/package.json
+++ b/libraries/botbuilder-ai-orchestrator/package.json
@@ -29,14 +29,18 @@
     }
   },
   "dependencies": {
-    "adaptive-expressions": "4.1.6",
-    "botbuilder-core": "4.1.6",
-    "botbuilder-dialogs": "4.1.6",
     "botbuilder-dialogs-adaptive": "4.1.6",
-    "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
-    "botbuilder-dialogs-declarative": "4.1.6",
     "@microsoft/orchestrator-core": "~4.14.0",
     "uuid": "^8.3.2"
+  },
+  "peerDependencies": {
+    "botbuilder-dialogs-declarative": "4.1.6",
+    "botbuilder-dialogs-adaptive-runtime-core": "4.1.6"
+  },
+  "devDependencies": {
+    "adaptive-expressions": "4.1.6",
+    "botbuilder-core": "4.1.6",
+    "botbuilder-dialogs": "4.1.6"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -29,9 +29,6 @@
   "dependencies": {
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "@azure/ms-rest-js": "1.9.1",
-    "adaptive-expressions": "4.1.6",
-    "botbuilder-core": "4.1.6",
-    "botbuilder-dialogs": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "lodash": "^4.17.21",
@@ -44,6 +41,9 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
+    "adaptive-expressions": "4.1.6",
+    "botbuilder-core": "4.1.6",
+    "botbuilder-dialogs": "4.1.6",
     "fs-extra": "^7.0.1",
     "nock": "^11.9.1"
   },

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -35,9 +35,6 @@
     "@microsoft/recognizers-text-choice": "~1.1.4",
     "@microsoft/recognizers-text-date-time": "~1.1.4",
     "@microsoft/recognizers-text-suite": "1.1.4",
-    "adaptive-expressions": "4.1.6",
-    "botbuilder": "4.1.6",
-    "botbuilder-dialogs": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "botbuilder-lg": "4.1.6",
@@ -45,7 +42,10 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.3"
+    "@types/node-fetch": "^2.5.3",
+    "adaptive-expressions": "4.1.6",
+    "botbuilder": "4.1.6",
+    "botbuilder-dialogs": "4.1.6"
   },
   "scripts": {
     "build": "npm-run-all build:src build:tests",

--- a/libraries/botbuilder-dialogs-declarative/package.json
+++ b/libraries/botbuilder-dialogs-declarative/package.json
@@ -28,7 +28,6 @@
     }
   },
   "dependencies": {
-    "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "chokidar": "^3.4.0",
@@ -36,6 +35,7 @@
   },
   "devDependencies": {
     "adaptive-expressions": "4.1.6",
+    "botbuilder-core": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "jsonschema": "^1.4.0"
   },


### PR DESCRIPTION
Fixes # 4064
#minor

## Description
This PR moves redundant dependencies out of the `dependencies` section and moved them under `peerDependencies` or `devDependencies` depending on the case.

> _**Note: If we remove the dependencies, although the build and the tests work, the `depcheck` command fails with the 'missing dependency' error.**_

## Specific Changes
- **botbuilder-ai-orchestrator**
   - Moved _botbuilder-dialogs-declarative_ and _botbuilder-dialogs-adaptive-runtime-core_ under `peerDependencies` as they are included in _botbuilder-dialogs-adaptive_.
   - Moved _adaptive-expressions_, _botbuilder-core_, and _botbuilder-dialogs_ under `devDependencies` as they are required by the tests.
- **botbuilder-ai**
   - Moved _adaptive-expressions_, _botbuilder-core_, and _botbuilder-dialogs_ under `devDependencies` as they are required by the tests.
- **botbuilder-dialogs-adaptive**
   - Moved _adaptive-expressions_, _botbuilder_, and _botbuilder-dialogs_ under `devDependencies` as they are required by the tests.
- **botbuilder-dialogs-declarative**
   - Moved _botbuilder-core_ under `devDependencies` as they are required by the tests.

## Testing
This image shows an extract of the console running the `depcheck` command with no issues.
![image](https://user-images.githubusercontent.com/44245136/157302848-46b38ca3-145a-43a3-a247-4c3d152dc877.png)
