### PR TITLE
port: [#3943] Add ShowSignInLink to OAuthPromptSettings (#5906)

### DIFF
--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -590,6 +590,7 @@ export interface OAuthPromptSettings {
     connectionName: string;
     endOnInvalidMessage?: boolean;
     oAuthAppCredentials?: CoreAppCredentials;
+    showSignInLink?: boolean;
     text?: string;
     timeout?: number;
     title: string;

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -87,8 +87,8 @@ export interface OAuthPromptSettings {
     endOnInvalidMessage?: boolean;
 
     /**
-     * (Optional)Gets or sets an optional boolean value to force
-     * the display of a Sign In link overriding the default behavior.
+     * (Optional) value to force the display of a Sign In link overriding the default behavior.
+     * True to display the SignInLink.
      */
     showSignInLink?: boolean;
 }
@@ -359,8 +359,8 @@ export class OAuthPrompt extends Dialog {
                     cardActionType = ActionTypes.OpenUrl;
                 }
             } else if (
-                (settings.showSignInLink != null && settings.showSignInLink == false) ||
-                (settings.showSignInLink == null && !this.channelRequiresSignInLink(turnContext.activity.channelId))
+                settings.showSignInLink === false ||
+                (!settings.showSignInLink && !this.channelRequiresSignInLink(turnContext.activity.channelId))
             ) {
                 link = undefined;
             }

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -85,6 +85,12 @@ export interface OAuthPromptSettings {
      * by default for backwards compatibility.
      */
     endOnInvalidMessage?: boolean;
+
+    /**
+     * (Optional)Gets or sets an optional boolean value to force
+     * the display of a Sign In link overriding the default behavior.
+     */
+    showSignInLink?: boolean;
 }
 
 /**
@@ -352,7 +358,10 @@ export class OAuthPrompt extends Dialog {
                 if (turnContext.activity.channelId === Channels.Emulator) {
                     cardActionType = ActionTypes.OpenUrl;
                 }
-            } else if (!this.channelRequiresSignInLink(turnContext.activity.channelId)) {
+            } else if (
+                (settings.showSignInLink != null && settings.showSignInLink == false) ||
+                (settings.showSignInLink == null && !this.channelRequiresSignInLink(turnContext.activity.channelId))
+            ) {
                 link = undefined;
             }
 


### PR DESCRIPTION
Fixes # 3943
#minor

## Description
This PR ports the changes in [BotBuilder-DotNet's PR#5906](https://github.com/microsoft/botbuilder-dotnet/pull/ 5906) to add the showSignInLink property in OAuthPromp allowing the user to decide if a sign-in link should be shown or not.

## Specific Changes
- Updated `oauthPrompt.ts` to include the _showSignInLink_ property and the validation to set the sign-in link.
- Added unit tests in `oauthPrompt.test.js` to cover the different test cases.
- Updated `botbuilder-dialogs.api.md` to include the new property.

## Testing
This image shows the new unit tests passing.
![image](https://user-images.githubusercontent.com/44245136/157894343-01e631c9-8396-46dd-b88e-842fd5f36e59.png)
