### PR TITLE
fix: [#4204] Fix remaining eslint warnings - botframework-config

### DIFF
--- a/libraries/botframework-config/etc/botframework-config.api.md
+++ b/libraries/botframework-config/etc/botframework-config.api.md
@@ -84,15 +84,15 @@ export class BotRecipe {
 export class BotService extends AzureService implements IBotService {
     constructor(source?: IBotService);
     appId: string;
-    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void;
-    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void;
+    decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void;
+    encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void;
 }
 
 // @public @deprecated
 export class ConnectedService implements IConnectedService {
     constructor(source?: IConnectedService, type?: ServiceTypes);
-    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void;
-    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void;
+    decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void;
+    encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void;
     id: string;
     name: string;
     toJSON(): IConnectedService;
@@ -131,8 +131,8 @@ export class EndpointService extends ConnectedService implements IEndpointServic
 // @public @deprecated
 export class FileService extends ConnectedService implements IFileService {
     constructor(source?: IFileService);
-    decrypt(secret: string, decryptString: (value: string, secret: string) => string): void;
-    encrypt(secret: string, encryptString: (value: string, secret: string) => string): void;
+    decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void;
+    encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void;
     path: string;
 }
 

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -28,8 +28,10 @@ export class BotConfiguration extends BotConfigurationBase {
     private internal: InternalBotConfig = {};
 
     /**
-     * Returns a new BotConfiguration instance given a JSON based configuration.
+     * Load the bot configuration from a JSON.
+     *
      * @param source JSON based configuration.
+     * @returns A new BotConfiguration instance.
      */
     public static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfiguration {
         // tslint:disable-next-line:prefer-const
@@ -53,11 +55,14 @@ export class BotConfiguration extends BotConfigurationBase {
     /**
      * Load the bot configuration by looking in a folder and loading the first .bot file in the
      * folder.
+     *
      * @param folder (Optional) folder to look for bot files. If not specified the current working directory is used.
      * @param secret (Optional) secret used to decrypt the bot file.
+     * @returns A Promise with the new BotConfiguration instance.
      */
     public static async loadBotFromFolder(folder?: string, secret?: string): Promise<BotConfiguration> {
         folder = folder || process.cwd();
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         let files: string[] = await fsx.readdir(folder);
         files = files.sort();
         for (const file of files) {
@@ -73,11 +78,14 @@ export class BotConfiguration extends BotConfigurationBase {
     /**
      * Load the bot configuration by looking in a folder and loading the first .bot file in the
      * folder. (blocking)
+     *
      * @param folder (Optional) folder to look for bot files. If not specified the current working directory is used.
      * @param secret (Optional) secret used to decrypt the bot file.
+     * @returns A new BotConfiguration instance.
      */
     public static loadBotFromFolderSync(folder?: string, secret?: string): BotConfiguration {
         folder = folder || process.cwd();
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         let files: string[] = fsx.readdirSync(folder);
         files = files.sort();
         for (const file of files) {
@@ -92,8 +100,10 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Load the configuration from a .bot file.
+     *
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to decrypt the bot file.
+     * @returns A Promise with the new BotConfiguration instance.
      */
     public static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
         const json: string = await txtfile.read(botpath);
@@ -105,8 +115,10 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Load the configuration from a .bot file. (blocking)
+     *
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to decrypt the bot file.
+     * @returns A new BotConfiguration instance.
      */
     public static loadSync(botpath: string, secret?: string): BotConfiguration {
         const json: string = txtfile.readSync(botpath);
@@ -118,6 +130,8 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Generate a new key suitable for encrypting.
+     *
+     * @returns Key to use with the [encrypt](xref:botframework-config.BotConfiguration.encrypt) method.
      */
     public static generateKey(): string {
         return encrypt.generateKey();
@@ -139,12 +153,13 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Save the configuration to a .bot file.
+     *
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to encrypt the bot file.
      */
     public async saveAs(botpath: string, secret?: string): Promise<void> {
         if (!botpath) {
-            throw new Error(`missing path`);
+            throw new Error('missing path');
         }
 
         this.internal.location = botpath;
@@ -165,12 +180,13 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Save the configuration to a .bot file. (blocking)
+     *
      * @param botpath Path to bot file.
      * @param secret (Optional) secret used to encrypt the bot file.
      */
     public saveAsSync(botpath: string, secret?: string): void {
         if (!botpath) {
-            throw new Error(`missing path`);
+            throw new Error('missing path');
         }
         this.internal.location = botpath;
 
@@ -191,14 +207,18 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Save the file with secret.
+     *
      * @param secret (Optional) secret used to encrypt the bot file.
+     * @returns A promise representing the asynchronous operation.
      */
     public async save(secret?: string): Promise<void> {
         return this.saveAs(this.internal.location, secret);
     }
 
+    // eslint-disable-next-line jsdoc/require-returns
     /**
      * Save the file with secret. (blocking)
+     *
      * @param secret (Optional) secret used to encrypt the bot file.
      */
     public saveSync(secret?: string): void {
@@ -214,6 +234,7 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Encrypt all values in the in memory config.
+     *
      * @param secret Secret to encrypt.
      */
     public encrypt(secret: string): void {
@@ -226,6 +247,7 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Decrypt all values in the in memory config.
+     *
      * @param secret Secret to decrypt.
      */
     public decrypt(secret?: string): void {
@@ -280,14 +302,16 @@ export class BotConfiguration extends BotConfigurationBase {
                         }
                     }
                 }
-            } catch (err2) {
+            } catch {
                 throw err;
             }
         }
     }
 
     /**
-     * Return the path that this config was loaded from.  .save() will save to this path.
+     * Gets the path that this config was loaded from.  .save() will save to this path.
+     *
+     * @returns The path.
      */
     public getPath(): string {
         return this.internal.location;
@@ -295,6 +319,7 @@ export class BotConfiguration extends BotConfigurationBase {
 
     /**
      * Make sure secret is correct by decrypting the secretKey with it.
+     *
      * @param secret Secret to use.
      */
     public validateSecret(secret: string): void {
@@ -312,7 +337,7 @@ export class BotConfiguration extends BotConfigurationBase {
                 // validate we can decrypt the padlock, this tells us we have the correct secret for the rest of the file.
                 encrypt.decryptString(this.padlock, secret);
             }
-        } catch (ex) {
+        } catch {
             throw new Error(
                 'You are attempting to perform an operation which needs access to the secret and --secret is incorrect.'
             );

--- a/libraries/botframework-config/src/botConfigurationBase.ts
+++ b/libraries/botframework-config/src/botConfigurationBase.ts
@@ -51,8 +51,10 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
     }
 
     /**
-     * Returns a ConnectedService instance given a JSON based service configuration.
+     * Loads a ConnectedService instance given a JSON based service configuration.
+     *
      * @param service JSON based service configuration.
+     * @returns A new ConnectedService instance.
      */
     public static serviceFromJSON(service: IConnectedService): ConnectedService {
         switch (service.type) {
@@ -92,8 +94,10 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
     }
 
     /**
-     * Returns a new BotConfigurationBase instance given a JSON based configuration.
+     * Loads a new BotConfigurationBase instance given a JSON based configuration.
+     *
      * @param source JSON based configuration.
+     * @returns A new BotConfigurationBase instance.
      */
     public static fromJSON(source: Partial<IBotConfiguration> = {}): BotConfigurationBase {
         // tslint:disable-next-line:prefer-const
@@ -109,7 +113,9 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
     }
 
     /**
-     * Returns a JSON based version of the current bot.
+     * Creates a JSON based version of the current bot.
+     *
+     * @returns An IBotConfiguration JSON.
      */
     public toJSON(): IBotConfiguration {
         const newConfig: IBotConfiguration = <IBotConfiguration>{};
@@ -124,6 +130,7 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
     /**
      * Connect a service to the bot file.
+     *
      * @param newService Service to add.
      * @returns Assigned ID for the service.
      */
@@ -150,7 +157,9 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
     /**
      * Find service by id.
+     *
      * @param id ID of the service to find.
+     * @returns The IConnectedService based on the provided id.
      */
     public findService(id: string): IConnectedService {
         for (const service of this.services) {
@@ -164,7 +173,9 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
     /**
      * Find service by name or id.
+     *
      * @param nameOrId Name or ID of the service to find.
+     * @returns The IConnectedService based on the provided name or id.
      */
     public findServiceByNameOrId(nameOrId: string): IConnectedService {
         for (const service of this.services) {
@@ -184,7 +195,9 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
     /**
      * Remove service by name or id.
+     *
      * @param nameOrId Name or ID of the service to remove.
+     * @returns The removed IConnectedService based on the provided name or id.
      */
     public disconnectServiceByNameOrId(nameOrId: string): IConnectedService {
         const { services = [] } = this;
@@ -200,7 +213,8 @@ export class BotConfigurationBase implements Partial<IBotConfiguration> {
 
     /**
      * Remove service by id.
-     * @param nameOrId ID of the service to remove.
+     *
+     * @param id ID of the service to remove.
      */
     public disconnectService(id: string): void {
         const { services = [] } = this;

--- a/libraries/botframework-config/src/botRecipe.ts
+++ b/libraries/botframework-config/src/botRecipe.ts
@@ -96,6 +96,7 @@ export class BotRecipe {
 
     /**
      * Creates a new [BotRecipe](xref:botframework-config.BotRecipe) instance from a JSON object.
+     *
      * @param source JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type.
      * @returns A new [BotRecipe](xref:botframework-config.BotRecipe) instance.
      */
@@ -110,6 +111,7 @@ export class BotRecipe {
 
     /**
      * Creates a JSON object from `this` class instance.
+     *
      * @returns A JSON object of [BotRecipe](xref:botframework-config.BotRecipe) type;
      */
     public toJSON(): Partial<BotRecipe> {

--- a/libraries/botframework-config/src/models/appInsightsService.ts
+++ b/libraries/botframework-config/src/models/appInsightsService.ts
@@ -9,6 +9,7 @@ import { AzureService } from './azureService';
 
 /**
  * Defines an App Insights service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class AppInsightsService extends AzureService implements IAppInsightsService {
@@ -29,6 +30,7 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
 
     /**
      * Creates a new AppInsightService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IAppInsightsService = {} as IAppInsightsService) {
@@ -38,34 +40,34 @@ export class AppInsightsService extends AzureService implements IAppInsightsServ
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
-        const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {
             this.instrumentationKey = encryptString(this.instrumentationKey, secret);
         }
         if (this.apiKeys) {
             Object.keys(this.apiKeys).forEach((prop: string) => {
-                that.apiKeys[prop] = encryptString(that.apiKeys[prop], secret);
+                this.apiKeys[prop] = encryptString(this.apiKeys[prop], secret);
             });
         }
     }
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
-        const that: AppInsightsService = this;
         if (this.instrumentationKey && this.instrumentationKey.length > 0) {
             this.instrumentationKey = decryptString(this.instrumentationKey, secret);
         }
         if (this.apiKeys) {
             Object.keys(this.apiKeys).forEach((prop: string) => {
-                that.apiKeys[prop] = decryptString(that.apiKeys[prop], secret);
+                this.apiKeys[prop] = decryptString(this.apiKeys[prop], secret);
             });
         }
     }

--- a/libraries/botframework-config/src/models/azureService.ts
+++ b/libraries/botframework-config/src/models/azureService.ts
@@ -9,6 +9,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Base class for all azure service definitions.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class AzureService extends ConnectedService implements IAzureService {
@@ -34,6 +35,7 @@ export class AzureService extends ConnectedService implements IAzureService {
 
     /**
      * Creates a new AzureService instance.
+     *
      * @param source (Optional) JSON based service definition.
      * @param type Type of service being defined.
      */

--- a/libraries/botframework-config/src/models/blobStorageService.ts
+++ b/libraries/botframework-config/src/models/blobStorageService.ts
@@ -9,6 +9,7 @@ import { AzureService } from './azureService';
 
 /**
  * Defines an blob storage service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class BlobStorageService extends AzureService implements IBlobStorageService {
@@ -24,6 +25,7 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
 
     /**
      * Creates a new BlobStorageService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IBlobStorageService = {} as IBlobStorageService) {
@@ -32,6 +34,7 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
@@ -43,6 +46,7 @@ export class BlobStorageService extends AzureService implements IBlobStorageServ
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */

--- a/libraries/botframework-config/src/models/botService.ts
+++ b/libraries/botframework-config/src/models/botService.ts
@@ -9,6 +9,7 @@ import { AzureService } from './azureService';
 
 /**
  * Defines an Azure Bot Service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class BotService extends AzureService implements IBotService {
@@ -19,6 +20,7 @@ export class BotService extends AzureService implements IBotService {
 
     /**
      * Creates a new BotService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IBotService = {} as IBotService) {
@@ -27,19 +29,21 @@ export class BotService extends AzureService implements IBotService {
 
     /**
      * Encrypt properties on this service.
-     * @param secret Secret to use to encrypt.
-     * @param encryptString Function called to encrypt an individual value.
+     *
+     * @param _secret Secret to use to encrypt.
+     * @param _encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    public encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
     /**
      * Decrypt properties on this service.
-     * @param secret Secret to use to decrypt.
-     * @param decryptString Function called to decrypt an individual value.
+     *
+     * @param _secret Secret to use to decrypt.
+     * @param _decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    public decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void {
         return;
     }
 }

--- a/libraries/botframework-config/src/models/connectedService.ts
+++ b/libraries/botframework-config/src/models/connectedService.ts
@@ -8,6 +8,7 @@ import { IConnectedService, ServiceTypes } from '../schema';
 
 /**
  * Base class for all connected service definitions.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class ConnectedService implements IConnectedService {
@@ -23,6 +24,7 @@ export class ConnectedService implements IConnectedService {
 
     /**
      * Creates a new ConnectedService instance.
+     *
      * @param source (Optional) JSON based service definition.
      * @param type (Optional) type of service being defined.
      */
@@ -34,7 +36,9 @@ export class ConnectedService implements IConnectedService {
     }
 
     /**
-     * Returns a JSON based version of the model for saving to disk.
+     * Creates a JSON based version of the model for saving to disk.
+     *
+     * @returns An IConnectedService JSON.
      */
     public toJSON(): IConnectedService {
         return <IConnectedService>Object.assign({}, this);
@@ -42,19 +46,21 @@ export class ConnectedService implements IConnectedService {
 
     /**
      * Encrypt properties on this service.
-     * @param secret Secret to use to encrypt the keys in this service.
-     * @param encryptString Function called to encrypt an individual value.
+     *
+     * @param _secret Secret to use to encrypt the keys in this service.
+     * @param _encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    public encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void {
         // noop
     }
 
     /**
      * Decrypt properties on this service.
-     * @param secret Secret to use to decrypt the keys in this service.
-     * @param decryptString Function called to decrypt an individual value.
+     *
+     * @param _secret Secret to use to decrypt the keys in this service.
+     * @param _decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    public decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void {
         // noop
     }
 }

--- a/libraries/botframework-config/src/models/cosmosDbService.ts
+++ b/libraries/botframework-config/src/models/cosmosDbService.ts
@@ -9,6 +9,7 @@ import { AzureService } from './azureService';
 
 /**
  * Defines a CosmosDB service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class CosmosDbService extends AzureService implements ICosmosDBService {
@@ -34,6 +35,7 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
 
     /**
      * Creates a new CosmosDBService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: ICosmosDBService = {} as ICosmosDBService) {
@@ -42,6 +44,7 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
@@ -53,6 +56,7 @@ export class CosmosDbService extends AzureService implements ICosmosDBService {
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */

--- a/libraries/botframework-config/src/models/dispatchService.ts
+++ b/libraries/botframework-config/src/models/dispatchService.ts
@@ -9,6 +9,7 @@ import { LuisService } from './luisService';
 
 /**
  * Defines a dispatch service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class DispatchService extends LuisService implements IDispatchService {
@@ -19,6 +20,7 @@ export class DispatchService extends LuisService implements IDispatchService {
 
     /**
      * Creates a new DispatchService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IDispatchService = {} as IDispatchService) {

--- a/libraries/botframework-config/src/models/endpointService.ts
+++ b/libraries/botframework-config/src/models/endpointService.ts
@@ -9,6 +9,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Defines an endpoint service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class EndpointService extends ConnectedService implements IEndpointService {
@@ -36,6 +37,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
 
     /**
      * Creates a new EndpointService instance.
+     *
      * @param source JSON based service definition.
      */
     constructor(source: IEndpointService) {
@@ -44,6 +46,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
@@ -55,6 +58,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */

--- a/libraries/botframework-config/src/models/fileService.ts
+++ b/libraries/botframework-config/src/models/fileService.ts
@@ -9,6 +9,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Defines an file service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class FileService extends ConnectedService implements IFileService {
@@ -19,6 +20,7 @@ export class FileService extends ConnectedService implements IFileService {
 
     /**
      * Creates a new FileService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IFileService = {} as IFileService) {
@@ -27,19 +29,21 @@ export class FileService extends ConnectedService implements IFileService {
 
     /**
      * Encrypt properties on this service.
-     * @param secret Secret to use to encrypt.
-     * @param encryptString Function called to encrypt an individual value.
+     *
+     * @param _secret Secret to use to encrypt.
+     * @param _encryptString Function called to encrypt an individual value.
      */
-    public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
+    public encrypt(_secret: string, _encryptString: (value: string, secret: string) => string): void {
         return;
     }
 
     /**
      * Decrypt properties on this service.
-     * @param secret Secret to use to decrypt.
-     * @param decryptString Function called to decrypt an individual value.
+     *
+     * @param _secret Secret to use to decrypt.
+     * @param _decryptString Function called to decrypt an individual value.
      */
-    public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
+    public decrypt(_secret: string, _decryptString: (value: string, secret: string) => string): void {
         return;
     }
 }

--- a/libraries/botframework-config/src/models/genericService.ts
+++ b/libraries/botframework-config/src/models/genericService.ts
@@ -9,6 +9,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Defines a generic service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class GenericService extends ConnectedService implements IGenericService {
@@ -24,6 +25,7 @@ export class GenericService extends ConnectedService implements IGenericService 
 
     /**
      * Creates a new GenericService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IGenericService = {} as IGenericService) {
@@ -32,28 +34,28 @@ export class GenericService extends ConnectedService implements IGenericService 
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
     public encrypt(secret: string, encryptString: (value: string, secret: string) => string): void {
-        const that: GenericService = this;
         if (this.configuration) {
             Object.keys(this.configuration).forEach((prop: string) => {
-                that.configuration[prop] = encryptString(that.configuration[prop], secret);
+                this.configuration[prop] = encryptString(this.configuration[prop], secret);
             });
         }
     }
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */
     public decrypt(secret: string, decryptString: (value: string, secret: string) => string): void {
-        const that: GenericService = this;
         if (this.configuration) {
             Object.keys(this.configuration).forEach((prop: string) => {
-                that.configuration[prop] = decryptString(that.configuration[prop], secret);
+                this.configuration[prop] = decryptString(this.configuration[prop], secret);
             });
         }
     }

--- a/libraries/botframework-config/src/models/luisService.ts
+++ b/libraries/botframework-config/src/models/luisService.ts
@@ -9,6 +9,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Defines a LUIS service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class LuisService extends ConnectedService implements ILuisService {
@@ -45,8 +46,9 @@ export class LuisService extends ConnectedService implements ILuisService {
 
     /**
      * Creates a new LuisService instance.
+     *
      * @param source (Optional) JSON based service definition.
-     * @param type (Optional) type of service being defined.
+     * @param serviceType (Optional) type of service being defined.
      */
     constructor(source: ILuisService = {} as ILuisService, serviceType?: ServiceTypes) {
         super(source, serviceType || ServiceTypes.Luis);
@@ -55,6 +57,8 @@ export class LuisService extends ConnectedService implements ILuisService {
     /**
      * Get endpoint for the luis service. If a customEndpoint is set then this is returned
      * otherwise the endpoint is automatically generated based on the region set.
+     *
+     * @returns The URL for this service.
      */
     public getEndpoint(): string {
         // If a custom endpoint has been supplied, then we should return this instead of
@@ -68,7 +72,7 @@ export class LuisService extends ConnectedService implements ILuisService {
         // usgovvirginia is that actual azure region name, but the cognitive service team called their endpoint 'virginia' instead of 'usgovvirginia'
         // We handle both region names as an alias for virginia.api.cognitive.microsoft.us
         if (reg === 'virginia' || reg === 'usgovvirginia') {
-            return `https://virginia.api.cognitive.microsoft.us`;
+            return 'https://virginia.api.cognitive.microsoft.us';
         }
         // regardless, if it starts with usgov or usdod then it is us TLD (ex: api.cognitive.microsoft.us )
         else if (reg.startsWith('usgov') || reg.startsWith('usdod')) {
@@ -80,6 +84,7 @@ export class LuisService extends ConnectedService implements ILuisService {
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
@@ -94,6 +99,7 @@ export class LuisService extends ConnectedService implements ILuisService {
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */

--- a/libraries/botframework-config/src/models/qnaMakerService.ts
+++ b/libraries/botframework-config/src/models/qnaMakerService.ts
@@ -10,6 +10,7 @@ import { ConnectedService } from './connectedService';
 
 /**
  * Defines a QnA Maker service connection.
+ *
  * @deprecated See https://aka.ms/bot-file-basics for more information.
  */
 export class QnaMakerService extends ConnectedService implements IQnAService {
@@ -35,6 +36,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
 
     /**
      * Creates a new QnaMakerService instance.
+     *
      * @param source (Optional) JSON based service definition.
      */
     constructor(source: IQnAService = {} as IQnAService) {
@@ -51,6 +53,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
 
     /**
      * Encrypt properties on this service.
+     *
      * @param secret Secret to use to encrypt.
      * @param encryptString Function called to encrypt an individual value.
      */
@@ -66,6 +69,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
 
     /**
      * Decrypt properties on this service.
+     *
      * @param secret Secret to use to decrypt.
      * @param decryptString Function called to decrypt an individual value.
      */

--- a/libraries/botframework-config/tests/botRecipe.test.js
+++ b/libraries/botframework-config/tests/botRecipe.test.js
@@ -4,28 +4,36 @@ const path = require('path');
 const { BotRecipe } = require('../lib');
 
 function assertService(newService, oldService) {
-    assert(newService.type === oldService.type,
-        `newService.type [${ newService.type }] !== oldService.type [${ oldService.type }]`);
-    assert(newService.id === oldService.id,
-        `newService.id [${ newService.id }] !== oldService.id [${ oldService.id }]`);
-    assert(newService.name === oldService.name,
-        `newService.name [${ newService.name }] !== oldService.name [${ oldService.name }]`);
-    assert(newService.url === oldService.url,
-        `newService.url [${ newService.url }] !== oldService.url [${ oldService.url }]`);
+    assert(
+        newService.type === oldService.type,
+        `newService.type [${newService.type}] !== oldService.type [${oldService.type}]`
+    );
+    assert(newService.id === oldService.id, `newService.id [${newService.id}] !== oldService.id [${oldService.id}]`);
+    assert(
+        newService.name === oldService.name,
+        `newService.name [${newService.name}] !== oldService.name [${oldService.name}]`
+    );
+    assert(
+        newService.url === oldService.url,
+        `newService.url [${newService.url}] !== oldService.url [${oldService.url}]`
+    );
 }
 
-describe('BotRecipe', () => {
+describe('BotRecipe', function () {
     const recipe = new BotRecipe();
-    it(`should have a default version of '1.0'.`, () => {
-        assert(recipe.version === '1.0', `expected version '1.0', instead received ${ recipe.version }`);
+    it("should have a default version of '1.0'.", function () {
+        assert(recipe.version === '1.0', `expected version '1.0', instead received ${recipe.version}`);
     });
 
-    it(`should have default resources be an empty array.`, () => {
-        assert(Array.isArray(recipe.resources), `expected resources to be an Array, instead it is type "${ typeof recipe.resources }"`);
-        assert(recipe.resources.length === 0, `initial resources should be length 0, not ${ recipe.resources.length }`);
+    it('should have default resources be an empty array.', function () {
+        assert(
+            Array.isArray(recipe.resources),
+            `expected resources to be an Array, instead it is type "${typeof recipe.resources}"`
+        );
+        assert(recipe.resources.length === 0, `initial resources should be length 0, not ${recipe.resources.length}`);
     });
 
-    it('should create a new recipe using .fromJSON().', () => {
+    it('should create a new recipe using .fromJSON().', function () {
         const filePath = path.join(__dirname, './bot.recipe');
         const data = fs.readFileSync(filePath).toString();
         const oldRecipe = JSON.parse(data);
@@ -35,24 +43,33 @@ describe('BotRecipe', () => {
         const oldResources = oldRecipe.resources;
         const oldEndpoint = oldRecipe.resources[0];
 
-        assert(newRecipe.version === oldVersion, `expected version ${ oldVersion }, instead received ${ newRecipe.version }`);
-        assert(Array.isArray(newRecipe.resources), `expected resources to be an Array, instead it is type "${ typeof newRecipe.resources }"`);
-        assert(newRecipe.resources.length === oldResources.length, `initial resources should be length ${ oldResources.length }, not ${ newRecipe.resources.length }`);
+        assert(
+            newRecipe.version === oldVersion,
+            `expected version ${oldVersion}, instead received ${newRecipe.version}`
+        );
+        assert(
+            Array.isArray(newRecipe.resources),
+            `expected resources to be an Array, instead it is type "${typeof newRecipe.resources}"`
+        );
+        assert(
+            newRecipe.resources.length === oldResources.length,
+            `initial resources should be length ${oldResources.length}, not ${newRecipe.resources.length}`
+        );
         assertService(newRecipe.resources[0], oldEndpoint);
     });
 
-    it(`should create an empty recipe without any args using .fromJSON().`, () => {
+    it('should create an empty recipe without any args using .fromJSON().', function () {
         const newRecipe = BotRecipe.fromJSON();
-        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${ newRecipe.version }`);
-        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${ newRecipe.resources.length }`);
+        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${newRecipe.version}`);
+        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${newRecipe.resources.length}`);
 
         const keys = Object.keys(newRecipe).length;
-        assert(keys === 2, `expected 2 keys, found ${ keys }`);
+        assert(keys === 2, `expected 2 keys, found ${keys}`);
     });
 
-    it(`should create a new recipe with .toJSON().`, () => {
+    it('should create a new recipe with .toJSON().', function () {
         const newRecipe = recipe.toJSON();
-        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${ newRecipe.version }`);
-        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${ newRecipe.resources.length }`);
+        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${newRecipe.version}`);
+        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${newRecipe.resources.length}`);
     });
 });

--- a/libraries/botframework-config/tests/connect.test.js
+++ b/libraries/botframework-config/tests/connect.test.js
@@ -1,75 +1,75 @@
-let assert = require('assert');
-let bf = require('../lib');
+const assert = require('assert');
+const bf = require('../lib');
 
 // do not save over testbot
-const testBotPath = require.resolve("./test.bot");
+const testBotPath = require.resolve('./test.bot');
 
-describe("ServiceManipulation", () => {
+describe('ServiceManipulation', function () {
     let config;
 
-    before(async () => {
+    before(async function () {
         config = await bf.BotConfiguration.load(testBotPath);
     });
 
     function mapServices(baseConfig, targetConfig) {
-        for (let service of baseConfig.services) {
+        for (const service of baseConfig.services) {
             targetConfig.connectService(service);
         }
 
-        let map = {};
-        for (let service of targetConfig.services) {
+        const map = {};
+        for (const service of targetConfig.services) {
             map[service.id] = service;
         }
         return map;
-    };
+    }
 
-    it("ConnectAssignsUniqueIds", async () => {
-        var config = await bf.BotConfiguration.load(testBotPath);
-        var config2 = new bf.BotConfiguration();
-        for (let service of config.services) {
+    it('ConnectAssignsUniqueIds', async function () {
+        const config = await bf.BotConfiguration.load(testBotPath);
+        const config2 = new bf.BotConfiguration();
+        for (const service of config.services) {
             service.id = undefined;
             config2.connectService(service);
         }
 
-        let map = {};
-        for (let service of config2.services) {
-            assert.ok(!map.hasOwnProperty(service.id), "Duplicate Id assigned");
+        const map = {};
+        for (const service of config2.services) {
+            assert.ok(!Object.prototype.hasOwnProperty.call(map, service.id), 'Duplicate Id assigned');
             map[service.id] = service;
         }
     });
 
-    it("FindServices", async () => {
-        assert.ok(config.findServiceByNameOrId("3"), "should find by id");
-        assert.ok(config.findServiceByNameOrId("testInsights"), "should find by name");
-        assert.ok(config.findService("3"), "should find by id");
-        assert.equal(config.findService("testInsights"), null, "should not find by name");
+    it('FindServices', async function () {
+        assert.ok(config.findServiceByNameOrId('3'), 'should find by id');
+        assert.ok(config.findServiceByNameOrId('testInsights'), 'should find by name');
+        assert.ok(config.findService('3'), 'should find by id');
+        assert.equal(config.findService('testInsights'), null, 'should not find by name');
     });
 
-    it("DisconnectServicesById", async () => {
-        var config2 = new bf.BotConfiguration();
-        var map = mapServices(config, config2);
+    it('DisconnectServicesById', async function () {
+        const config2 = new bf.BotConfiguration();
+        const map = mapServices(config, config2);
 
-        for (let prop in map) {
+        for (const prop in map) {
             config2.disconnectService(map[prop].id);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");
     });
 
-    it("DisconnectServicesByNameOrId_UsingId", async () => {
-        var config2 = new bf.BotConfiguration();
-        var map = mapServices(config, config2);
+    it('DisconnectServicesByNameOrId_UsingId', async function () {
+        const config2 = new bf.BotConfiguration();
+        const map = mapServices(config, config2);
 
-        for (let prop in map) {
+        for (const prop in map) {
             config2.disconnectServiceByNameOrId(map[prop].id);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");
     });
 
-    it("DisconnectByNameOrId_UsingName", async () => {
-        var config2 = new bf.BotConfiguration();
-        var map = mapServices(config, config2);
+    it('DisconnectByNameOrId_UsingName', async function () {
+        const config2 = new bf.BotConfiguration();
+        const map = mapServices(config, config2);
 
-        for (let prop in map) {
+        for (const prop in map) {
             config2.disconnectServiceByNameOrId(map[prop].name);
         }
         assert.equal(config2.services.length, 0, "didn't remove all services");

--- a/libraries/botframework-config/tests/service.test.js
+++ b/libraries/botframework-config/tests/service.test.js
@@ -1,50 +1,49 @@
-let assert = require('assert');
-let bf = require('../lib');
-let fs = require('fs');
-let path = require('path');
-let txtfile = require('read-text-file');
+const assert = require('assert');
+const bf = require('../lib');
 
-describe("Service Tests", () => {
-    it("Luis.getEndpoint() returns correct url for region", async () => {
-        let luis = new bf.LuisService({ region: "westus" });
-        assert.equal(luis.getEndpoint(), `https://westus.api.cognitive.microsoft.com`);
+describe('Service Tests', function () {
+    it('Luis.getEndpoint() returns correct url for region', async function () {
+        let luis = new bf.LuisService({ region: 'westus' });
+        assert.equal(luis.getEndpoint(), 'https://westus.api.cognitive.microsoft.com');
 
-        luis = new bf.LuisService({ region: "virginia" });
-        assert.equal(luis.getEndpoint(),  `https://virginia.api.cognitive.microsoft.us`);
+        luis = new bf.LuisService({ region: 'virginia' });
+        assert.equal(luis.getEndpoint(), 'https://virginia.api.cognitive.microsoft.us');
 
-        luis = new bf.LuisService({ region: "usgovvirginia" });
-        assert.equal(luis.getEndpoint(),  `https://virginia.api.cognitive.microsoft.us`);
+        luis = new bf.LuisService({ region: 'usgovvirginia' });
+        assert.equal(luis.getEndpoint(), 'https://virginia.api.cognitive.microsoft.us');
 
-        luis = new bf.LuisService({ region: "usgoviowa" });
-        assert.equal(luis.getEndpoint(),  `https://usgoviowa.api.cognitive.microsoft.us`);
+        luis = new bf.LuisService({ region: 'usgoviowa' });
+        assert.equal(luis.getEndpoint(), 'https://usgoviowa.api.cognitive.microsoft.us');
     });
 
-    it("QNAMaker corretly adds suffix", () => {
+    it('QNAMaker corretly adds suffix', function () {
         let qna = new bf.QnaMakerService({
-            hostname: "https://myservice.azurewebsites.net"
+            hostname: 'https://myservice.azurewebsites.net',
         });
-        assert.equal(qna.hostname, "https://myservice.azurewebsites.net/qnamaker");
+        assert.equal(qna.hostname, 'https://myservice.azurewebsites.net/qnamaker');
         qna = new bf.QnaMakerService({
-            hostname: "https://myservice.azurewebsites.net/sdfasdfsadfsdf?x=13"
+            hostname: 'https://myservice.azurewebsites.net/sdfasdfsadfsdf?x=13',
         });
-        assert.equal(qna.hostname, "https://myservice.azurewebsites.net/qnamaker");
+        assert.equal(qna.hostname, 'https://myservice.azurewebsites.net/qnamaker');
     });
 
-    it("QnAMaker correctly does not add suffix when already hostname endind with \/qnamaker", () => {
-        let qnaWithQnamakerHostname = new bf.QnaMakerService({
-            hostname: "https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker"
+    it('QnAMaker correctly does not add suffix when already hostname endind with /qnamaker', function () {
+        const qnaWithQnamakerHostname = new bf.QnaMakerService({
+            hostname: 'https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker',
         });
-        assert.equal(qnaWithQnamakerHostname.hostname, "https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker");
+        assert.equal(
+            qnaWithQnamakerHostname.hostname,
+            'https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker'
+        );
     });
 
-    it("QnAMaker should throw error without hostname", () => {
+    it('QnAMaker should throw error without hostname', function () {
         function createQnaWithoutHostname() {
             new bf.QnaMakerService({});
         }
 
-        let noHostnameError = new TypeError('QnAMakerService requires source parameter to have a hostname.')
+        const noHostnameError = new TypeError('QnAMakerService requires source parameter to have a hostname.');
 
-        assert.throws(() => createQnaWithoutHostname(), noHostnameError)
+        assert.throws(() => createQnaWithoutHostname(), noHostnameError);
     });
 });
-


### PR DESCRIPTION
Addresses # 4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the `botframework-config` library.

**_Note: we excluded the @typescript-eslint/no-explicit-any and @typescript-eslint/explicit-module-boundary-types to tackle those issues as a separate task, as they require deeper analysis and testing._**

## Specific Changes
- Applied auto-fixes with `yarn lint --fix`
   - Add a blank line in between comments.
   - Fix spacing.
   - Fix quoting.
   - Replace arrow functions: `() =>` with `function ()`.
   - Replace `let` with `const`. 
- Applied manual fixes for: 
  - Missing documentation.
  - Unused parameters and imports.
  - Replacing `hasOwnProperty` calls.
  - Removed unused `catch` error variables.
  - Updated methods documentation in `botframework-config.md`.

## Testing
Here we can see the ESLint status before and after.
![image](https://user-images.githubusercontent.com/62260472/165805922-3b98ce02-0238-4e4e-8efb-158dbdb1fdba.png)