### PR TITLE
port: [#3917] Add ThrowOnRecursive to LG AnalyzerOptions (#5872)

### DIFF
--- a/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
+++ b/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
@@ -26,7 +26,7 @@ import { Vocabulary } from 'antlr4ts/Vocabulary';
 
 // @public
 export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implements LGTemplateParserVisitor<AnalyzerResult> {
-    constructor(templates: Templates, opt?: EvaluationOptions);
+    constructor(templates: Templates, opt?: EvaluationOptions, analyzerOptions?: AnalyzerOptions);
     analyzeTemplate(templateName: string): AnalyzerResult;
     protected defaultResult(): AnalyzerResult;
     readonly templates: Templates;
@@ -38,6 +38,13 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
     visitStructureValue(ctx: KeyValueStructureLineContext): AnalyzerResult;
     visitSwitchCaseBody(ctx: SwitchCaseBodyContext): AnalyzerResult;
 }
+
+// @public
+export class AnalyzerOptions {
+    constructor(options?: AnalyzerOptions | string[]);
+    Merge(opt: AnalyzerOptions): AnalyzerOptions;
+    ThrowOnRecursive?: boolean;
+    }
 
 // @public
 export class AnalyzerResult {
@@ -1665,7 +1672,7 @@ export class Templates implements Iterable<Template> {
     addTemplate(templateName: string, parameters: string[], templateBody: string): Templates;
     readonly allDiagnostics: Diagnostic[];
     readonly allTemplates: Template[];
-    analyzeTemplate(templateName: string): AnalyzerResult;
+    analyzeTemplate(templateName: string, analyzerOptions?: AnalyzerOptions): AnalyzerResult;
     content: string;
     deleteTemplate(templateName: string): Templates;
     diagnostics: Diagnostic[];

--- a/libraries/botbuilder-lg/src/analyzerOptions.ts
+++ b/libraries/botbuilder-lg/src/analyzerOptions.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Options for analyzing LG templates.
+ */
+export class AnalyzerOptions {
+    /**
+     * Gets or sets a value determining if recursive calls throw an exception.
+     *
+     * @returns When true, throw an exception if a recursive call is detected.
+     */
+    public ThrowOnRecursive?: boolean = null;
+
+    private readonly _throwOnRecursive: string = '@throwOnRecursive';
+
+    /**
+     * Initializes a new instance of the [AnalyzerOptions](xref:botbuilder-lg.AnalyzerOptions) class.
+     *
+     * @param options Optional. Instance to copy analyzer settings from or list of strings containing the options from an LG file.
+     */
+    public constructor(options?: AnalyzerOptions | string[]) {
+        if (!options) {
+            this.ThrowOnRecursive = null;
+        } else if (options instanceof AnalyzerOptions) {
+            this.ThrowOnRecursive = options.ThrowOnRecursive;
+        } else {
+            for (const option in options) {
+                if (option && option.includes('=')) {
+                    const index = option.indexOf('=');
+                    const key = option.substring(0, index).trim();
+                    const value = option.substring(index + 1).trim();
+                    if (key === this._throwOnRecursive) {
+                        if (value.toLowerCase() === 'true') {
+                            this.ThrowOnRecursive = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Merge an incoming option to current option. If a property in incoming option is not null while it is null in current
+     * option, then the value of this property will be overwritten.
+     *
+     * @param opt Incoming option for merging.
+     * @returns Result after merging.
+     */
+    public Merge(opt: AnalyzerOptions): AnalyzerOptions {
+        const properties = Object.getOwnPropertyNames(opt);
+        for (const property in properties) {
+            if (this[property] && opt[property]) {
+                this[property] = opt[property];
+            }
+        }
+
+        return this;
+    }
+}

--- a/libraries/botbuilder-lg/src/index.ts
+++ b/libraries/botbuilder-lg/src/index.ts
@@ -29,3 +29,4 @@ export * from './expander';
 export * from './multiLanguageLG';
 export * from './evaluationOptions';
 export * from './lgResource';
+export * from './analyzerOptions';

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -33,6 +33,7 @@ import { basename } from 'path';
 import { StaticChecker } from './staticChecker';
 import { LGResource } from './lgResource';
 import { CustomizedMemory } from './customizedMemory';
+import { AnalyzerOptions } from './analyzerOptions';
 
 /**
  * LG entrance, including properties that LG file has, and evaluate functions.
@@ -292,10 +293,10 @@ export class Templates implements Iterable<Template> {
      * @param templateName Template name to be evaluated.
      * @returns Analyzer result.
      */
-    public analyzeTemplate(templateName: string): AnalyzerResult {
+    public analyzeTemplate(templateName: string, analyzerOptions?: AnalyzerOptions): AnalyzerResult {
         this.checkErrors();
 
-        const analyzer = new Analyzer(this);
+        const analyzer = new Analyzer(this, this.lgOptions, analyzerOptions);
         return analyzer.analyzeTemplate(templateName);
     }
 

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -300,6 +300,26 @@ describe(`LGExceptionTest`, function () {
                 `Loop detected: welcome_user => wPhrase [wPhrase]  Error occurred when evaluating '-\${wPhrase()}'. [welcome_user]  Error occurred when evaluating '-\${welcome_user()}'.`
             )
         );
+
+        // Without ThrowOnRecursive does not throw exception when loop is detected
+        const wPhraseResult = templates.analyzeTemplate('wPhrase');
+        assert.strictEqual('welcome_user', wPhraseResult.TemplateReferences[0]);
+        assert.strictEqual('wPhrase', wPhraseResult.TemplateReferences[1]);
+
+        const selfLoopResult = templates.analyzeTemplate('selfLoop');
+        assert.strictEqual('selfLoop', selfLoopResult.TemplateReferences[0]);
+        assert.strictEqual('x', selfLoopResult.Variables[0]);
+
+        // ThrowOnRecursive throws InvalidOperationException
+        assert.throws(
+            () => templates.analyzeTemplate('wPhrase', { ThrowOnRecursive: true }),
+            new Error('Loop detected: welcome_user,wPhrase => wPhrase')
+        );
+
+        assert.throws(
+            () => templates.analyzeTemplate('selfLoop', { ThrowOnRecursive: true }),
+            new Error('Loop detected: selfLoop => selfLoop')
+        );
     });
 
     it(`AddTextWithWrongId`, function () {

--- a/libraries/botbuilder-lg/tests/testData/exceptionExamples/LoopDetected.lg
+++ b/libraries/botbuilder-lg/tests/testData/exceptionExamples/LoopDetected.lg
@@ -9,5 +9,5 @@
 - ${wPhrase()}
 
 > self loop
-# shouldFail(x)
-- ${shouldFail(x)} 
+# selfLoop(x)
+- ${selfLoop(x)} 


### PR DESCRIPTION
Fixes # 3917
#minor

## Description
This PR ports the changes in [BotBuilder-DotNet's PR#5872](https://github.com/microsoft/botbuilder-dotnet/pull/ 5872) so the analyzeTemplate method throws an error with loop detected message.

## Specific Changes
- Updated `analyzer` class to include the _analyzerOptions_ in its constructor and in the _analyzeTemplate_ method.
- Added new `analyzerOptions`class.
- Included the new class in the `index` export list.
- Updated `templates` class to include the _analyzerOptions_ in the _analyzeTemplate_ method.
- Added new asserts in the `TestLoopDetected` test.
- Updated `botbuilder-lg.api.md` documentation with the changes in the API.

## Testing
This image shows the TestLoopDetected passing with the new asserts.
![image](https://user-images.githubusercontent.com/44245136/157734117-73bada86-3007-4620-89ba-f277c34f1884.png)
