### PR TITLE
port: [#4044] Add obsolete attribute to BotFrameworkHttpAdapter and related classes. (#6096)

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -86,7 +86,7 @@ import { WebResource } from '@azure/ms-rest-js';
 
 // Warning: (ae-forgotten-export) The symbol "ConnectorClientBuilder" needs to be exported by the entry point index.d.ts
 //
-// @public
+// @public @deprecated (undocumented)
 export class BotFrameworkAdapter extends BotAdapter implements BotFrameworkHttpAdapter, ConnectorClientBuilder, ExtendedUserTokenProvider, RequestHandler {
     constructor(settings?: Partial<BotFrameworkAdapterSettings>);
     protected authenticateRequest(request: Partial<Activity>, authHeader: string): Promise<void>;
@@ -150,7 +150,7 @@ export class BotFrameworkAdapter extends BotAdapter implements BotFrameworkHttpA
     useWebSocket(req: WebRequest, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<any>): Promise<void>;
     }
 
-// @public
+// @public @deprecated (undocumented)
 export interface BotFrameworkAdapterSettings {
     appId: string;
     appPassword: string;
@@ -165,13 +165,13 @@ export interface BotFrameworkAdapterSettings {
     webSocketFactory?: NodeWebSocketFactoryBase;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export interface BotFrameworkHttpAdapter {
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class BotFrameworkHttpClient implements BotFrameworkClient {
     constructor(credentialProvider: ICredentialProvider, channelService?: string);
     protected buildCredentials(appId: string, oAuthScope?: string): Promise<AppCredentials>;
@@ -180,7 +180,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     postActivity<T = any>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class ChannelServiceHandler extends ChannelServiceHandlerBase {
     constructor(credentialProvider: ICredentialProvider, authConfig: AuthenticationConfiguration, channelService?: string);
     // (undocumented)
@@ -321,7 +321,7 @@ export class SetSpeakMiddleware implements Middleware {
     onTurn(turnContext: TurnContext, next: () => Promise<void>): Promise<void>;
     }
 
-// @public
+// @public @deprecated (undocumented)
 export class SkillHandler extends ChannelServiceHandler {
     constructor(adapter: BotAdapter, bot: ActivityHandlerBase, conversationIdFactory: SkillConversationIdFactoryBase, credentialProvider: ICredentialProvider, authConfig: AuthenticationConfiguration, channelService?: string);
     protected onDeleteActivity(claimsIdentity: ClaimsIdentity, conversationId: string, activityId: string): Promise<void>;

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -89,6 +89,7 @@ import {
 } from './streaming';
 
 /**
+ * @deprecated Use `CloudAdapter` with `ConfigurationBotFrameworkAuthentication` instead to configure bot runtime.
  * Contains settings used to configure a [BotFrameworkAdapter](xref:botbuilder.BotFrameworkAdapter) instance.
  */
 export interface BotFrameworkAdapterSettings {
@@ -193,6 +194,10 @@ const US_GOV_OAUTH_ENDPOINT = 'https://api.botframework.azure.us';
  *     // Catch-all logic for errors.
  * };
  * ```
+ */
+
+/**
+ * @deprecated Use `CloudAdapter` instead.
  */
 export class BotFrameworkAdapter
     extends BotAdapter

--- a/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
@@ -6,6 +6,7 @@ import type { Request, Response } from './interfaces';
 import type { TurnContext } from 'botbuilder-core';
 
 /**
+ * @deprecated Use `CloudAdapter` instead.
  * BotFrameworkHttpAdapter is the interface that describes a Bot Framework
  * adapter that operates on HTTP requests.
  */

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -22,6 +22,7 @@ import {
 import { USER_AGENT } from './botFrameworkAdapter';
 
 /**
+ * @deprecated Use `BotFrameworkAuthentication.createBotFrameworkClient()` to obtain a client and perform the operations that were accomplished through `BotFrameworkHttpClient`.
  * HttpClient for calling skills from a Node.js BotBuilder V4 SDK bot.
  */
 export class BotFrameworkHttpClient implements BotFrameworkClient {

--- a/libraries/botbuilder/src/channelServiceHandler.ts
+++ b/libraries/botbuilder/src/channelServiceHandler.ts
@@ -15,6 +15,7 @@ import {
 } from 'botframework-connector';
 
 /**
+ * @deprecated Use `CloudChannelServiceHandler` instead.
  * The ChannelServiceHandler implements API to forward activity to a skill and
  * implements routing ChannelAPI calls from the Skill up through the bot/adapter.
  */

--- a/libraries/botbuilder/src/skills/skillHandler.ts
+++ b/libraries/botbuilder/src/skills/skillHandler.ts
@@ -23,6 +23,7 @@ import {
 } from 'botbuilder-core';
 
 /**
+ * @deprecated Use `CloudSkillHandler` instead.
  * A Bot Framework Handler for skills.
  */
 export class SkillHandler extends ChannelServiceHandler {

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -15,10 +15,10 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 /**
  * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform channel validation.
  */
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ChannelValidation {
     export let OpenIdMetadataEndpoint: string;
 

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -16,6 +16,9 @@ import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
+/**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform channel validation.
+ */
 export namespace ChannelValidation {
     export let OpenIdMetadataEndpoint: string;
 

--- a/libraries/botframework-connector/src/auth/credentialProvider.ts
+++ b/libraries/botframework-connector/src/auth/credentialProvider.ts
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.
  * CredentialProvider interface. This interface allows Bots to provide their own
  * implementation of what is, and what is not, a valid appId and password. This is
  * useful in the case of multi-tenant bots, where the bot may need to call
@@ -52,6 +53,7 @@ export interface ICredentialProvider {
 }
 
 /**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.
  * A simple implementation of the [ICredentialProvider](xref:botframework-connector.ICredentialProvider) interface.
  */
 export class SimpleCredentialProvider implements ICredentialProvider {

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -21,6 +21,7 @@ import { StatusCodes } from 'botframework-schema';
 import { ToBotFromBotOrEmulatorTokenValidationParameters } from './tokenValidationParameters';
 
 /**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform emulator validation.
  * Validates and Examines JWT tokens from the Bot Framework Emulator
  */
 export namespace EmulatorValidation {

--- a/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
@@ -17,6 +17,9 @@ import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
+/**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform enterprise channel validation.
+ */
 export namespace EnterpriseChannelValidation {
     /**
      * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot

--- a/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
@@ -16,10 +16,10 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 /**
  * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform enterprise channel validation.
  */
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace EnterpriseChannelValidation {
     /**
      * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot

--- a/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
@@ -18,6 +18,9 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
+/**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform government channel validation.
+ */
 export namespace GovernmentChannelValidation {
     export let OpenIdMetadataEndpoint: string;
 

--- a/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
@@ -20,10 +20,10 @@ import { GovernmentChannelValidation } from './governmentChannelValidation';
 import { GovernmentConstants } from './governmentConstants';
 import { SkillValidation } from './skillValidation';
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 /**
  * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform JWT token validation.
  */
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JwtTokenValidation {
     /**
      * Authenticates the request and sets the service url in the set of trusted urls.

--- a/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
@@ -21,6 +21,9 @@ import { GovernmentConstants } from './governmentConstants';
 import { SkillValidation } from './skillValidation';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
+/**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform JWT token validation.
+ */
 export namespace JwtTokenValidation {
     /**
      * Authenticates the request and sets the service url in the set of trusted urls.

--- a/libraries/botframework-connector/src/auth/skillValidation.ts
+++ b/libraries/botframework-connector/src/auth/skillValidation.ts
@@ -21,6 +21,7 @@ import { ToBotFromBotOrEmulatorTokenValidationParameters } from './tokenValidati
 import { decode, VerifyOptions } from 'jsonwebtoken';
 
 /**
+ * @deprecated Use `ConfigurationBotFrameworkAuthentication` instead to perform skill validation.
  * Validates JWT tokens sent to and from a Skill.
  */
 export namespace SkillValidation {


### PR DESCRIPTION
Fixes # 4044
#minor

## Description
This PR adds the `@deprecated` attribute to BotFrameworkHttpAdapter and related classes, in order to migrate to CloudAdapter.
[BotBuilder-DotNet's PR#6096](https://github.com/microsoft/botbuilder-dotnet/pull/ 6096) was taken as a base.

## Specific Changes
  - Added the `@deprecated` attribute to the following classes:
     - botFrameworkAdapter
     - botFrameworkAdapterSettings
     - botFrameworkHttpAdapter
     - botFrameworkHttpClient
     - channelServiceHandler
     - skillHandler
     - channelValidation
     - SimplecredentialProvider
     - ICredentialProvider
     - emulatorValidation
     - enterpriseChannelValidation
     - governmentChannelValidation
     - jwtTokenValidation
     - skillValidation
  - Updated botbuilder.api.md documentation

## Testing
This image shows the build passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/158629784-eb1c0b30-aed7-4478-9395-7859038fb99c.png)
