### PR TITLE
fix: [#4204] Fix remaining eslint warnings - botbuilder-lg

### DIFF
--- a/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
+++ b/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
@@ -1667,13 +1667,10 @@ export class TemplateNameLineContext extends ParserRuleContext_2 {
 
 // @public
 export class Templates implements Iterable<Template> {
-    // (undocumented)
     [Symbol.iterator](): Iterator<Template>;
     constructor(items?: Template[], imports?: TemplateImport[], diagnostics?: Diagnostic[], references?: Templates[], content?: string, id?: string, expressionParser?: ExpressionParser, importResolverDelegate?: ImportResolverDelegate, options?: string[], source?: string, namedReferences?: Record<string, Templates>);
     addTemplate(templateName: string, parameters: string[], templateBody: string): Templates;
-    // (undocumented)
     readonly allDiagnostics: Diagnostic[];
-    // (undocumented)
     readonly allTemplates: Template[];
     analyzeTemplate(templateName: string, analyzerOptions?: AnalyzerOptions): AnalyzerResult;
     content: string;
@@ -1688,10 +1685,8 @@ export class Templates implements Iterable<Template> {
     importResolver: ImportResolverDelegate;
     imports: TemplateImport[];
     static readonly inlineTemplateIdPrefix: string;
-    // (undocumented)
     readonly lgOptions: EvaluationOptions;
     namedReferences: Record<string, Templates>;
-    // (undocumented)
     readonly namespace: string;
     options: string[];
     static parseFile(filePath: string, importResolver?: ImportResolverDelegate, expressionParser?: ExpressionParser): Templates;
@@ -1701,7 +1696,6 @@ export class Templates implements Iterable<Template> {
     push(...args: Template[]): void;
     references: Templates[];
     source: string;
-    // (undocumented)
     toArray(): Template[];
     toString(): string;
     updateTemplate(templateName: string, newTemplateName: string, parameters: string[], templateBody: string): Templates;

--- a/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
+++ b/libraries/botbuilder-lg/etc/botbuilder-lg.api.md
@@ -1667,10 +1667,13 @@ export class TemplateNameLineContext extends ParserRuleContext_2 {
 
 // @public
 export class Templates implements Iterable<Template> {
+    // (undocumented)
     [Symbol.iterator](): Iterator<Template>;
     constructor(items?: Template[], imports?: TemplateImport[], diagnostics?: Diagnostic[], references?: Templates[], content?: string, id?: string, expressionParser?: ExpressionParser, importResolverDelegate?: ImportResolverDelegate, options?: string[], source?: string, namedReferences?: Record<string, Templates>);
     addTemplate(templateName: string, parameters: string[], templateBody: string): Templates;
+    // (undocumented)
     readonly allDiagnostics: Diagnostic[];
+    // (undocumented)
     readonly allTemplates: Template[];
     analyzeTemplate(templateName: string, analyzerOptions?: AnalyzerOptions): AnalyzerResult;
     content: string;
@@ -1685,8 +1688,10 @@ export class Templates implements Iterable<Template> {
     importResolver: ImportResolverDelegate;
     imports: TemplateImport[];
     static readonly inlineTemplateIdPrefix: string;
+    // (undocumented)
     readonly lgOptions: EvaluationOptions;
     namedReferences: Record<string, Templates>;
+    // (undocumented)
     readonly namespace: string;
     options: string[];
     static parseFile(filePath: string, importResolver?: ImportResolverDelegate, expressionParser?: ExpressionParser): Templates;
@@ -1696,6 +1701,7 @@ export class Templates implements Iterable<Template> {
     push(...args: Template[]): void;
     references: Templates[];
     source: string;
+    // (undocumented)
     toArray(): Template[];
     toString(): string;
     updateTemplate(templateName: string, newTemplateName: string, parameters: string[], templateBody: string): Templates;

--- a/libraries/botbuilder-lg/src/analyzer.ts
+++ b/libraries/botbuilder-lg/src/analyzer.ts
@@ -16,7 +16,7 @@ import { LGTemplateParserVisitor } from './generated/LGTemplateParserVisitor';
 import { Template } from './template';
 import { TemplateExtensions } from './templateExtensions';
 import { Templates } from './templates';
-import { keyBy } from 'lodash';
+import keyBy = require('lodash/keyBy');
 
 import {
     IfConditionRuleContext,
@@ -68,6 +68,7 @@ export class Analyzer
 
     /**
      * Analyze a template to get the static analyzer results.
+     *
      * @param templateName Template name.
      * @returns Analyze result including variables and template references.
      */
@@ -108,6 +109,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -117,6 +119,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -131,6 +134,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -152,6 +156,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredValue.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -175,6 +180,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -197,6 +203,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -218,6 +225,7 @@ export class Analyzer
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     *
      * @param ctx The parse tree.
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
@@ -233,7 +241,7 @@ export class Analyzer
 
     /**
      * Gets the default value returned by visitor methods.
-     * @returns An instance of the AnalyzerResult class.
+     *
      * @returns The [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) instance.
      */
     protected defaultResult(): AnalyzerResult {

--- a/libraries/botbuilder-lg/src/analyzerResult.ts
+++ b/libraries/botbuilder-lg/src/analyzerResult.ts
@@ -22,6 +22,7 @@ export class AnalyzerResult {
 
     /**
      * Creates a new instance of the [AnalyzerResult](xref:botbuilder-lg.AnalyzerResult) class.
+     *
      * @param variables Init varibales.
      * @param templateRefNames Init template references.
      */
@@ -32,6 +33,7 @@ export class AnalyzerResult {
 
     /**
      * Combine two analyzer results.
+     *
      * @param outputItem Another analyzer result.
      * @returns Combined analyzer result.
      */

--- a/libraries/botbuilder-lg/src/customizedMemory.ts
+++ b/libraries/botbuilder-lg/src/customizedMemory.ts
@@ -26,6 +26,7 @@ export class CustomizedMemory implements MemoryInterface {
 
     /**
      * Creates a new instance of the [CustomizedMemory](xref:botbuilder-lg.CustomizedMemory) class.
+     *
      * @param scope Optional. Scope.
      * @param localMemory Optional. Local memory.
      */
@@ -37,6 +38,7 @@ export class CustomizedMemory implements MemoryInterface {
     /**
      *  Try to get the value from a given path. Firstly, get result from global memory,
      *  if global memory does not contain, get from local memory.
+     *
      * @param path Memory path.
      * @returns Resolved value.
      */
@@ -57,6 +59,7 @@ export class CustomizedMemory implements MemoryInterface {
 
     /**
      * Set value to a given path. This method is not implemented.
+     *
      * @param _path Memory path.
      * @param _value Value to set.
      */
@@ -68,6 +71,7 @@ export class CustomizedMemory implements MemoryInterface {
     /**
      * Used to identify whether a particular memory instance has been updated or not.
      * If version is not changed, the caller may choose to use the cached result instead of recomputing everything.
+     *
      * @returns A string indicating the version.
      */
     public version(): string {

--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -31,6 +31,7 @@ export class Diagnostic {
 
     /**
      * Creates a new instance of the [Diagnostic](xref:botbuilder-lg.Diagnostic) class.
+     *
      * @param range Range where the error or warning occurred.
      * @param message Error message of the error or warning.
      * @param severity Severity of the error or warning.
@@ -53,6 +54,7 @@ export class Diagnostic {
 
     /**
      * Returns a string that represents the current [Diagnostic](xref:botbuilder-lg.Diagnostic) object.
+     *
      * @returns A string that represents the current [Diagnostic](xref:botbuilder-lg.Diagnostic).
      */
     public toString(): string {

--- a/libraries/botbuilder-lg/src/errorListener.ts
+++ b/libraries/botbuilder-lg/src/errorListener.ts
@@ -21,6 +21,7 @@ export class ErrorListener implements ANTLRErrorListener<void> {
 
     /**
      * Creates a new instance of the [ErrorListener](xref:botbuilder-lg.ErrorListener) class.
+     *
      * @param errorSource String value that represents the source of the error.
      * @param lineOffset Offset of the line where the error occurred.
      */
@@ -34,6 +35,7 @@ export class ErrorListener implements ANTLRErrorListener<void> {
 
     /**
      * Notifies any interested parties upon a syntax error.
+     *
      * @param recognizer What parser got the error. From this object, you can access the context as well as the input stream.
      * @param offendingSymbol Offending token in the input token stream, unless recognizer is a lexer (then it's null).
      * @param line Line number in the input where the error occurred.

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -59,6 +59,7 @@ export class EvaluationOptions {
 
     /**
      * Creates a new instance of the [EvaluationOptions](xref:botbuilder-lg.EvaluationOptions) class.
+     *
      * @param opt Instance to copy initial settings from.
      */
     public constructor(opt?: EvaluationOptions | string[]) {
@@ -86,7 +87,7 @@ export class EvaluationOptions {
                                     this.strictMode = true;
                                 }
                             } else if (key.toLowerCase() === this.replaceNullKey.toLowerCase()) {
-                                this.nullSubstitution = (path) =>
+                                this.nullSubstitution = (_path) =>
                                     // eslint-disable-next-line security/detect-eval-with-expression
                                     eval('`' + value.replace(this.nullKeyReplaceStrRegex, '${path}') + '`');
                             } else if (key.toLowerCase() === this.lineBreakKey.toLowerCase()) {
@@ -112,6 +113,7 @@ export class EvaluationOptions {
     /**
      * Merges an incoming option to current option. If a property in incoming option is not null while it is null in current
      * option, then the value of this property will be overwritten.
+     *
      * @param opt Incoming option for merging.
      * @returns Result after merging.
      */

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -87,7 +87,8 @@ export class EvaluationOptions {
                                     this.strictMode = true;
                                 }
                             } else if (key.toLowerCase() === this.replaceNullKey.toLowerCase()) {
-                                this.nullSubstitution = (_path) =>
+                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                this.nullSubstitution = (path) =>
                                     // eslint-disable-next-line security/detect-eval-with-expression
                                     eval('`' + value.replace(this.nullKeyReplaceStrRegex, '${path}') + '`');
                             } else if (key.toLowerCase() === this.lineBreakKey.toLowerCase()) {

--- a/libraries/botbuilder-lg/src/evaluationTarget.ts
+++ b/libraries/botbuilder-lg/src/evaluationTarget.ts
@@ -28,6 +28,7 @@ export class EvaluationTarget {
 
     /**
      * Creates a new instance of the [EvaluationTarget](xref:botbuilder-lg.EvaluationTarget) class.
+     *
      * @param templateName Template name.
      * @param scope Template scope.
      */
@@ -40,6 +41,7 @@ export class EvaluationTarget {
     /**
      * Get current instance id. If two target has the same Id,
      * we can say they have the same template evaluation result.
+     *
      * @returns Id.
      */
     public getId(): string {

--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -1,4 +1,5 @@
 /* eslint-disable security/detect-object-injection */
+/* eslint-disable security/detect-non-literal-fs-filename */
 /**
  * @module botbuilder-lg
  */
@@ -18,7 +19,7 @@ import { Template } from './template';
 import { TemplateErrors } from './templateErrors';
 import { TemplateExtensions } from './templateExtensions';
 import { Templates } from './templates';
-import { keyBy } from 'lodash';
+import keyBy = require('lodash/keyBy');
 
 import {
     Constant,
@@ -104,6 +105,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Creates a new instance of the [Evaluator](xref:botbuilder-lg.Evaluator) class.
+     *
      * @param templates Templates.
      * @param opt Options for LG.
      */
@@ -122,6 +124,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Evaluate a template with given name and scope.
+     *
      * @param inputTemplateName Template name.
      * @param scope Scope.
      * @returns Evaluate result.
@@ -193,6 +196,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredTemplateBody.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the structured template body.
      */
@@ -222,7 +226,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
                     propertyObject[Evaluator.LGType].toString() === typeName
                 ) {
                     for (const key of Object.keys(propertyObject)) {
-                        if (propertyObject.hasOwnProperty(key) && !(key in result)) {
+                        if (Object.prototype.hasOwnProperty.call(propertyObject, key) && !(key in result)) {
                             result[key] = propertyObject[key];
                         }
                     }
@@ -249,7 +253,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
                 let itemStringResult = '';
                 for (const child of item.children) {
                     if (child instanceof ExpressionInStructureContext) {
-                        const errorPrefix = `Property '` + ctx.STRUCTURE_IDENTIFIER().text + `':`;
+                        const errorPrefix = "Property '" + ctx.STRUCTURE_IDENTIFIER().text + "':";
                         itemStringResult += this.evalExpression(child.text, child, ctx.text, errorPrefix);
                     } else {
                         const node = child as TerminalNode;
@@ -273,6 +277,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the normal body.
      */
@@ -282,6 +287,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the normal template body.
      */
@@ -294,7 +300,9 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
+     * @returns The visitor result.
      */
     public visitIfElseBody(ctx: IfElseBodyContext): unknown {
         const ifRules: IfConditionRuleContext[] = ctx.ifElseTemplateBody().ifConditionRule();
@@ -309,6 +317,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     *
      * @param ctx The parse tree.
      * @returns The string result of visiting the normal template string.
      */
@@ -354,6 +363,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
     /**
      * Constructs the scope for mapping the values of arguments to the parameters of the template.
      * Throws errors if certain errors detected [TemplateErrors](xref:botbuilder-lg.TemplateErrors).
+     *
      * @param inputTemplateName Template name to evaluate.
      * @param args Arguments to map to the template parameters.
      * @param allTemplates All templates.
@@ -388,6 +398,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The string result of visiting the switch case body.
      */
@@ -396,7 +407,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
         const length: number = switchcaseNodes.length;
         const switchNode: SwitchCaseRuleContext = switchcaseNodes[0];
         const switchExprs = switchNode.switchCaseStat().expression();
-        const switchErrorPrefix = `Switch '` + switchExprs[0].text + `': `;
+        const switchErrorPrefix = "Switch '" + switchExprs[0].text + "': ";
         const switchExprResult = this.evalExpression(
             switchExprs[0].text,
             switchExprs[0],
@@ -419,7 +430,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
             }
 
             const caseExprs = caseNode.switchCaseStat().expression();
-            const caseErrorPrefix = `Case '` + caseExprs[0].text + `': `;
+            const caseErrorPrefix = "Case '" + caseExprs[0].text + "': ";
             const caseExprResult = this.evalExpression(
                 caseExprs[0].text,
                 caseExprs[0],
@@ -438,8 +449,10 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Replaces an expression contained in text.
+     *
      * @param exp Expression Text.
      * @param regex Regex to select the text to replace.
+     * @returns Text with expression replaced.
      */
     public wrappedEvalTextContainsExpression(exp: string, regex: RegExp): string {
         return exp
@@ -456,6 +469,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Gets the default value returned by visitor methods.
+     *
      * @returns Empty string.
      */
     protected defaultResult(): string {
@@ -464,6 +478,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Concatenates two error messages.
+     *
      * @param firstError First error message to concatenate.
      * @param secondError Second error message to concatenate.
      * @returns The concatenated error messages.
@@ -482,6 +497,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
 
     /**
      * Checks an expression result and throws the corresponding error.
+     *
      * @param exp Expression text.
      * @param error Error message.
      * @param result Result.
@@ -536,7 +552,7 @@ export class Evaluator extends AbstractParseTreeVisitor<unknown> implements LGTe
             return true; // no expression means it's else
         }
 
-        if (this.evalExpressionInCondition(expression, condition.text, `Condition '` + expression.text + `':`)) {
+        if (this.evalExpressionInCondition(expression, condition.text, "Condition '" + expression.text + "':")) {
             return true;
         }
 

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -94,7 +94,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
         this.templateMap = keyBy(templates.allTemplates, (t: Template): string => t.name);
         this.lgOptions = opt;
 
-        // generate a new customized expression parser by injecting the template as functions
+        // Generate a new customized expression parser by injecting the template as functions.
         this.expanderExpressionParser = new ExpressionParser(
             this.customizedEvaluatorLookup(templates.expressionParser.EvaluatorLookup, true)
         );
@@ -415,7 +415,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
      * @param inputTemplateName The template name to evaluate.
      * @param args Arguments to map to the template parameters.
      * @param allTemplates All templates.
-     * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory
+     * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory.
      * with the mapping of the parameter name to the argument value added to the scope.
      */
     public constructScope(inputTemplateName: string, args: unknown[], allTemplates: Template[]): MemoryInterface {

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -1,4 +1,5 @@
 /* eslint-disable security/detect-object-injection */
+/* eslint-disable security/detect-non-literal-fs-filename */
 /**
  * @module botbuilder-lg
  */
@@ -19,7 +20,7 @@ import { Template } from './template';
 import { TemplateErrors } from './templateErrors';
 import { TemplateExtensions } from './templateExtensions';
 import { Templates } from './templates';
-import { keyBy } from 'lodash';
+import keyBy = require('lodash/keyBy');
 
 import {
     Constant,
@@ -83,8 +84,8 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Creates a new instance of the Expander class.
+     *
      * @param templates Template list.
-     * @param expressionParser Given expression parser.
      * @param opt Options for LG.
      */
     public constructor(templates: Templates, opt?: EvaluationOptions) {
@@ -93,7 +94,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
         this.templateMap = keyBy(templates.allTemplates, (t: Template): string => t.name);
         this.lgOptions = opt;
 
-        // generate a new customzied expression parser by injecting the template as functions
+        // generate a new customized expression parser by injecting the template as functions
         this.expanderExpressionParser = new ExpressionParser(
             this.customizedEvaluatorLookup(templates.expressionParser.EvaluatorLookup, true)
         );
@@ -104,6 +105,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Expand the results of a template with given name and scope.
+     *
      * @param templateName Given template name.
      * @param scope Given scope.
      * @returns All possiable results.
@@ -136,6 +138,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by the normalBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the normal body.
      */
@@ -145,6 +148,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the normal template body.
      */
@@ -160,7 +164,9 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
+     * @returns The result of visiting if-else body.
      */
     public visitIfElseBody(ctx: IfElseBodyContext): unknown[] {
         const ifRules: IfConditionRuleContext[] = ctx.ifElseTemplateBody().ifConditionRule();
@@ -175,6 +181,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by LGTemplateParser.structuredBody.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the structured body.
      */
@@ -236,7 +243,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
                             propertyObject[Evaluator.LGType].toString() === typeName
                         ) {
                             for (const key of Object.keys(propertyObject)) {
-                                if (propertyObject.hasOwnProperty(key) && !(key in tempRes)) {
+                                if (Object.prototype.hasOwnProperty.call(propertyObject, key) && !(key in tempRes)) {
                                     tempRes[key] = propertyObject[key];
                                 }
                             }
@@ -316,6 +323,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param ctx The parse tree.
      * @returns The result of visiting the switch case body.
      */
@@ -367,7 +375,9 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateString.
+     *
      * @param ctx The parse tree.
+     * @returns The result of visiting NormalTemplateString.
      */
     public visitNormalTemplateString(ctx: NormalTemplateStringContext): unknown[] {
         const prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(ctx);
@@ -401,7 +411,8 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Constructs the scope for mapping the values of arguments to the parameters of the template.
-     * @param templateName The template name to evaluate.
+     *
+     * @param inputTemplateName The template name to evaluate.
      * @param args Arguments to map to the template parameters.
      * @param allTemplates All templates.
      * @returns The current scope if the number of arguments is 0, otherwise, returns a CustomizedMemory
@@ -435,6 +446,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
 
     /**
      * Gets the default value returned by visitor methods.
+     *
      * @returns Empty string array.
      */
     protected defaultResult(): string[] {
@@ -457,7 +469,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
             return true; // no expression means it's else
         }
 
-        if (this.evalExpressionInCondition(expression, condition.text, `Condition '` + expression.text + `':`)) {
+        if (this.evalExpressionInCondition(expression, condition.text, "Condition '" + expression.text + "':")) {
             return true;
         }
 

--- a/libraries/botbuilder-lg/src/extractor.ts
+++ b/libraries/botbuilder-lg/src/extractor.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { AbstractParseTreeVisitor, TerminalNode } from 'antlr4ts/tree';
-import { keyBy } from 'lodash';
+import keyBy = require('lodash/keyBy');
 import { LGTemplateParserVisitor } from './generated/LGTemplateParserVisitor';
 import { Template } from './template';
 
@@ -33,6 +33,7 @@ export class Extractor
 
     /**
      * Creates a new instance of the [Extractor](xref:botbuilder-lg.Extractor) class.
+     *
      * @param templates Template list.
      */
     public constructor(templates: Template[]) {
@@ -43,6 +44,7 @@ export class Extractor
 
     /**
      * Extracts the templates and returns a map with their names and bodies.
+     *
      * @returns Map object with template names and bodies.
      */
     public extract(): Map<string, string[] | Map<string, string[]>>[] {
@@ -74,6 +76,7 @@ export class Extractor
 
     /**
      * Visit a parse tree produced by LGTemplateParser.normalTemplateBody.
+     *
      * @param context The parse tree.
      * @returns The result of visiting the normal template body.
      */
@@ -88,6 +91,7 @@ export class Extractor
 
     /**
      * Visit a parse tree produced by the structuredBody labeled alternative in LGTemplateParser.body.
+     *
      * @param context The parse tree.
      * @returns The result of visiting the structured body.
      */
@@ -108,6 +112,7 @@ export class Extractor
 
     /**
      * Visit a parse tree produced by the ifElseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param context The parse tree.
      * @returns The result of visiting the if else body.
      */
@@ -146,6 +151,7 @@ export class Extractor
 
     /**
      * Visit a parse tree produced by the switchCaseBody labeled alternative in LGTemplateParser.body.
+     *
      * @param context The parse tree.
      * @returns The result of visiting the switch case body.
      */
@@ -185,6 +191,7 @@ export class Extractor
 
     /**
      * Gets the default value returned by visitor methods.
+     *
      * @returns Empty Map<string,  string[]>.
      */
     protected defaultResult(): Map<string, string[]> {

--- a/libraries/botbuilder-lg/src/lgResource.ts
+++ b/libraries/botbuilder-lg/src/lgResource.ts
@@ -28,6 +28,7 @@ export class LGResource {
 
     /**
      * Creates a new instance of the [LGResource](xref:botbuilder-lg.LGResource) class.
+     *
      * @param id Resource id.
      * @param fullName The full path to the resource on disk.
      * @param content Resource content.

--- a/libraries/botbuilder-lg/src/multiLanguageLG.ts
+++ b/libraries/botbuilder-lg/src/multiLanguageLG.ts
@@ -869,6 +869,7 @@ export class MultiLanguageLG {
 
     /**
      * Initializes a new instance of the MultiLanguageLG class.
+     *
      * @param templatesPerLocale A map of LG file templates per locale.
      * @param filePerLocale A map of locale and LG file.
      * @param defaultLanguage Default language.
@@ -881,7 +882,7 @@ export class MultiLanguageLG {
         if (templatesPerLocale !== undefined) {
             this.lgPerLocale = templatesPerLocale;
         } else if (filePerLocale === undefined) {
-            throw new Error(`input is empty`);
+            throw new Error('input is empty');
         } else {
             this.lgPerLocale = new Map<string, Templates>();
             for (const item of filePerLocale.entries()) {
@@ -895,9 +896,11 @@ export class MultiLanguageLG {
 
     /**
      * Generate template evaluate result.
+     *
      * @param template Template name.
      * @param data Scope data.
      * @param locale Locale info.
+     * @returns The evaluated template result.
      */
     public generate(template: string, data?: object, locale?: string): any {
         if (!template) {

--- a/libraries/botbuilder-lg/src/position.ts
+++ b/libraries/botbuilder-lg/src/position.ts
@@ -15,6 +15,7 @@ export class Position {
 
     /**
      * Creates a new instance of the [Position](xref:botbuilder-lg.Position) class.
+     *
      * @param line Line number of the current position.
      * @param character Character number of the current line.
      */

--- a/libraries/botbuilder-lg/src/range.ts
+++ b/libraries/botbuilder-lg/src/range.ts
@@ -18,6 +18,7 @@ export class Range {
 
     /**
      * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
+     *
      * @param start Starting [Position](xref:botbuilder-lg.Position).
      * @param end Ending [Position](xref:botbuilder-lg.Position).
      */
@@ -25,6 +26,7 @@ export class Range {
 
     /**
      * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
+     *
      * @param x Starting line number in a file.
      * @param y Starting character number in a file.
      * @param endLine Ending line number in a file.
@@ -34,6 +36,7 @@ export class Range {
 
     /**
      * Creates a new instance of the [Range](xref:botbuilder-lg.Range) class.
+     *
      * @param x Starting line number in a file or [Position](xref:botbuilder-lg.Position).
      * @param y Starting character number in a file or [Position](xref:botbuilder-lg.Position).
      * @param endLine Optional. Ending line number in a file.

--- a/libraries/botbuilder-lg/src/sourceRange.ts
+++ b/libraries/botbuilder-lg/src/sourceRange.ts
@@ -26,6 +26,7 @@ export class SourceRange {
 
     /**
      * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     *
      * @param parseTree `ParserRuleContext`. Rule invocation record for parsing.
      * @param source Optional. Source, used as the lg file path.
      * @param offset Optional. Offset in the parse tree.
@@ -34,6 +35,7 @@ export class SourceRange {
 
     /**
      * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     *
      * @param range [Range](xref:botbuilder-lg.Range) of block.
      * @param source Optional. Source, used as the lg file path.
      */
@@ -41,6 +43,7 @@ export class SourceRange {
 
     /**
      * Creates a new instance of the [SourceRange](xref:botbuilder-lg.SourceRange) class.
+     *
      * @param x [Range](xref:botbuilder-lg.Range) of block or `ParserRuleContext`, rule invocation record for parsing.
      * @param source Optional. Source, used as the lg file path.
      * @param offset Optional. Offset in the parse tree.

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -42,6 +42,7 @@ export class StaticChecker
 
     /**
      * Creates a new instance of the [StaticChecker](xref:botbuilder-lg.StaticChecker) class.
+     *
      * @param templates [Templates](xref:botbuilder-lg.Templates) to be checked.
      */
     public constructor(templates: Templates) {
@@ -65,6 +66,7 @@ export class StaticChecker
 
     /**
      * Return error messages list.
+     *
      * @returns Report result.
      */
     public check(): Diagnostic[] {
@@ -115,7 +117,9 @@ export class StaticChecker
 
     /**
      * Visit a parse tree produced by `LGTemplateParser.normalTemplateBody`.
+     *
      * @param context The parse tree.
+     * @returns The result of visiting normal template body.
      */
     public visitNormalTemplateBody(context: NormalTemplateBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
@@ -134,7 +138,9 @@ export class StaticChecker
 
     /**
      * Visit a parse tree produced by `LGTemplateParser.structuredTemplateBody`.
+     *
      * @param context The parse tree.
+     * @returns The result of visiting structured template body.
      */
     public visitStructuredTemplateBody(context: StructuredTemplateBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
@@ -169,7 +175,7 @@ export class StaticChecker
                         result = result.concat(this.checkExpression(body.expressionInStructure()));
                     } else {
                         const structureValues = body.keyValueStructureLine().keyValueStructureValue();
-                        const errorPrefix = `Property  '` + body.keyValueStructureLine().text + `':`;
+                        const errorPrefix = "Property  '" + body.keyValueStructureLine().text + "':";
                         for (const structureValue of structureValues) {
                             for (const expr of structureValue.expressionInStructure()) {
                                 result = result.concat(this.checkExpression(expr, errorPrefix));
@@ -185,7 +191,9 @@ export class StaticChecker
 
     /**
      * Visit a parse tree produced by the `ifElseBody` labeled alternative in `LGTemplateParser.body`.
+     *
      * @param context The parse tree.
+     * @returns The result of visiting if-else body.
      */
     public visitIfElseBody(context: IfElseBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
@@ -244,7 +252,7 @@ export class StaticChecker
                         this.buildLGDiagnostic(TemplateErrors.invalidExpressionInCondition, undefined, conditionNode)
                     );
                 } else {
-                    const errorPrefix = `Condition '` + conditionNode.expression(0).text + `': `;
+                    const errorPrefix = "Condition '" + conditionNode.expression(0).text + "': ";
                     result = result.concat(this.checkExpression(conditionNode.expression(0), errorPrefix));
                 }
             } else {
@@ -270,7 +278,9 @@ export class StaticChecker
 
     /**
      * Visit a parse tree produced by the `switchCaseBody` labeled alternative in `LGTemplateParser.body`.
+     *
      * @param context The parse tree.
+     * @returns The result of visiting switch-case body
      */
     public visitSwitchCaseBody(context: SwitchCaseBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
@@ -375,7 +385,9 @@ export class StaticChecker
 
     /**
      * Visit a parse tree produced by `LGTemplateParser.normalTemplateString`.
+     *
      * @param context The parse tree.
+     * @returns The result of visiting normal template string
      */
     public visitNormalTemplateString(context: NormalTemplateStringContext): Diagnostic[] {
         const prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(context);
@@ -396,6 +408,7 @@ export class StaticChecker
 
     /**
      * Gets the default value returned by visitor methods.
+     *
      * @returns Empty [Diagnostic](xref:botbuilder-lg.Diagnostic) array.
      */
     protected defaultResult(): Diagnostic[] {

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -280,7 +280,7 @@ export class StaticChecker
      * Visit a parse tree produced by the `switchCaseBody` labeled alternative in `LGTemplateParser.body`.
      *
      * @param context The parse tree.
-     * @returns The result of visiting switch-case body
+     * @returns The result of visiting switch-case body.
      */
     public visitSwitchCaseBody(context: SwitchCaseBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
@@ -387,7 +387,7 @@ export class StaticChecker
      * Visit a parse tree produced by `LGTemplateParser.normalTemplateString`.
      *
      * @param context The parse tree.
-     * @returns The result of visiting normal template string
+     * @returns The result of visiting normal template string.
      */
     public visitNormalTemplateString(context: NormalTemplateStringContext): Diagnostic[] {
         const prefixErrorMsg = TemplateExtensions.getPrefixErrorMessage(context);

--- a/libraries/botbuilder-lg/src/template.ts
+++ b/libraries/botbuilder-lg/src/template.ts
@@ -45,6 +45,7 @@ export class Template {
 
     /**
      * Creates a new instance of the [Template](xref:botbuilder-lg.Template) class.
+     *
      * @param templatename Template name without parameters.
      * @param parameters Parameter list.
      * @param templatebody Template content.
@@ -59,6 +60,7 @@ export class Template {
 
     /**
      * Returns a string representing the current [Template](xref:botbuilder-lg.Template) object.
+     *
      * @returns A string representing the [Template](xref:botbuilder-lg.Template).
      */
     public toString(): string {

--- a/libraries/botbuilder-lg/src/templateErrors.ts
+++ b/libraries/botbuilder-lg/src/templateErrors.ts
@@ -10,62 +10,78 @@
  * Centralized LG errors.
  */
 export class TemplateErrors {
-    public static readonly noTemplate: string = `LG file must have at least one template definition.`;
+    public static readonly noTemplate: string = 'LG file must have at least one template definition.';
 
-    public static readonly invalidTemplateBody: string = `Invalid template body. Expecting '-' prefix.`;
+    public static readonly invalidTemplateBody: string = "Invalid template body. Expecting '-' prefix.";
 
-    public static readonly missingStrucEnd: string = `Invalid structure body. Expecting ']' at the end of the body.`;
+    public static readonly missingStrucEnd: string = "Invalid structure body. Expecting ']' at the end of the body.";
 
-    public static readonly emptyStrucContent: string = `Invalid structure body. Body cannot be empty.`;
+    public static readonly emptyStrucContent: string = 'Invalid structure body. Body cannot be empty.';
 
-    public static readonly invalidWhitespaceInCondition: string = `Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.`;
+    public static readonly invalidWhitespaceInCondition: string =
+        "Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.";
 
-    public static readonly notStartWithIfInCondition: string = `Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix.`;
+    public static readonly notStartWithIfInCondition: string =
+        "Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix.";
 
-    public static readonly multipleIfInCondition: string = `Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement.`;
+    public static readonly multipleIfInCondition: string =
+        "Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement.";
 
-    public static readonly notEndWithElseInCondition: string = `Conditional response template does not end with 'ELSE' condition.`;
+    public static readonly notEndWithElseInCondition: string =
+        "Conditional response template does not end with 'ELSE' condition.";
 
-    public static readonly invalidMiddleInCondition: string = `Invalid template body. Expecting 'ELSEIF'.`;
+    public static readonly invalidMiddleInCondition: string = "Invalid template body. Expecting 'ELSEIF'.";
 
-    public static readonly invalidExpressionInCondition: string = `Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression.`;
+    public static readonly invalidExpressionInCondition: string =
+        "Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression.";
 
-    public static readonly extraExpressionInCondition: string = `Invalid condition. 'ELSE' definition cannot include an expression.`;
+    public static readonly extraExpressionInCondition: string =
+        "Invalid condition. 'ELSE' definition cannot include an expression.";
 
-    public static readonly missingTemplateBodyInCondition: string = `Invalid condition body. Conditions must include a valid body.`;
+    public static readonly missingTemplateBodyInCondition: string =
+        'Invalid condition body. Conditions must include a valid body.';
 
-    public static readonly invalidWhitespaceInSwitchCase: string = `Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'.`;
+    public static readonly invalidWhitespaceInSwitchCase: string =
+        "Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'.";
 
-    public static readonly notStartWithSwitchInSwitchCase: string = `Invalid conditional response template. Expecting a 'SWITCH' statement?`;
+    public static readonly notStartWithSwitchInSwitchCase: string =
+        "Invalid conditional response template. Expecting a 'SWITCH' statement?";
 
-    public static readonly multipleSwithStatementInSwitchCase: string = `Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement.`;
+    public static readonly multipleSwithStatementInSwitchCase: string =
+        "Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement.";
 
-    public static readonly invalidStatementInMiddlerOfSwitchCase: string = `Invalid template body. Expecting a 'CASE' statement.`;
+    public static readonly invalidStatementInMiddlerOfSwitchCase: string =
+        "Invalid template body. Expecting a 'CASE' statement.";
 
-    public static readonly notEndWithDefaultInSwitchCase: string = `Conditional response template does not end with 'DEFAULT' condition.`;
+    public static readonly notEndWithDefaultInSwitchCase: string =
+        "Conditional response template does not end with 'DEFAULT' condition.";
 
-    public static readonly missingCaseInSwitchCase: string = `Invalid template body. Expecting at least one 'CASE' statement.`;
+    public static readonly missingCaseInSwitchCase: string =
+        "Invalid template body. Expecting at least one 'CASE' statement.";
 
-    public static readonly invalidExpressionInSwiathCase: string = `Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression.`;
+    public static readonly invalidExpressionInSwiathCase: string =
+        "Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression.";
 
-    public static readonly extraExpressionInSwitchCase: string = `Invalid condition. 'DEFAULT' statement cannot include an expression.`;
+    public static readonly extraExpressionInSwitchCase: string =
+        "Invalid condition. 'DEFAULT' statement cannot include an expression.";
 
-    public static readonly missingTemplateBodyInSwitchCase: string = `Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block.`;
+    public static readonly missingTemplateBodyInSwitchCase: string =
+        "Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block.";
 
     public static readonly noEndingInMultiline: string = 'Expecting "```" to close the multi-line block.';
 
-    public static readonly noCloseBracket: string = `Close } is missing in Expression.`;
+    public static readonly noCloseBracket: string = 'Close } is missing in Expression.';
 
-    public static readonly loopDetected: string = `Loop detected:`;
+    public static readonly loopDetected: string = 'Loop detected:';
 
-    public static readonly invalidMemory: string = `Scope is not a LG customized memory.`;
+    public static readonly invalidMemory: string = 'Scope is not a LG customized memory.';
 
-    public static readonly staticFailure: string = `Static failure with the following error.`;
+    public static readonly staticFailure: string = 'Static failure with the following error.';
 
     public static readonly invalidTemplateNameType: string =
         'Expected string type for the parameter of template function.';
 
-    public static readonly importFormatError: string = `Import format should follow '[x](y)' or '[x](y) as z'.`;
+    public static readonly importFormatError: string = "Import format should follow '[x](y)' or '[x](y) as z'.";
 
     public static readonly invalidStrucBody = (invalidBody: string): string =>
         `Invalid structure body: '${invalidBody}'. Body can include <PropertyName> = <Value> pairs or \${reference()} template reference.`;
@@ -103,13 +119,13 @@ export class TemplateErrors {
         expectedCount: number,
         actualCount: number
     ): string =>
-        `arguments mismatch for template '` +
+        "arguments mismatch for template '" +
         `${templateName}` +
-        `'. Expecting '` +
+        "'. Expecting '" +
         `${expectedCount}` +
-        `' arguments, actual '` +
+        "' arguments, actual '" +
         `${actualCount}` +
-        `'.`;
+        "'.";
 
     public static readonly templateExist = (templateName: string): string =>
         `template '${templateName}' already exists.`;

--- a/libraries/botbuilder-lg/src/templateException.ts
+++ b/libraries/botbuilder-lg/src/templateException.ts
@@ -15,6 +15,7 @@ export class TemplateException extends Error {
 
     /**
      * Creates a new instance of the [TemplateException](xref:botbuilder-lg.TemplateException) class.
+     *
      * @param m Error message.
      * @param diagnostics List of [Diagnostic](xref:botbuilder-lg.Diagnostic) to throw.
      */
@@ -26,6 +27,8 @@ export class TemplateException extends Error {
 
     /**
      * Diagnostics.
+     *
+     * @returns A diagnostic of the error or warning (range, message, severity, source, code).
      */
     public getDiagnostic(): Diagnostic[] {
         return this.diagnostics;

--- a/libraries/botbuilder-lg/src/templateExtensions.ts
+++ b/libraries/botbuilder-lg/src/templateExtensions.ts
@@ -157,7 +157,7 @@ export class TemplateExtensions {
     }
 
     /**
-     * read line from text.
+     * Read line from text.
      *
      * @param input Text content.
      * @returns Split read line.

--- a/libraries/botbuilder-lg/src/templateExtensions.ts
+++ b/libraries/botbuilder-lg/src/templateExtensions.ts
@@ -26,6 +26,7 @@ import {
 export class TemplateExtensions {
     /**
      * Trim expression. ${abc} => abc,  ${a == {}} => a == {}.
+     *
      * @param expression Input expression string.
      * @returns Pure expression string.
      */
@@ -49,6 +50,7 @@ export class TemplateExtensions {
      * path is from authored content which doesn't know what OS it is running on.
      * This method treats / and \ both as seperators regardless of OS, for windows that means / -> \ and for linux/mac \ -> /.
      * This allows author to use ../foo.lg or ..\foo.lg as equivelents for importing.
+     *
      * @param ambiguousPath AuthoredPath.
      * @returns Path expressed as OS path.
      */
@@ -64,6 +66,7 @@ export class TemplateExtensions {
 
     /**
      * Get prefix error message from normal template sting context.
+     *
      * @param context Normal template sting context.
      * @returns Prefix error message.
      */
@@ -75,14 +78,14 @@ export class TemplateExtensions {
                 let tempMsg = '';
                 if (conditionContext.ifCondition() && conditionContext.ifCondition().expression().length > 0) {
                     tempMsg = conditionContext.ifCondition().expression(0).text;
-                    errorPrefix = `Condition '` + tempMsg + `': `;
+                    errorPrefix = "Condition '" + tempMsg + "': ";
                 }
             } else {
                 if (context.parent.parent.parent instanceof SwitchCaseRuleContext) {
                     const switchCaseContext = context.parent.parent.parent;
                     const state = switchCaseContext.switchCaseStat();
                     if (state && state.DEFAULT()) {
-                        errorPrefix = `Case 'Default':`;
+                        errorPrefix = "Case 'Default':";
                     } else if (state && state.SWITCH()) {
                         let tempMsg = '';
                         if (state.expression(0)) {
@@ -105,7 +108,9 @@ export class TemplateExtensions {
 
     /**
      * If a value is pure Expression.
+     *
      * @param ctx Key value structure value context.
+     * @returns True if the value is pure Expression, false otherwise.
      */
     public static isPureExpression(ctx: KeyValueStructureValueContext): boolean {
         if (ctx.expressionInStructure() === undefined || ctx.expressionInStructure().length != 1) {
@@ -117,6 +122,7 @@ export class TemplateExtensions {
 
     /**
      * Escape \ from text.
+     *
      * @param exp Input text.
      * @returns Escaped text.
      */
@@ -143,6 +149,8 @@ export class TemplateExtensions {
 
     /**
      * Generate new guid string.
+     *
+     * @returns The new guid string.
      */
     public static newGuid(): string {
         return uuidv4();
@@ -150,7 +158,9 @@ export class TemplateExtensions {
 
     /**
      * read line from text.
+     *
      * @param input Text content.
+     * @returns Split read line.
      */
     public static readLine(input: string): string[] {
         if (!input) {
@@ -162,6 +172,7 @@ export class TemplateExtensions {
 
     /**
      * Convert antlr parser into Range.
+     *
      * @param context Antlr parse context.
      * @param [lineOffset] Line offset.
      * @returns Range object.

--- a/libraries/botbuilder-lg/src/templateImport.ts
+++ b/libraries/botbuilder-lg/src/templateImport.ts
@@ -34,6 +34,7 @@ export class TemplateImport {
 
     /**
      * Creates a new instance of the [TemplateImport](xref:botbuilder-lg.TemplateImport) class.
+     *
      * @param description Import description, which is in [].
      * @param id Import id, which is a path, in ().
      * @param sourceRange [SourceRange](xref:botbuilder-lg.SourceRange) of template.

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -225,7 +225,7 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * parse a file and return LG file.
+     * Parse a file and return LG file.
      *
      * @param filePath LG absolute file path..
      * @param importResolver Resolver to resolve LG import id to template text.

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -149,6 +149,8 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
+     * Iterates over values in the template collection.
+     *
      * @returns A new iterator for the template collection.
      */
     public [Symbol.iterator](): Iterator<Template> {
@@ -165,6 +167,8 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
+     * Gets the collection of templates.
+     *
      * @returns A reference to the internal list of collection templates.
      */
     public toArray(): Template[] {
@@ -181,20 +185,26 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * @returns A value indicating whether the options when evaluating LG templates.
+     * Gets the evluation options for the current LG file.
+     *
+     *  @returns A value indicating whether the options when evaluating LG templates.
      */
     public get lgOptions(): EvaluationOptions {
         return new EvaluationOptions(this.options);
     }
 
     /**
-     * @returns A string value representing the namespace to register for current LG file.
+     * Gets the namespace to register for the current LG file.
+     *
+     *  @returns A string value representing the namespace to register for the current LG file.
      */
     public get namespace(): string {
         return this.extractNamespace(this.options);
     }
 
     /**
+     * Gets all templates from current lg file and reference lg files.
+     *
      * @returns All templates from current lg file and reference lg files.
      */
     public get allTemplates(): Template[] {
@@ -204,6 +214,8 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
+     * Gets all diagnostics from current lg file and reference lg files.
+     *
      * @returns All diagnostics from current lg file and reference lg files.
      */
     public get allDiagnostics(): Diagnostic[] {

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -46,7 +46,7 @@ export class Templates implements Iterable<Template> {
     /**
      * Indicates whether fromFile is allowed in LG templates.
      */
-    public static enableFromFile: boolean = false;
+    public static enableFromFile = false;
     private readonly newLineRegex = /(\r?\n)/g;
     private readonly newLine: string = '\r\n';
     private readonly namespaceKey = '@namespace';
@@ -108,6 +108,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Creates a new instance of the [Templates](xref:botbuilder-lg.Templates) class.
+     *
      * @param items Optional. List of [Template](xref:botbuilder-lg.Template) instances.
      * @param imports Optional. List of [TemplateImport](xref:botbuilder-lg.TemplateImport) instances.
      * @param diagnostics Optional. List of [Diagnostic](xref:botbuilder-lg.Diagnostic) instances.
@@ -148,7 +149,7 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * Returns a new iterator for the template collection.
+     * @returns A new iterator for the template collection.
      */
     public [Symbol.iterator](): Iterator<Template> {
         let index = 0;
@@ -164,7 +165,7 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * Returns a reference to the internal list of collection templates.
+     * @returns A reference to the internal list of collection templates.
      */
     public toArray(): Template[] {
         return this.items;
@@ -172,6 +173,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Appends 1 or more templates to the collection.
+     *
      * @param args List of templates to add.
      */
     public push(...args: Template[]): void {
@@ -179,21 +181,21 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * A value indicating whether the options when evaluation LG templates.
+     * @returns A value indicating whether the options when evaluating LG templates.
      */
     public get lgOptions(): EvaluationOptions {
         return new EvaluationOptions(this.options);
     }
 
     /**
-     * A string value represents the namespace to register for current LG file.
+     * @returns A string value representing the namespace to register for current LG file.
      */
     public get namespace(): string {
         return this.extractNamespace(this.options);
     }
 
     /**
-     * All templates from current lg file and reference lg files.
+     * @returns All templates from current lg file and reference lg files.
      */
     public get allTemplates(): Template[] {
         let result = this.items;
@@ -202,7 +204,7 @@ export class Templates implements Iterable<Template> {
     }
 
     /**
-     * All diagnostics from current lg file and reference lg files.
+     * @returns All diagnostics from current lg file and reference lg files.
      */
     public get allDiagnostics(): Diagnostic[] {
         let result = this.diagnostics;
@@ -212,6 +214,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * parse a file and return LG file.
+     *
      * @param filePath LG absolute file path..
      * @param importResolver Resolver to resolve LG import id to template text.
      * @param expressionParser Expression parser for evaluating expressions.
@@ -227,6 +230,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Parser to turn lg content into a Templates.
+     *
      * @deprecated This method will soon be deprecated. Use ParseResource instead.
      * @param content Text content contains lg templates.
      * @param id Id is the identifier of content. If importResolver is undefined, id must be a full path string.
@@ -245,7 +249,8 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Parser to turn lg content into a Templates.
-     * @param aresource LG resource.
+     *
+     * @param resource LG resource.
      * @param importResolver Resolver to resolve LG import id to template text.
      * @param expressionParser Expression parser for evaluating expressions.
      * @returns Entity.
@@ -260,8 +265,10 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Evaluate a template with given name and scope.
+     *
      * @param templateName Template name to be evaluated.
      * @param scope The state visible in the evaluation.
+     * @param opt EvaluationOptions in evaluating a template.
      * @returns Evaluate result.
      */
     public evaluate(templateName: string, scope?: object, opt: EvaluationOptions = undefined): any {
@@ -280,8 +287,10 @@ export class Templates implements Iterable<Template> {
     /**
      * Expand a template with given name and scope.
      * Return all possible responses instead of random one.
+     *
      * @param templateName Template name to be evaluated.
      * @param scope The state visible in the evaluation.
+     * @param opt EvaluationOptions in expanding a template.
      * @returns Expand result.
      */
     public expandTemplate(templateName: string, scope?: object, opt: EvaluationOptions = undefined): any[] {
@@ -294,7 +303,9 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Analyze a template to get the static analyzer results including variables and template references.
+     *
      * @param templateName Template name to be evaluated.
+     * @param analyzerOptions Options for analyzing template.
      * @returns Analyzer result.
      */
     public analyzeTemplate(templateName: string, analyzerOptions?: AnalyzerOptions): AnalyzerResult {
@@ -306,8 +317,11 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Use to evaluate an inline template str.
+     *
      * @param inlineStr Inline string which will be evaluated.
      * @param scope Scope object or JToken.
+     * @param opt EvaluationOptions in evaluating a template.
+     * @returns Evaluated result object.
      */
     public evaluateText(inlineStr: string, scope?: object, opt: EvaluationOptions = undefined): any {
         if (inlineStr === undefined) {
@@ -335,6 +349,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Update a template and return LG file.
+     *
      * @param templateName Orignial template name.
      * @param newTemplateName New template name.
      * @param parameters New params.
@@ -390,6 +405,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Add a new template and return LG file.
+     *
      * @param templateName New template name.
      * @param parameters New params.
      * @param templateBody New  template body.
@@ -442,6 +458,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Delete an exist template.
+     *
      * @param templateName Which template should delete.
      * @returns Return the new lg file.
      */
@@ -464,6 +481,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * Returns a string representation of a [Templates](xref:botbuilder-lg.Templates) content.
+     *
      * @returns A string representation of a [Templates](xref:botbuilder-lg.Templates) content.
      */
     public toString(): string {

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -66,7 +66,7 @@ export class TemplatesParser {
     public static readonly importRegex: RegExp = new RegExp(/\[([^\]]*)\]\(([^)]*)\)([\w\s]*)/);
 
     /**
-     * parse a file and return LG file.
+     * Parse a file and return LG file.
      *
      * @param filePath LG absolute file path..
      * @param importResolver Resolver to resolve LG import id to template text.

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -67,6 +67,7 @@ export class TemplatesParser {
 
     /**
      * parse a file and return LG file.
+     *
      * @param filePath LG absolute file path..
      * @param importResolver Resolver to resolve LG import id to template text.
      * @param expressionParser Expression parser for evaluating expressions.
@@ -85,6 +86,7 @@ export class TemplatesParser {
 
     /**
      * Parser to turn lg content into a Templates.
+     *
      * @deprecated This method will soon be deprecated. Use ParseResource instead.
      * @param content Text content contains lg templates.
      * @param id Id is the identifier of content. If importResolver is undefined, id must be a full path string.
@@ -104,10 +106,10 @@ export class TemplatesParser {
 
     /**
      * Parser to turn lg content into a Templates.
+     *
      * @param resource LG resource.
      * @param importResolver Resolver to resolve LG import id to template text.
      * @param expressionParser Expression parser for evaluating expressions.
-     * @param cachedTemplates Give the file path and templates to avoid parsing and to improve performance.
      * @returns Entity.
      */
     public static parseResource(
@@ -120,12 +122,14 @@ export class TemplatesParser {
 
     /**
      * Parser to turn lg content into a Templates based on the original Templates.
+     *
      * @param content Text content contains lg templates.
-     * @param originalTemplates Original templates
+     * @param originalTemplates Original templates.
+     * @returns Template containing lg content.
      */
     public static parseTextWithRef(content: string, originalTemplates: Templates): Templates {
         if (!originalTemplates) {
-            throw Error(`templates is empty`);
+            throw Error('templates is empty');
         }
 
         const id = TemplatesParser.inlineContentId;
@@ -158,8 +162,10 @@ export class TemplatesParser {
     }
     /**
      * Default import resolver, using relative/absolute file path to access the file content.
+     *
      * @param resource Original Resource.
      * @param resourceId Import path.
+     * @returns Accessed lg resource.
      */
     public static defaultFileResolver(resource: LGResource, resourceId: string): LGResource {
         // If the import id contains "#", we would cut it to use the left path.
@@ -184,6 +190,7 @@ export class TemplatesParser {
 
     /**
      * Parser to turn lg content into a Templates.
+     *
      * @param resource LG resource.
      * @param importResolver Resolver to resolve LG import id to template text.
      * @param expressionParser Expression parser for evaluating expressions.
@@ -234,6 +241,7 @@ export class TemplatesParser {
 
     /**
      * Parse LG content and return the AST.
+     *
      * @param resource LG resource.
      * @returns The abstract syntax tree of lg file.
      */
@@ -356,6 +364,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Creates a new instance of the [TemplatesTransformer](xref:botbuilder-lg.TemplatesTransformer) class.
+     *
      * @param templates Templates.
      */
     public constructor(templates: Templates) {
@@ -365,7 +374,9 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Transform the parse tree into templates.
+     *
      * @param parseTree Input abstract syntax tree.
+     * @returns Parse tree templates.
      */
     public transform(parseTree: ParseTree): Templates {
         if (parseTree) {
@@ -393,6 +404,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Visit a parse tree produced by `LGFileParser.errorDefinition`.
+     *
      * @param context The parse tree.
      */
     public visitErrorDefinition(context: ErrorDefinitionContext): void {
@@ -409,6 +421,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Visit a parse tree produced by `LGFileParser.importDefinition`.
+     *
      * @param context The parse tree.
      */
     public visitImportDefinition(context: ImportDefinitionContext): void {
@@ -444,6 +457,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Visit a parse tree produced by `LGFileParser.optionDefinition`.
+     *
      * @param context The parse tree.
      */
     public visitOptionDefinition(context: OptionDefinitionContext): void {
@@ -463,6 +477,7 @@ export class TemplatesTransformer extends AbstractParseTreeVisitor<void> impleme
 
     /**
      * Visit a parse tree produced by `LGFileParser.templateDefinition`.
+     *
      * @param context The parse tree.
      */
     public visitTemplateDefinition(context: TemplateDefinitionContext): void {

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -486,7 +486,7 @@ describe('LG', function () {
         assert.strictEqual(evaled, 2, `Evaled is ${evaled}`);
 
         evaled = templates.evaluate('compose', { property: 'Show' });
-        assert.strictEqual(evaled, `you made it!`);
+        assert.strictEqual(evaled, 'you made it!');
     });
 
     it('TestAnalyzelgTemplateFunction', function () {
@@ -529,7 +529,7 @@ describe('LG', function () {
         const resource = new LGResource(
             GetExampleFilePath('xx.lg'),
             GetExampleFilePath('xx.lg'),
-            `[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n`
+            '[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n'
         );
         templates = Templates.parseResource(resource);
 
@@ -1634,13 +1634,13 @@ describe('LG', function () {
         ({ value: evaled, error } = Expression.parse('common.countTotal()').tryEvaluate(scope1));
         assert.strictEqual(
             error,
-            `list1 is not a list or array. [countTotal]  Error occurred when evaluating '-\${count(union(list1,list2))}'.`
+            "list1 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'."
         );
 
         ({ value: evaled, error } = Expression.parse('common.countTotal(a, b, c)').tryEvaluate(scope1));
         assert.strictEqual(
             error,
-            `list2 is not a list or array. [countTotal]  Error occurred when evaluating '-\${count(union(list1,list2))}'.`
+            "list2 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'."
         );
 
         const scope2 = { i: 1, j: 2, k: 3, l: 4 };

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -6,47 +6,47 @@ function GetExceptionExampleFilePath(fileName) {
 }
 
 function GetLGFile(fileName) {
-    var filePath = GetExceptionExampleFilePath(fileName);
+    const filePath = GetExceptionExampleFilePath(fileName);
     return Templates.parseFile(filePath);
 }
 
 function GetDiagnostics(fileName) {
-    var filePath = GetExceptionExampleFilePath(fileName);
+    const filePath = GetExceptionExampleFilePath(fileName);
     return Templates.parseFile(filePath).diagnostics;
 }
 
-describe(`LGExceptionTest`, function () {
+describe('LGExceptionTest', function () {
     /**
      * Disk I/O is slow and variable, causing issues in pipeline tests, so we
      * preload all of the file reads here so that it doesn't count against individual test duration.
      */
     const preloaded = {
-        ConditionFormatError: GetDiagnostics(`ConditionFormatError.lg`),
-        DuplicatedTemplates: GetDiagnostics(`DuplicatedTemplates.lg`),
-        DuplicatedTemplatesLg: GetLGFile(`DuplicatedTemplates.lg`),
-        DuplicatedTemplatesInImportFiles: GetDiagnostics(`DuplicatedTemplatesInImportFiles.lg`),
-        EmptyTemplate: GetDiagnostics(`EmptyTemplate.lg`),
-        EmptyLGFile: GetDiagnostics(`EmptyLGFile.lg`),
-        ErrorStructuredTemplate: GetDiagnostics(`ErrorStructuredTemplate.lg`),
-        ErrorTemplateName: GetDiagnostics(`ErrorTemplateName.lg`),
-        InvalidLGFileImportPath: GetDiagnostics(`InvalidLGFileImportPath.lg`),
-        InvalidImportFormat: GetDiagnostics(`InvalidImportFormat.lg`),
-        LgTemplateFunctionError: GetDiagnostics(`LgTemplateFunctionError.lg`),
-        MultiLineVariation: GetDiagnostics(`MultiLineVariation.lg`),
-        MultiLineTemplate: GetDiagnostics(`MultiLineTemplate.lg`),
-        NoNormalTemplateBody: GetDiagnostics(`NoNormalTemplateBody.lg`),
-        NoTemplateRef: GetDiagnostics(`NoTemplateRef.lg`),
-        SwitchCaseFormatError: GetDiagnostics(`SwitchCaseFormatError.lg`),
-        LoopDetected: GetLGFile(`LoopDetected.lg`),
-        ErrorExpression: GetLGFile(`ErrorExpression.lg`),
+        ConditionFormatError: GetDiagnostics('ConditionFormatError.lg'),
+        DuplicatedTemplates: GetDiagnostics('DuplicatedTemplates.lg'),
+        DuplicatedTemplatesLg: GetLGFile('DuplicatedTemplates.lg'),
+        DuplicatedTemplatesInImportFiles: GetDiagnostics('DuplicatedTemplatesInImportFiles.lg'),
+        EmptyTemplate: GetDiagnostics('EmptyTemplate.lg'),
+        EmptyLGFile: GetDiagnostics('EmptyLGFile.lg'),
+        ErrorStructuredTemplate: GetDiagnostics('ErrorStructuredTemplate.lg'),
+        ErrorTemplateName: GetDiagnostics('ErrorTemplateName.lg'),
+        InvalidLGFileImportPath: GetDiagnostics('InvalidLGFileImportPath.lg'),
+        InvalidImportFormat: GetDiagnostics('InvalidImportFormat.lg'),
+        LgTemplateFunctionError: GetDiagnostics('LgTemplateFunctionError.lg'),
+        MultiLineVariation: GetDiagnostics('MultiLineVariation.lg'),
+        MultiLineTemplate: GetDiagnostics('MultiLineTemplate.lg'),
+        NoNormalTemplateBody: GetDiagnostics('NoNormalTemplateBody.lg'),
+        NoTemplateRef: GetDiagnostics('NoTemplateRef.lg'),
+        SwitchCaseFormatError: GetDiagnostics('SwitchCaseFormatError.lg'),
+        LoopDetected: GetLGFile('LoopDetected.lg'),
+        ErrorExpression: GetLGFile('ErrorExpression.lg'),
         RunTimeErrors: GetLGFile('RunTimeErrors.lg'),
-        ExpressionFormatError: GetDiagnostics(`ExpressionFormatError.lg`),
-        MultiLineExprError: GetDiagnostics(`MultiLineExprError.lg`),
-        ErrorLine: GetDiagnostics(`ErrorLine.lg`),
-        CycleRef1: GetDiagnostics(`CycleRef1.lg`),
+        ExpressionFormatError: GetDiagnostics('ExpressionFormatError.lg'),
+        MultiLineExprError: GetDiagnostics('MultiLineExprError.lg'),
+        ErrorLine: GetDiagnostics('ErrorLine.lg'),
+        CycleRef1: GetDiagnostics('CycleRef1.lg'),
     };
 
-    it(`TestConditionFormatError`, function () {
+    it('TestConditionFormatError', function () {
         const diagnostics = preloaded.ConditionFormatError;
         assert.strictEqual(diagnostics.length, 10);
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Warning);
@@ -71,7 +71,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[9].message.includes(TemplateErrors.notStartWithIfInCondition));
     });
 
-    it(`TestDuplicatedTemplates`, function () {
+    it('TestDuplicatedTemplates', function () {
         const diagnostics = preloaded.DuplicatedTemplates;
 
         assert.strictEqual(diagnostics.length, 2);
@@ -89,22 +89,22 @@ describe(`LGExceptionTest`, function () {
         assert.strictEqual(allDiagnostics[1].severity, DiagnosticSeverity.Error);
         assert(allDiagnostics[1].message.includes(TemplateErrors.duplicatedTemplateInSameTemplate('template1')));
         assert.strictEqual(allDiagnostics[2].severity, DiagnosticSeverity.Error);
-        assert(allDiagnostics[2].message.includes(`Duplicated definitions found for template: 'basicTemplate'`));
+        assert(allDiagnostics[2].message.includes("Duplicated definitions found for template: 'basicTemplate'"));
         assert.strictEqual(allDiagnostics[3].severity, DiagnosticSeverity.Error);
-        assert(allDiagnostics[3].message.includes(`Duplicated definitions found for template: 'basicTemplate2'`));
+        assert(allDiagnostics[3].message.includes("Duplicated definitions found for template: 'basicTemplate2'"));
     });
 
-    it(`TestDuplicatedTemplatesInImportFiles`, function () {
+    it('TestDuplicatedTemplatesInImportFiles', function () {
         const diagnostics = preloaded.DuplicatedTemplatesInImportFiles;
 
         assert.strictEqual(diagnostics.length, 2);
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-        assert(diagnostics[0].message.includes(`Duplicated definitions found for template: 'basicTemplate'`));
+        assert(diagnostics[0].message.includes("Duplicated definitions found for template: 'basicTemplate'"));
         assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Error);
-        assert(diagnostics[1].message.includes(`Duplicated definitions found for template: 'basicTemplate2'`));
+        assert(diagnostics[1].message.includes("Duplicated definitions found for template: 'basicTemplate2'"));
     });
 
-    it(`TestEmptyTemplate`, function () {
+    it('TestEmptyTemplate', function () {
         const diagnostics = preloaded.EmptyTemplate;
 
         assert.strictEqual(diagnostics.length, 1);
@@ -112,7 +112,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[0].message.includes(TemplateErrors.noTemplateBody('template')));
     });
 
-    it(`TestEmptyLGFile`, function () {
+    it('TestEmptyLGFile', function () {
         const diagnostics = preloaded.EmptyLGFile;
 
         assert.strictEqual(diagnostics.length, 1);
@@ -120,7 +120,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[0].message.includes(TemplateErrors.noTemplate));
     });
 
-    it(`TestErrorStructuredTemplate`, function () {
+    it('TestErrorStructuredTemplate', function () {
         const diagnostics = preloaded.ErrorStructuredTemplate;
 
         assert.strictEqual(diagnostics.length, 8);
@@ -131,13 +131,13 @@ describe(`LGExceptionTest`, function () {
         assert.strictEqual(diagnostics[2].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[2].message.includes(
-                `Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator`
+                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator"
             )
         );
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[3].severity);
         assert(
             diagnostics[3].message.includes(
-                `Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator`
+                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator"
             )
         );
         assert.strictEqual(diagnostics[4].severity, DiagnosticSeverity.Error);
@@ -150,7 +150,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[7].message.includes(TemplateErrors.invalidStrucBody('- hi')));
     });
 
-    it(`TestErrorTemplateName`, function () {
+    it('TestErrorTemplateName', function () {
         const diagnostics = preloaded.ErrorTemplateName;
 
         assert.strictEqual(diagnostics.length, 7);
@@ -170,15 +170,15 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[6].message.includes(TemplateErrors.invalidTemplateName('t1.1')));
     });
 
-    it(`TestInvalidLGFileImportPath`, function () {
+    it('TestInvalidLGFileImportPath', function () {
         const diagnostics = preloaded.InvalidLGFileImportPath;
 
         assert.strictEqual(diagnostics.length, 1);
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-        assert(diagnostics[0].message.includes(`Could not find file`));
+        assert(diagnostics[0].message.includes('Could not find file'));
     });
 
-    it(`TestInvalidImportFormat`, function () {
+    it('TestInvalidImportFormat', function () {
         const diagnostics = preloaded.InvalidImportFormat;
 
         assert.strictEqual(diagnostics.length, 1);
@@ -186,25 +186,25 @@ describe(`LGExceptionTest`, function () {
         assert.strictEqual(diagnostics[0].message, TemplateErrors.importFormatError);
     });
 
-    it(`TestLgTemplateFunctionError`, function () {
+    it('TestLgTemplateFunctionError', function () {
         const diagnostics = preloaded.LgTemplateFunctionError;
 
         assert.strictEqual(diagnostics.length, 2);
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[0].message.includes(
-                `Error occurred when parsing expression 'NotExistTemplate()'. NotExistTemplate does not have an evaluator`
+                "Error occurred when parsing expression 'NotExistTemplate()'. NotExistTemplate does not have an evaluator"
             )
         );
         assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[1].message.includes(
-                `Error occurred when parsing expression 'template5('hello', 'world')'. arguments mismatch for template 'template5'. Expecting '1' arguments, actual '2'`
+                "Error occurred when parsing expression 'template5('hello', 'world')'. arguments mismatch for template 'template5'. Expecting '1' arguments, actual '2'"
             )
         );
     });
 
-    it(`TestMultiLineVariation`, function () {
+    it('TestMultiLineVariation', function () {
         const diagnostics = preloaded.MultiLineVariation;
 
         assert.strictEqual(diagnostics.length, 1);
@@ -212,7 +212,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[0].message.includes(TemplateErrors.noEndingInMultiline));
     });
 
-    it(`TestMultiLineTemplate`, function () {
+    it('TestMultiLineTemplate', function () {
         const diagnostics = preloaded.MultiLineTemplate;
 
         assert.strictEqual(diagnostics.length, 1);
@@ -220,7 +220,7 @@ describe(`LGExceptionTest`, function () {
         assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.noEndingInMultiline), true);
     });
 
-    it(`TestNoNormalTemplateBody`, function () {
+    it('TestNoNormalTemplateBody', function () {
         const diagnostics = preloaded.NoNormalTemplateBody;
 
         assert.strictEqual(diagnostics.length, 3);
@@ -232,7 +232,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[2].message.includes(TemplateErrors.missingTemplateBodyInCondition));
     });
 
-    it(`TestNoTemplateRef`, function () {
+    it('TestNoTemplateRef', function () {
         const diagnostics = preloaded.NoTemplateRef;
 
         assert.strictEqual(diagnostics.length, 3);
@@ -240,24 +240,24 @@ describe(`LGExceptionTest`, function () {
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[0].message.includes(
-                `Error occurred when parsing expression 'templateRef()'. templateRef does not have an evaluator`
+                "Error occurred when parsing expression 'templateRef()'. templateRef does not have an evaluator"
             )
         );
         assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[1].message.includes(
-                `Error occurred when parsing expression 'templateRef(a)'. templateRef does not have an evaluator`
+                "Error occurred when parsing expression 'templateRef(a)'. templateRef does not have an evaluator"
             )
         );
         assert.strictEqual(diagnostics[2].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[2].message.includes(
-                `Error occurred when parsing expression 'templateRefInMultiLine()'. templateRefInMultiLine does not have an evaluator`
+                "Error occurred when parsing expression 'templateRefInMultiLine()'. templateRefInMultiLine does not have an evaluator"
             )
         );
     });
 
-    it(`TestSwitchCaseFormatError`, function () {
+    it('TestSwitchCaseFormatError', function () {
         const diagnostics = preloaded.SwitchCaseFormatError;
 
         assert.strictEqual(diagnostics.length, 14);
@@ -291,13 +291,13 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[13].message.includes(TemplateErrors.notEndWithDefaultInSwitchCase));
     });
 
-    it(`TestLoopDetected`, function () {
+    it('TestLoopDetected', function () {
         const templates = preloaded.LoopDetected;
 
         assert.throws(
-            () => templates.evaluate(`wPhrase`),
+            () => templates.evaluate('wPhrase'),
             new Error(
-                `Loop detected: welcome_user => wPhrase [wPhrase]  Error occurred when evaluating '-\${wPhrase()}'. [welcome_user]  Error occurred when evaluating '-\${welcome_user()}'.`
+                "Loop detected: welcome_user => wPhrase [wPhrase]  Error occurred when evaluating '-${wPhrase()}'. [welcome_user]  Error occurred when evaluating '-${welcome_user()}'."
             )
         );
 
@@ -322,19 +322,19 @@ describe(`LGExceptionTest`, function () {
         );
     });
 
-    it(`AddTextWithWrongId`, function () {
-        const diagnostics = Templates.parseResource(new LGResource('a.lg', 'a.lg', `[import](xx.lg) \r\n # t \n - hi`))
+    it('AddTextWithWrongId', function () {
+        const diagnostics = Templates.parseResource(new LGResource('a.lg', 'a.lg', '[import](xx.lg) \r\n # t \n - hi'))
             .diagnostics;
         assert.strictEqual(diagnostics.length, 1);
-        assert(diagnostics[0].message.includes(`Could not find file`));
+        assert(diagnostics[0].message.includes('Could not find file'));
     });
 
-    it(`TestErrorExpression`, function () {
+    it('TestErrorExpression', function () {
         const templates = preloaded.ErrorExpression;
         assert.throws(
-            () => templates.evaluate(`template1`),
+            () => templates.evaluate('template1'),
             new Error(
-                `first(createArray(1, 2)) is neither a string nor a null object. [template1]  Error occurred when evaluating '-\${length(first(createArray(1,2)))}'.`
+                "first(createArray(1, 2)) is neither a string nor a null object. [template1]  Error occurred when evaluating '-${length(first(createArray(1,2)))}'."
             )
         );
     });
@@ -343,100 +343,100 @@ describe(`LGExceptionTest`, function () {
         const templates = preloaded.RunTimeErrors;
 
         assert.throws(
-            () => templates.evaluate(`template1`),
+            () => templates.evaluate('template1'),
             new Error(
-                `'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'.`
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`prebuilt1`),
+            () => templates.evaluate('prebuilt1'),
             new Error(
-                `'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want \${foreach(dialog.abc, item, template1())}'.`
+                "'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`template2`),
+            () => templates.evaluate('template2'),
             new Error(
-                `'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition \${template1()}'.`
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'."
             )
         );
 
         assert.throws(
             () => templates.evaluate('conditionalTemplate1', { dialog: true }),
             new Error(
-                `'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [conditionalTemplate1] Condition '\${dialog}':  Error occurred when evaluating '-I want \${template1()}'.`
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`conditionalTemplate2`),
+            () => templates.evaluate('conditionalTemplate2'),
             new Error(
-                `'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '\${dialog.abc}': Error occurred when evaluating '-IF :\${dialog.abc}'.`
+                "'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`structured1`),
+            () => templates.evaluate('structured1'),
             new Error(
-                `'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want \${dialog.abc}'.`
+                "'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`structured2`),
+            () => templates.evaluate('structured2'),
             new Error(
-                `'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'.`
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`structured3`),
+            () => templates.evaluate('structured3'),
             new Error(
-                `'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'. [structured3]  Error occurred when evaluating '\${structured2()}'.`
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`switchcase1`, { turn: { testValue: 1 } }),
+            () => templates.evaluate('switchcase1', { turn: { testValue: 1 } }),
             new Error(
-                `'dialog.abc' evaluated to null. [switchcase1] Case '\${1}': Error occurred when evaluating '-I want \${dialog.abc}'.`
+                "'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'."
             )
         );
 
         assert.throws(
-            () => templates.evaluate(`switchcase2`, { turn: { testValue: 0 } }),
+            () => templates.evaluate('switchcase2', { turn: { testValue: 0 } }),
             new Error(
-                `'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want \${dialog.abc}'.`
+                "'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'."
             )
         );
     });
 
-    it(`TestExpressionFormatError`, function () {
+    it('TestExpressionFormatError', function () {
         const diagnostics = preloaded.ExpressionFormatError;
         assert.strictEqual(diagnostics.length, 1);
-        assert(diagnostics[0].message.includes(`Close } is missing in Expression`));
+        assert(diagnostics[0].message.includes('Close } is missing in Expression'));
     });
 
-    it(`TestMultiLineExpressionInLG`, function () {
+    it('TestMultiLineExpressionInLG', function () {
         let diagnostics = preloaded.MultiLineExprError;
         assert.strictEqual(diagnostics.length, 1);
-        assert(diagnostics[0].message.includes(`Close } is missing in Expression`));
+        assert(diagnostics[0].message.includes('Close } is missing in Expression'));
 
         diagnostics = Templates.parseResource(new LGResource('', '', '#Demo2\r\n- ${createArray(1,\r\n, 2,3)'))
             .diagnostics;
         assert.strictEqual(diagnostics.length, 1);
-        assert(diagnostics[0].message.includes(`Close } is missing in Expression`));
+        assert(diagnostics[0].message.includes('Close } is missing in Expression'));
 
         diagnostics = Templates.parseResource(
             new LGResource('', '', '#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment')
         ).diagnostics;
         assert.strictEqual(diagnostics.length, 1);
-        assert(diagnostics[0].message.includes(`Close } is missing in Expression`));
+        assert(diagnostics[0].message.includes('Close } is missing in Expression'));
     });
 
-    it(`TestErrorLine`, function () {
+    it('TestErrorLine', function () {
         const diagnostics = preloaded.ErrorLine;
         assert.strictEqual(diagnostics.length, 4);
 
@@ -450,7 +450,7 @@ describe(`LGExceptionTest`, function () {
         assert(diagnostics[3].message.includes(TemplateErrors.invalidStrucBody('- hi')));
     });
 
-    it(`TestLoopReference`, function () {
+    it('TestLoopReference', function () {
         const diagnostics = preloaded.CycleRef1;
         assert.strictEqual(diagnostics.length, 1);
 


### PR DESCRIPTION
Addresses # 4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the botbuilder-lg library.

## Specific Changes
- Applied auto-fixes with yarn lint --fix.
	- Add trailing commas
	- Fix spacing.
	- Fix indentation.
	- Add blank line in between comments.
	- Fix quoting.
	- Replace arrow functions: () => with function ().
	- Replace let with const.
- Applied manual fixes for:
	- Missing documentation.
	- Unused parameters and imports.
	- Replacing hasOwnProperty calls.
	- Fixing lodash imports.

## Testing
<img width="151" alt="image" src="https://user-images.githubusercontent.com/64815358/166258887-d4d4a601-13f9-46f6-afd3-f0b84bbd98bf.png">

<img width="290" alt="image" src="https://user-images.githubusercontent.com/64815358/166258615-6eaebe0e-85b2-4dab-bfaf-178458c25cca.png">
