### PR TITLE
port: [#4092] Add ActivityTypeProperty to TelemetryLoggerMiddleware

### DIFF
--- a/libraries/botbuilder-core/src/telemetryConstants.ts
+++ b/libraries/botbuilder-core/src/telemetryConstants.ts
@@ -5,18 +5,78 @@
  * Defines names of common properties for use with a [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient) object.
  */
 export class TelemetryConstants {
+    /**
+     * The telemetry property value for channel id.
+     */
     public static readonly channelIdProperty: string = 'channelId';
+
+    /**
+     * The telemetry property value for conversation id.
+     */
     public static readonly conversationIdProperty: string = 'conversationId';
+
+    /**
+     * The telemetry property value for conversation name.
+     */
     public static readonly conversationNameProperty: string = 'conversationName';
+
+    /**
+     * The telemetry property value for dialog id.
+     */
     public static readonly dialogIdProperty: string = 'dialogId';
+
+    /**
+     * The telemetry property value for from id.
+     */
     public static readonly fromIdProperty: string = 'fromId';
+
+    /**
+     * The telemetry property value for from name.
+     */
     public static readonly fromNameProperty: string = 'fromName';
+
+    /**
+     * The telemetry property value for locale.
+     */
     public static readonly localeProperty: string = 'locale';
+
+    /**
+     * The telemetry property value for recipient id.
+     */
     public static readonly recipientIdProperty: string = 'recipientId';
+
+    /**
+     * The telemetry property value for recipient name.
+     */
     public static readonly recipientNameProperty: string = 'recipientName';
+
+    /**
+     * The telemetry property value for reply activity id.
+     */
     public static readonly replyActivityIdProperty: string = 'replyActivityId';
+
+    /**
+     * The telemetry property value for text.
+     */
     public static readonly textProperty: string = 'text';
+
+    /**
+     * The telemetry property value for speak.
+     */
     public static readonly speakProperty: string = 'speak';
+
+    /**
+     * The telemetry property value for user id.
+     */
     public static readonly userIdProperty: string = 'userId';
+
+    /**
+     * The telemetry property value for attachments.
+     */
     public static readonly attachmentsProperty: string = 'attachments';
+
+    /**
+     * The telemetry property value for activity type.
+     */
+    public static readonly activityTypeProperty: string = 'type';
 }

--- a/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
+++ b/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
@@ -215,6 +215,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.localeProperty] = activity.locale ?? '';
             properties[TelemetryConstants.recipientIdProperty] = activity.recipient?.id ?? '';
             properties[TelemetryConstants.recipientNameProperty] = activity.recipient?.name ?? '';
+            properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (this.logPersonalInformation) {
@@ -269,6 +270,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.conversationIdProperty] = activity.conversation?.id ?? '';
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
             properties[TelemetryConstants.localeProperty] = activity.locale ?? '';
+            properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (this.logPersonalInformation) {
@@ -321,6 +323,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.conversationIdProperty] = activity.conversation?.id ?? '';
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
             properties[TelemetryConstants.localeProperty] = activity.locale ?? '';
+            properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
             if (this.logPersonalInformation) {
@@ -357,6 +360,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.recipientIdProperty] = activity.recipient?.id ?? '';
             properties[TelemetryConstants.conversationIdProperty] = activity.conversation?.id ?? '';
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
+            properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
 
             // Additional Properties can override "stock" properties.
             if (telemetryProperties) {

--- a/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
@@ -45,6 +45,7 @@ describe(`TelemetryMiddleware`, () => {
             expectExactEvent(name, {
                 conversationName: sinon.match.string,
                 recipientId: sinon.match.string,
+                type: sinon.match.string,
                 ...properties,
             });
         };
@@ -96,9 +97,10 @@ describe(`TelemetryMiddleware`, () => {
             fromName: sinon.match.string,
             recipientName: sinon.match.string,
             text: 'foo',
+            type: ActivityTypes.Message
         });
 
-        expectSendEvent({ conversationId: sinon.match.string });
+        expectSendEvent({ conversationId: sinon.match.string, type: ActivityTypes.Typing });
         expectSendEvent({ conversationId: sinon.match.string, text: 'echo:foo' });
 
         expectReceiveEvent({
@@ -106,9 +108,10 @@ describe(`TelemetryMiddleware`, () => {
             fromName: sinon.match.string,
             recipientName: sinon.match.string,
             text: 'bar',
+            type: ActivityTypes.Message
         });
 
-        expectSendEvent({ conversationId: sinon.match.string });
+        expectSendEvent({ conversationId: sinon.match.string, type: ActivityTypes.Typing });
         expectSendEvent({ conversationId: sinon.match.string, text: 'echo:bar' });
 
         const adapter = makeAdapter({
@@ -167,13 +170,14 @@ describe(`TelemetryMiddleware`, () => {
     it(`telemetry should log update activities`, async () => {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
-        expectReceiveEvent({ text: 'foo' });
+        expectReceiveEvent({ text: 'foo', type: ActivityTypes.Message });
         expectSendEvent();
 
         expectReceiveEvent({ text: 'update' });
         expectTrackEvent(TelemetryLoggerMiddleware.botMsgUpdateEvent, {
             conversationId: sinon.match.string,
             text: 'new response',
+            type: ActivityTypes.Message
         });
 
         const adapter = makeAdapter({
@@ -196,11 +200,11 @@ describe(`TelemetryMiddleware`, () => {
     it(`telemetry should log delete activities`, async () => {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
-        expectReceiveEvent({ text: 'foo' });
+        expectReceiveEvent({ text: 'foo', type: ActivityTypes.Message });
         expectSendEvent({ text: 'response' });
 
         expectReceiveEvent({ text: 'delete' });
-        expectTrackEvent(TelemetryLoggerMiddleware.botMsgDeleteEvent);
+        expectTrackEvent(TelemetryLoggerMiddleware.botMsgDeleteEvent, { type: ActivityTypes.MessageDelete });
 
         let response;
         const adapter = makeAdapter({


### PR DESCRIPTION
Fixes # 4092
#minor

## Description
This PR adds the `activityTypeProperty` into the `TelemetryConstants` class, also adds the missing documentation for the rest of the properties. Additionally, it adds the type property to the `TelemetryLoggerMiddleware` receive, update and delete events, and updates the unit tests.

## Specific Changes
- Adds the `activityTypeProperty` into the `TelemetryConstants` class.
- Adds the missing property comments in the `TelemetryConstants` class.
- Adds the property to the `TelemetryLoggerMiddleware` receive, update and delete events.
- Updates the unit tests to support the new property.

## Testing
The following image shows the tests passing successfully.
![image](https://user-images.githubusercontent.com/62260472/158258850-baa2a610-95f4-4d5b-a4e1-27bb8ab9d613.png)