### PR TITLE
chore: [#3518] Remove public access modifier from botframework-config and connector

### DIFF
--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -31,7 +31,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * Returns a new BotConfiguration instance given a JSON based configuration.
      * @param source JSON based configuration.
      */
-    public static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfiguration {
+    static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfiguration {
         // tslint:disable-next-line:prefer-const
         const services: IConnectedService[] = source.services
             ? source.services.slice().map(BotConfigurationBase.serviceFromJSON)
@@ -56,7 +56,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param folder (Optional) folder to look for bot files. If not specified the current working directory is used.
      * @param secret (Optional) secret used to decrypt the bot file.
      */
-    public static async loadBotFromFolder(folder?: string, secret?: string): Promise<BotConfiguration> {
+    static async loadBotFromFolder(folder?: string, secret?: string): Promise<BotConfiguration> {
         folder = folder || process.cwd();
         let files: string[] = await fsx.readdir(folder);
         files = files.sort();
@@ -76,7 +76,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param folder (Optional) folder to look for bot files. If not specified the current working directory is used.
      * @param secret (Optional) secret used to decrypt the bot file.
      */
-    public static loadBotFromFolderSync(folder?: string, secret?: string): BotConfiguration {
+    static loadBotFromFolderSync(folder?: string, secret?: string): BotConfiguration {
         folder = folder || process.cwd();
         let files: string[] = fsx.readdirSync(folder);
         files = files.sort();
@@ -95,7 +95,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to decrypt the bot file.
      */
-    public static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
+    static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
         const json: string = await txtfile.read(botpath);
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
@@ -108,7 +108,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to decrypt the bot file.
      */
-    public static loadSync(botpath: string, secret?: string): BotConfiguration {
+    static loadSync(botpath: string, secret?: string): BotConfiguration {
         const json: string = txtfile.readSync(botpath);
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
@@ -119,7 +119,7 @@ export class BotConfiguration extends BotConfigurationBase {
     /**
      * Generate a new key suitable for encrypting.
      */
-    public static generateKey(): string {
+    static generateKey(): string {
         return encrypt.generateKey();
     }
 
@@ -142,7 +142,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to encrypt the bot file.
      */
-    public async saveAs(botpath: string, secret?: string): Promise<void> {
+    async saveAs(botpath: string, secret?: string): Promise<void> {
         if (!botpath) {
             throw new Error(`missing path`);
         }
@@ -168,7 +168,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to encrypt the bot file.
      */
-    public saveAsSync(botpath: string, secret?: string): void {
+    saveAsSync(botpath: string, secret?: string): void {
         if (!botpath) {
             throw new Error(`missing path`);
         }
@@ -193,7 +193,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * Save the file with secret.
      * @param secret (Optional) secret used to encrypt the bot file.
      */
-    public async save(secret?: string): Promise<void> {
+    async save(secret?: string): Promise<void> {
         return this.saveAs(this.internal.location, secret);
     }
 
@@ -201,14 +201,14 @@ export class BotConfiguration extends BotConfigurationBase {
      * Save the file with secret. (blocking)
      * @param secret (Optional) secret used to encrypt the bot file.
      */
-    public saveSync(secret?: string): void {
+    saveSync(secret?: string): void {
         return this.saveAsSync(this.internal.location, secret);
     }
 
     /**
      * Clear secret.
      */
-    public clearSecret(): void {
+    clearSecret(): void {
         this.padlock = '';
     }
 
@@ -216,7 +216,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * Encrypt all values in the in memory config.
      * @param secret Secret to encrypt.
      */
-    public encrypt(secret: string): void {
+    encrypt(secret: string): void {
         this.validateSecret(secret);
 
         for (const service of this.services) {
@@ -228,7 +228,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * Decrypt all values in the in memory config.
      * @param secret Secret to decrypt.
      */
-    public decrypt(secret?: string): void {
+    decrypt(secret?: string): void {
         try {
             this.validateSecret(secret);
 
@@ -289,7 +289,7 @@ export class BotConfiguration extends BotConfigurationBase {
     /**
      * Return the path that this config was loaded from.  .save() will save to this path.
      */
-    public getPath(): string {
+    getPath(): string {
         return this.internal.location;
     }
 
@@ -297,7 +297,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * Make sure secret is correct by decrypting the secretKey with it.
      * @param secret Secret to use.
      */
-    public validateSecret(secret: string): void {
+    validateSecret(secret: string): void {
         if (!secret) {
             throw new Error(
                 'You are attempting to perform an operation which needs access to the secret and --secret is missing'

--- a/libraries/botframework-config/src/botConfigurationBase.ts
+++ b/libraries/botframework-config/src/botConfigurationBase.ts
@@ -37,11 +37,11 @@ import {
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class BotConfigurationBase implements Partial<IBotConfiguration> {
-    public name = '';
-    public description = '';
-    public services: IConnectedService[] = [];
-    public padlock = '';
-    public version = '2.0';
+    name = '';
+    description = '';
+    services: IConnectedService[] = [];
+    padlock = '';
+    version = '2.0';
 
     /**
      * Creates a new BotConfigurationBase instance.
@@ -54,7 +54,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Returns a ConnectedService instance given a JSON based service configuration.
      * @param service JSON based service configuration.
      */
-    public static serviceFromJSON(service: IConnectedService): ConnectedService {
+    static serviceFromJSON(service: IConnectedService): ConnectedService {
         switch (service.type) {
             case ServiceTypes.File:
                 return new FileService(<IFileService>service);
@@ -95,7 +95,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Returns a new BotConfigurationBase instance given a JSON based configuration.
      * @param source JSON based configuration.
      */
-    public static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfigurationBase {
+    static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfigurationBase {
         // tslint:disable-next-line:prefer-const
         const services: IConnectedService[] = source.services
             ? source.services.slice().map(BotConfigurationBase.serviceFromJSON)
@@ -111,7 +111,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
     /**
      * Returns a JSON based version of the current bot.
      */
-    public toJSON(): IBotConfiguration {
+    toJSON(): IBotConfiguration {
         const newConfig: IBotConfiguration = <IBotConfiguration>{};
         Object.assign(newConfig, this);
         delete (<any>newConfig).internal;
@@ -127,7 +127,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * @param newService Service to add.
      * @returns Assigned ID for the service.
      */
-    public connectService(newService: IConnectedService): string {
+    connectService(newService: IConnectedService): string {
         const service: ConnectedService = BotConfigurationBase.serviceFromJSON(newService);
 
         if (!service.id) {
@@ -152,7 +152,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Find service by id.
      * @param id ID of the service to find.
      */
-    public findService(id: string): IConnectedService {
+    findService(id: string): IConnectedService {
         for (const service of this.services) {
             if (service.id === id) {
                 return service;
@@ -166,7 +166,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Find service by name or id.
      * @param nameOrId Name or ID of the service to find.
      */
-    public findServiceByNameOrId(nameOrId: string): IConnectedService {
+    findServiceByNameOrId(nameOrId: string): IConnectedService {
         for (const service of this.services) {
             if (service.id === nameOrId) {
                 return service;
@@ -186,7 +186,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Remove service by name or id.
      * @param nameOrId Name or ID of the service to remove.
      */
-    public disconnectServiceByNameOrId(nameOrId: string): IConnectedService {
+    disconnectServiceByNameOrId(nameOrId: string): IConnectedService {
         const { services = [] } = this;
         let i: number = services.length;
         while (i--) {
@@ -202,7 +202,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
      * Remove service by id.
      * @param nameOrId ID of the service to remove.
      */
-    public disconnectService(id: string): void {
+    disconnectService(id: string): void {
         const { services = [] } = this;
         let i: number = services.length;
         while (i--) {

--- a/libraries/botframework-config/src/botRecipe.ts
+++ b/libraries/botframework-config/src/botRecipe.ts
@@ -80,12 +80,12 @@ export class BotRecipe {
     /**
      * Version of the recipe.
      */
-    public version = '1.0';
+    version = '1.0';
 
     /**
      *
      */
-    public resources: IResource[] = [];
+    resources: IResource[] = [];
 
     /**
      * Creates a new BotRecipe instance.
@@ -99,7 +99,7 @@ export class BotRecipe {
      * @param source JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type.
      * @returns A new [BotRecipe](xref:botframework-config.BotRecipe) instance.
      */
-    public static fromJSON(source: Partial<BotRecipe> = {}): BotRecipe {
+    static fromJSON(source: Partial<BotRecipe> = {}): BotRecipe {
         const botRecipe: BotRecipe = new BotRecipe();
         const { version, resources } = source;
         botRecipe.resources = resources ? resources : botRecipe.resources;
@@ -112,7 +112,7 @@ export class BotRecipe {
      * Creates a JSON object from `this` class instance.
      * @returns A JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type;
      */
-    public toJSON(): Partial<BotRecipe> {
+    toJSON(): Partial<BotRecipe> {
         const { version, resources } = this;
 
         return { version, resources };

--- a/libraries/botframework-config/src/models/appInsightsService.ts
+++ b/libraries/botframework-config/src/models/appInsightsService.ts
@@ -15,17 +15,17 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
     /**
      * Instrumentation key for logging data to appInsights.
      */
-    public instrumentationKey: string;
+    instrumentationKey: string;
 
     /**
      * (Optional) application ID used for programmatic access to AppInsights.
      */
-    public applicationId: string;
+    applicationId: string;
 
     /**
      * (Optional) named api keys for programmatic access to AppInsights.
      */
-    public apiKeys: { [key: string]: string };
+    apiKeys: { [key: string]: string };
 
     /**
      * Creates a new AppInsightService instance.
@@ -41,7 +41,7 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {
             this.instrumentationKey = encryptString(this.instrumentationKey, secret);
@@ -58,7 +58,7 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {
             this.instrumentationKey = decryptString(this.instrumentationKey, secret);

--- a/libraries/botframework-config/src/models/azureService.ts
+++ b/libraries/botframework-config/src/models/azureService.ts
@@ -15,22 +15,22 @@ export class AzureService extends ConnectedService implements IAzureService {
     /**
      * Tenant ID for azure.
      */
-    public tenantId: string;
+    tenantId: string;
 
     /**
      * Subscription ID for azure.
      */
-    public subscriptionId: string;
+    subscriptionId: string;
 
     /**
      * Resource group for azure.
      */
-    public resourceGroup: string;
+    resourceGroup: string;
 
     /**
      * Name of the service.
      */
-    public serviceName: string;
+    serviceName: string;
 
     /**
      * Creates a new AzureService instance.

--- a/libraries/botframework-config/src/models/blobStorageService.ts
+++ b/libraries/botframework-config/src/models/blobStorageService.ts
@@ -15,12 +15,12 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
     /**
      * Connection string for blob storage.
      */
-    public connectionString: string;
+    connectionString: string;
 
     /**
      * (Optional) container name.
      */
-    public container: string;
+    container: string;
 
     /**
      * Creates a new BlobStorageService instance.
@@ -35,7 +35,7 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.connectionString && this.connectionString.length > 0) {
             this.connectionString = encryptString(this.connectionString, secret);
         }
@@ -46,7 +46,7 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.connectionString && this.connectionString.length > 0) {
             this.connectionString = decryptString(this.connectionString, secret);
         }

--- a/libraries/botframework-config/src/models/botService.ts
+++ b/libraries/botframework-config/src/models/botService.ts
@@ -15,7 +15,7 @@ export class BotService extends AzureService implements IBotService {
     /**
      * MSA App ID for the bot.
      */
-    public appId: string;
+    appId: string;
 
     /**
      * Creates a new BotService instance.
@@ -30,7 +30,7 @@ export class BotService extends AzureService implements IBotService {
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
@@ -39,7 +39,7 @@ export class BotService extends AzureService implements IBotService {
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         return;
     }
 }

--- a/libraries/botframework-config/src/models/connectedService.ts
+++ b/libraries/botframework-config/src/models/connectedService.ts
@@ -14,19 +14,19 @@ export class ConnectedService implements IConnectedService {
     /**
      * Unique Id for the service.
      */
-    public id: string;
+    id: string;
 
     /**
      * Friendly name for the service.
      */
-    public name: string;
+    name: string;
 
     /**
      * Creates a new ConnectedService instance.
      * @param source (Optional) JSON based service definition.
      * @param type (Optional) type of service being defined.
      */
-    public constructor(source: IConnectedService = {} as IConnectedService, public type?: ServiceTypes) {
+    constructor(source: IConnectedService = {} as IConnectedService, public type?: ServiceTypes) {
         Object.assign(this, source);
         if (type) {
             this.type = type;
@@ -36,7 +36,7 @@ export class ConnectedService implements IConnectedService {
     /**
      * Returns a JSON based version of the model for saving to disk.
      */
-    public toJSON(): IConnectedService {
+    toJSON(): IConnectedService {
         return <IConnectedService>Object.assign({}, this);
     }
 
@@ -45,7 +45,7 @@ export class ConnectedService implements IConnectedService {
      * @param secret Secret to use to encrypt the keys in this service.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         // noop
     }
 
@@ -54,7 +54,7 @@ export class ConnectedService implements IConnectedService {
      * @param secret Secret to use to decrypt the keys in this service.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         // noop
     }
 }

--- a/libraries/botframework-config/src/models/cosmosDbService.ts
+++ b/libraries/botframework-config/src/models/cosmosDbService.ts
@@ -15,22 +15,22 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
     /**
      * Endpoint/uri for CosmosDB.
      */
-    public endpoint: string;
+    endpoint: string;
 
     /**
      * Key for accessing CosmosDB.
      */
-    public key: string;
+    key: string;
 
     /**
      * Database name.
      */
-    public database: string;
+    database: string;
 
     /**
      * Collection name.
      */
-    public collection: string;
+    collection: string;
 
     /**
      * Creates a new CosmosDBService instance.
@@ -45,7 +45,7 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.key && this.key.length > 0) {
             this.key = encryptString(this.key, secret);
         }
@@ -56,7 +56,7 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.key && this.key.length > 0) {
             this.key = decryptString(this.key, secret);
         }

--- a/libraries/botframework-config/src/models/dispatchService.ts
+++ b/libraries/botframework-config/src/models/dispatchService.ts
@@ -15,7 +15,7 @@ export class DispatchService extends LuisService implements IDispatchService {
     /**
      * Service IDs that the dispatch model will dispatch across.
      */
-    public serviceIds: string[];
+    serviceIds: string[];
 
     /**
      * Creates a new DispatchService instance.

--- a/libraries/botframework-config/src/models/endpointService.ts
+++ b/libraries/botframework-config/src/models/endpointService.ts
@@ -15,24 +15,24 @@ export class EndpointService extends ConnectedService implements IEndpointServic
     /**
      * MSA App ID.
      */
-    public appId: string;
+    appId: string;
 
     /**
      * MSA app password for the bot.
      */
-    public appPassword: string;
+    appPassword: string;
 
     /**
      * Endpoint of localhost service.
      */
-    public endpoint: string;
+    endpoint: string;
 
     /**
      * The channel service (Azure or US Government Azure) for the bot.
      * A value of 'https://botframework.azure.us' means the bot will be talking to a US Government Azure data center.
      * An undefined or null value means the bot will be talking to public Azure
      */
-    public channelService: string;
+    channelService: string;
 
     /**
      * Creates a new EndpointService instance.
@@ -47,7 +47,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.appPassword && this.appPassword.length > 0) {
             this.appPassword = encryptString(this.appPassword, secret);
         }
@@ -58,7 +58,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.appPassword && this.appPassword.length > 0) {
             this.appPassword = decryptString(this.appPassword, secret);
         }

--- a/libraries/botframework-config/src/models/fileService.ts
+++ b/libraries/botframework-config/src/models/fileService.ts
@@ -15,7 +15,7 @@ export class FileService extends ConnectedService implements IFileService {
     /**
      * File path.
      */
-    public path: string;
+    path: string;
 
     /**
      * Creates a new FileService instance.
@@ -30,7 +30,7 @@ export class FileService extends ConnectedService implements IFileService {
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
@@ -39,7 +39,7 @@ export class FileService extends ConnectedService implements IFileService {
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         return;
     }
 }

--- a/libraries/botframework-config/src/models/genericService.ts
+++ b/libraries/botframework-config/src/models/genericService.ts
@@ -15,12 +15,12 @@ export class GenericService extends ConnectedService implements IGenericService 
     /**
      * Deep link to service.
      */
-    public url: string;
+    url: string;
 
     /**
      * Named/value configuration data.
      */
-    public configuration: { [key: string]: string };
+    configuration: { [key: string]: string };
 
     /**
      * Creates a new GenericService instance.
@@ -35,7 +35,7 @@ export class GenericService extends ConnectedService implements IGenericService 
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         const that: GenericService = this;
         if (this.configuration) {
             Object.keys(this.configuration).forEach((prop: string) => {
@@ -49,7 +49,7 @@ export class GenericService extends ConnectedService implements IGenericService 
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         const that: GenericService = this;
         if (this.configuration) {
             Object.keys(this.configuration).forEach((prop: string) => {

--- a/libraries/botframework-config/src/models/luisService.ts
+++ b/libraries/botframework-config/src/models/luisService.ts
@@ -15,33 +15,33 @@ export class LuisService extends ConnectedService implements ILuisService {
     /**
      * Luis app ID.
      */
-    public appId: string;
+    appId: string;
 
     /**
      * Authoring key for using authoring api.
      */
-    public authoringKey: string;
+    authoringKey: string;
 
     /**
      * Subscription key for using calling model api for predictions.
      */
-    public subscriptionKey: string;
+    subscriptionKey: string;
 
     /**
      * Version of the application.
      */
-    public version: string;
+    version: string;
 
     /**
      * Region for luis.
      */
-    public region: string;
+    region: string;
 
     /**
      * URL for a custom endpoint. This should only be used when the LUIS deployed via a container.
      * If a value is set, then the GetEndpoint() method will return the value for Custom Endpoint.
      */
-    public customEndpoint: string;
+    customEndpoint: string;
 
     /**
      * Creates a new LuisService instance.
@@ -56,7 +56,7 @@ export class LuisService extends ConnectedService implements ILuisService {
      * Get endpoint for the luis service. If a customEndpoint is set then this is returned
      * otherwise the endpoint is automatically generated based on the region set.
      */
-    public getEndpoint(): string {
+    getEndpoint(): string {
         // If a custom endpoint has been supplied, then we should return this instead of
         // generating an endpoint based on the region.
         if (this.customEndpoint) {
@@ -83,7 +83,7 @@ export class LuisService extends ConnectedService implements ILuisService {
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.authoringKey && this.authoringKey.length > 0) {
             this.authoringKey = encryptString(this.authoringKey, secret);
         }
@@ -97,7 +97,7 @@ export class LuisService extends ConnectedService implements ILuisService {
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.authoringKey && this.authoringKey.length > 0) {
             this.authoringKey = decryptString(this.authoringKey, secret);
         }

--- a/libraries/botframework-config/src/models/qnaMakerService.ts
+++ b/libraries/botframework-config/src/models/qnaMakerService.ts
@@ -16,22 +16,22 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
     /**
      * Knowledge base id.
      */
-    public kbId: string;
+    kbId: string;
 
     /**
      * Subscription key for calling admin api.
      */
-    public subscriptionKey: string;
+    subscriptionKey: string;
 
     /**
      * hostname for private service endpoint Example: https://myqna.azurewebsites.net.
      */
-    public hostname: string;
+    hostname: string;
 
     /**
      * Endpoint Key for querying the kb.
      */
-    public endpointKey: string;
+    endpointKey: string;
 
     /**
      * Creates a new QnaMakerService instance.
@@ -54,7 +54,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
         if (this.endpointKey && this.endpointKey.length > 0) {
             this.endpointKey = encryptString(this.endpointKey, secret);
         }
@@ -69,7 +69,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
         if (this.endpointKey && this.endpointKey.length > 0) {
             this.endpointKey = decryptString(this.endpointKey, secret);
         }

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -17,12 +17,12 @@ import { AuthenticationConstants } from './authenticationConstants';
 export abstract class AppCredentials implements msrest.ServiceClientCredentials {
     private static readonly cache: Map<string, adal.TokenResponse> = new Map<string, adal.TokenResponse>();
 
-    public appId: string;
+    appId: string;
 
     private _oAuthEndpoint: string;
     private _oAuthScope: string;
     private _tenant: string;
-    public tokenCacheKey: string;
+    tokenCacheKey: string;
     protected refreshingToken: Promise<adal.TokenResponse> | null = null;
     protected authenticationContext: adal.AuthenticationContext;
 
@@ -44,7 +44,7 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param channelAuthTenant Optional. The oauth token tenant.
      * @param oAuthScope The scope for the token.
      */
-    public constructor(
+    constructor(
         appId: string,
         channelAuthTenant?: string,
         oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer
@@ -76,14 +76,14 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      *
      * @returns The OAuth scope to use.
      */
-    public get oAuthScope(): string {
+    get oAuthScope(): string {
         return this._oAuthScope;
     }
 
     /**
      * Sets the OAuth scope to use.
      */
-    public set oAuthScope(value: string) {
+    set oAuthScope(value: string) {
         this._oAuthScope = value;
         this.tokenCacheKey = `${this.appId}${this.oAuthScope}-cache`;
     }
@@ -93,14 +93,14 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      *
      * @returns The OAuthEndpoint to use.
      */
-    public get oAuthEndpoint(): string {
+    get oAuthEndpoint(): string {
         return this._oAuthEndpoint;
     }
 
     /**
      * Sets the OAuth endpoint to use.
      */
-    public set oAuthEndpoint(value: string) {
+    set oAuthEndpoint(value: string) {
         // aadApiVersion is set to '1.5' to avoid the "spn:" concatenation on the audience claim
         // For more info, see https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/128
         this._oAuthEndpoint = value;
@@ -116,8 +116,8 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param  {string} serviceUrl The service url
      * @param  {Date} expiration? The expiration date after which this service url is not trusted anymore
      */
-    public static trustServiceUrl(serviceUrl: string, expiration?: Date): void;
-    public static trustServiceUrl(): void {
+    static trustServiceUrl(serviceUrl: string, expiration?: Date): void;
+    static trustServiceUrl(): void {
         // no-op
     }
 
@@ -129,8 +129,8 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param  {string} serviceUrl The service url
      * @returns {boolean} True if the host of the service url is trusted; False otherwise.
      */
-    public static isTrustedServiceUrl(serviceUrl: string): boolean;
-    public static isTrustedServiceUrl(): boolean {
+    static isTrustedServiceUrl(serviceUrl: string): boolean;
+    static isTrustedServiceUrl(): boolean {
         return true;
     }
 
@@ -140,7 +140,7 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param webResource The WebResource HTTP request.
      * @returns A Promise representing the asynchronous operation.
      */
-    public async signRequest(webResource: msrest.WebResource): Promise<msrest.WebResource> {
+    async signRequest(webResource: msrest.WebResource): Promise<msrest.WebResource> {
         if (this.shouldSetToken()) {
             return new msrest.TokenCredentials(await this.getToken()).signRequest(webResource);
         }
@@ -156,7 +156,7 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @returns A Promise that represents the work queued to execute.
      * @remarks If the promise is successful, the result contains the access token string.
      */
-    public async getToken(forceRefresh = false): Promise<string> {
+    async getToken(forceRefresh = false): Promise<string> {
         if (!forceRefresh) {
             // check the global cache for the token. If we have it, and it's valid, we're done.
             const oAuthToken: adal.TokenResponse = AppCredentials.cache.get(this.tokenCacheKey);

--- a/libraries/botframework-connector/src/auth/authenticationError.ts
+++ b/libraries/botframework-connector/src/auth/authenticationError.ts
@@ -28,7 +28,7 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * @returns If `err` is an [IStatusCodeError](xref:botframework-schema.IStatusCodeError), the result is true; otherwise false.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    public static isStatusCodeError(err: any): err is IStatusCodeError {
+    static isStatusCodeError(err: any): err is IStatusCodeError {
         return !!(err && typeof err.statusCode === 'number');
     }
 
@@ -39,7 +39,7 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * @returns The error message to be sent as a response.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    public static determineStatusCodeAndBuildMessage(err: any): string {
+    static determineStatusCodeAndBuildMessage(err: any): string {
         const errMessage: string = err && err.message ? err.message : 'Internal Server Error';
         const code: number = AuthenticationError.determineStatusCode(errMessage);
         const connectionHeader = "Connection: 'close'\r\n";

--- a/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
@@ -13,8 +13,8 @@ import { AppCredentials } from './appCredentials';
  * CertificateAppCredentials auth implementation
  */
 export class CertificateAppCredentials extends AppCredentials {
-    public certificateThumbprint: string;
-    public certificatePrivateKey: string;
+    certificateThumbprint: string;
+    certificatePrivateKey: string;
 
     /**
      * Initializes a new instance of the [CertificateAppCredentials](xref:botframework-connector.CertificateAppCredentials) class.

--- a/libraries/botframework-connector/src/auth/claimsIdentity.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentity.ts
@@ -26,7 +26,7 @@ export class ClaimsIdentity {
      */
     constructor(public readonly claims: Claim[], private readonly authenticationType?: string | boolean) {}
 
-    public get isAuthenticated(): boolean {
+    get isAuthenticated(): boolean {
         if (typeof this.authenticationType === 'boolean') {
             return this.authenticationType;
         }
@@ -40,7 +40,7 @@ export class ClaimsIdentity {
      * @param  {string} claimType The claim type to look for
      * @returns {string|null} The claim value or null if not found
      */
-    public getClaimValue(claimType: string): string | null {
+    getClaimValue(claimType: string): string | null {
         const claim = this.claims.find((c) => c.type === claimType);
 
         return claim?.value ?? null;

--- a/libraries/botframework-connector/src/auth/credentialProvider.ts
+++ b/libraries/botframework-connector/src/auth/credentialProvider.ts
@@ -85,7 +85,7 @@ export class SimpleCredentialProvider implements ICredentialProvider {
      * @param {string} appId bot appid
      * @returns {Promise<boolean>} true if it is a valid AppId
      */
-    public isValidAppId(appId: string): Promise<boolean> {
+    isValidAppId(appId: string): Promise<boolean> {
         return Promise.resolve(this.appId === appId);
     }
 
@@ -98,7 +98,7 @@ export class SimpleCredentialProvider implements ICredentialProvider {
      * @param {string} appId bot appid
      * @returns {Promise<string|null>} password or null for invalid appid
      */
-    public getAppPassword(appId: string): Promise<string | null> {
+    getAppPassword(appId: string): Promise<string | null> {
         return Promise.resolve(this.appId === appId ? this.appPassword : null);
     }
 
@@ -111,7 +111,7 @@ export class SimpleCredentialProvider implements ICredentialProvider {
      *
      * @returns {Promise<boolean>} true if bot authentication is disabled.
      */
-    public isAuthenticationDisabled(): Promise<boolean> {
+    isAuthenticationDisabled(): Promise<boolean> {
         return Promise.resolve(!this.appId);
     }
 }

--- a/libraries/botframework-connector/src/auth/endorsementsValidator.ts
+++ b/libraries/botframework-connector/src/auth/endorsementsValidator.ts
@@ -22,7 +22,7 @@ export class EndorsementsValidator {
      * some specific channels. That list is the endorsement list, and is validated here against the channelId.
      * @returns {boolean} True is the channelId is found in the Endorsement set. False if the channelId is not found.
      */
-    public static validate(channelId: string, endorsements: string[]): boolean {
+    static validate(channelId: string, endorsements: string[]): boolean {
         // If the Activity came in and doesn't have a Channel ID then it's making no
         // assertions as to who endorses it. This means it should pass.
         if (channelId === null || channelId.trim() === '') {

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -21,10 +21,10 @@ export class JwtTokenExtractor {
     private static openIdMetadataCache: Map<string, OpenIdMetadata> = new Map<string, OpenIdMetadata>();
 
     // Token validation parameters for this instance
-    public readonly tokenValidationParameters: VerifyOptions;
+    readonly tokenValidationParameters: VerifyOptions;
 
     // OpenIdMetadata for this instance
-    public readonly openIdMetadata: OpenIdMetadata;
+    readonly openIdMetadata: OpenIdMetadata;
 
     /**
      * Initializes a new instance of the [JwtTokenExtractor](xref:botframework-connector.JwtTokenExtractor) class. Extracts relevant data from JWT Tokens.
@@ -57,7 +57,7 @@ export class JwtTokenExtractor {
      * @param requiredEndorsements The required JWT endorsements.
      * @returns A `Promise` representation for either a [ClaimsIdentity](botframework-connector:module.ClaimsIdentity) or `null`.
      */
-    public async getIdentityFromAuthHeader(
+    async getIdentityFromAuthHeader(
         authorizationHeader: string,
         channelId: string,
         requiredEndorsements?: string[]
@@ -83,7 +83,7 @@ export class JwtTokenExtractor {
      * @param requiredEndorsements The required JWT endorsements.
      * @returns A `Promise` representation for either a [ClaimsIdentity](botframework-connector:module.ClaimsIdentity) or `null`.
      */
-    public async getIdentity(
+    async getIdentity(
         scheme: string,
         parameter: string,
         channelId: string,

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -26,7 +26,7 @@ export class MicrosoftAppCredentials extends AppCredentials {
     /**
      * An empty set of credentials.
      */
-    public static readonly Empty = new MicrosoftAppCredentials(null, null);
+    static readonly Empty = new MicrosoftAppCredentials(null, null);
 
     /**
      * Initializes a new instance of the [MicrosoftAppCredentials](xref:botframework-connector.MicrosoftAppCredentials) class.
@@ -36,7 +36,7 @@ export class MicrosoftAppCredentials extends AppCredentials {
      * @param {string} channelAuthTenant Optional. The oauth token tenant.
      * @param {string} oAuthScope Optional. The scope for the token.
      */
-    public constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {
+    constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {
         super(appId, channelAuthTenant, oAuthScope);
     }
 

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -32,7 +32,7 @@ export class OpenIdMetadata {
      * @param keyId The key ID to search for.
      * @returns A `Promise` representation for either a [IOpenIdMetadataKey](botframework-connector:module.IOpenIdMetadataKey) or `null`.
      */
-    public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
+    async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
         // If keys are more than 24 hours old, refresh them
         if (this.lastUpdated < Date.now() - 1000 * 60 * 60 * 24) {
             await this.refreshCache();

--- a/libraries/botframework-connector/src/emulatorApiClient.ts
+++ b/libraries/botframework-connector/src/emulatorApiClient.ts
@@ -23,7 +23,7 @@ export class EmulatorApiClient {
      * @param emulate `true` to send an emulated OAuth card to the emulator; or `false` to not send the card.
      * @returns `true` on a successful emulation of OAuthCards.
      */
-    public static async emulateOAuthCards(
+    static async emulateOAuthCards(
         credentials: AppCredentials,
         emulatorUrl: string,
         emulate: boolean


### PR DESCRIPTION
Addresses # 3518
#minor

## Description
This PR removes the `public` access modifier from all constructors, methods and properties for the `botframework-config` and `botframework-connector` folders.

> **Note:** These changes do not include the `Typescript Constructor Shorthands` ([link](https://dev.to/satansdeer/typescript-constructor-shorthand-3ibd)).

## Specific Changes
- Removes all `public` access modifiers from where it's declared under the `botframework-config` and `botframework-connector` folders.