### PR TITLE
port: [#3931] Add "omnichannel" to Channels (#5891)

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -444,6 +444,8 @@ export enum Channels {
     // (undocumented)
     Msteams = "msteams",
     // (undocumented)
+    Omni = "omnichannel",
+    // (undocumented)
     Skype = "skype",
     // (undocumented)
     Skypeforbusiness = "skypeforbusiness",

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2256,6 +2256,7 @@ export enum Channels {
     Kik = 'kik',
     Line = 'line',
     Msteams = 'msteams',
+    Omni = 'omnichannel',
     Skype = 'skype',
     Skypeforbusiness = 'skypeforbusiness',
     Slack = 'slack',

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2238,7 +2238,7 @@ export enum SemanticActionStateTypes {
 /**
  * Defines values for ChannelIds for Channels.
  * Possible values include: 'alexa', 'console', 'cortana', 'directline', 'directlinespeech', 'email',
- * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'skype', 'skypeforbusiness',
+ * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'skype', 'skypeforbusiness',
  * 'slack', 'sms', 'telegram', 'test', 'twilio-sms', 'webchat'
  *
  * @readonly


### PR DESCRIPTION
Fixes # 3931
#minor

## Description
This PR adds `omnichannel` to the Channels enum in _botframework-schema_.

## Specific Changes
- Added `Omni` value to the Channels enum in _botframework-schema_.
- Updated `botframework-schema.api.md` to include the new channel value.

## Testing
This image shows the schema tests passing after including the new channel.
![image](https://user-images.githubusercontent.com/44245136/157499214-5dc91d4e-eb60-4755-80c0-67cfdfecd532.png)