### PR TITLE
fix: [#4204] Fix remaining eslint warnings - Rest of botbuilder-dialogs libraries - botbuilder adaptive testing

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
+++ b/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
@@ -31,7 +31,7 @@ import { StringExpression } from 'adaptive-expressions';
 import { TestAdapter } from 'botbuilder-core';
 import { TurnContext } from 'botbuilder-core';
 
-// @public (undocumented)
+// @public
 export class AdaptiveTestBotComponent extends BotComponent {
     // (undocumented)
     configureServices(services: ServiceCollection, _configuration: Configuration): void;
@@ -44,7 +44,6 @@ export class AssertCondition<O extends object = {}> extends Dialog<O> implements
     beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     condition: Expression;
     description: StringExpression;
-    // (undocumented)
     getConverter(property: keyof AssertConditionConfiguration): Converter | ConverterFactory;
     // (undocumented)
     protected onComputeId(): string;
@@ -148,7 +147,7 @@ export interface AssertTelemetryContainsConfiguration {
     events?: string[];
 }
 
-// @public (undocumented)
+// @public
 class CustomEvent_2<T = unknown> extends TestAction implements CustomEventConfiguration {
     // (undocumented)
     static $kind: string;
@@ -229,7 +228,6 @@ export class MockLuisRecognizer extends Recognizer {
 export class MockSettingsMiddleware implements Middleware {
     // Warning: (ae-forgotten-export) The symbol "SettingMock" needs to be exported by the entry point index.d.ts
     constructor(settingMocks: SettingMock[]);
-    // (undocumented)
     onTurn(context: TurnContext, next: () => Promise<void>): Promise<void>;
 }
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
+++ b/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
@@ -41,7 +41,7 @@ export class AdaptiveTestBotComponent extends BotComponent {
 export class AssertCondition<O extends object = {}> extends Dialog<O> implements AssertConditionConfiguration {
     // (undocumented)
     static $kind: string;
-    beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+    beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult>;
     condition: Expression;
     description: StringExpression;
     // (undocumented)
@@ -63,7 +63,7 @@ export class AssertNoActivity extends TestAction implements AssertNoActivityConf
     // (undocumented)
     static $kind: string;
     description: string;
-    execute(adapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(adapter: TestAdapter, _callback: (context: TurnContext) => Promise<void>, _inspector?: Inspector): Promise<void>;
     getConditionDescription(): string;
 }
 
@@ -89,7 +89,7 @@ export class AssertReplyActivity extends TestAction implements AssertReplyActivi
     static $kind: string;
     assertions: string[];
     description: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<any>, inspector?: Inspector): Promise<any>;
+    execute(testAdapter: TestAdapter, _callback: (context: TurnContext) => Promise<any>, _inspector?: Inspector): Promise<any>;
     getConditionDescription(): string;
     timeout: number;
     validateReply(activity: Activity): void;
@@ -137,7 +137,7 @@ export class AssertTelemetryContains extends TestAction implements AssertTelemet
     static $kind: string;
     description: string;
     events: string[];
-    execute(adapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(_adapter: TestAdapter, _callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
 }
 
 // @public (undocumented)
@@ -152,7 +152,7 @@ export interface AssertTelemetryContainsConfiguration {
 class CustomEvent_2<T = unknown> extends TestAction implements CustomEventConfiguration {
     // (undocumented)
     static $kind: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, _inspector?: Inspector): Promise<void>;
     name: string;
     value?: T;
 }
@@ -188,7 +188,7 @@ export class MemoryAssertions extends TestAction implements MemoryAssertionsConf
     static $kind: string;
     assertions: string[];
     description: string;
-    execute(adapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(_adapter: TestAdapter, _callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
 }
 
 // @public (undocumented)
@@ -238,7 +238,7 @@ export class SetProperties extends TestAction {
     // (undocumented)
     static $kind: string;
     assignments: PropertyAssignment[];
-    execute(adapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(_adapter: TestAdapter, _callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
     // (undocumented)
     getConverter(property: keyof SetPropertiesConfiguration): Converter | ConverterFactory;
 }
@@ -329,7 +329,7 @@ export interface UserActivityConfiguration {
 export class UserConversationUpdate extends TestAction implements UserConversationUpdateConfiguration {
     // (undocumented)
     static $kind: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, _inspector?: Inspector): Promise<void>;
     membersAdded: string[];
     membersRemoved: string[];
 }
@@ -346,7 +346,7 @@ export interface UserConversationUpdateConfiguration {
 export class UserDelay extends TestAction implements UserDelayConfiguration {
     // (undocumented)
     static $kind: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<any>, inspector?: Inspector): Promise<void>;
+    execute(_testAdapter: TestAdapter, _callback: (context: TurnContext) => Promise<any>, _inspector?: Inspector): Promise<void>;
     timespan: number;
 }
 
@@ -360,7 +360,7 @@ export interface UserDelayConfiguration {
 export class UserSays extends TestAction implements UserSaysConfiguration {
     // (undocumented)
     static $kind: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, inspector?: Inspector): Promise<void>;
+    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<void>, _inspector?: Inspector): Promise<void>;
     locale: string;
     text: string;
     user: string;
@@ -378,7 +378,7 @@ export interface UserSaysConfiguration {
 export class UserTyping extends Configurable implements TestAction, UserTypingConfiguration {
     // (undocumented)
     static $kind: string;
-    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<any>, inspector?: Inspector): Promise<any>;
+    execute(testAdapter: TestAdapter, callback: (context: TurnContext) => Promise<any>, _inspector?: Inspector): Promise<any>;
     user: string;
 }
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/actions/assertCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/actions/assertCondition.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */
@@ -38,6 +37,13 @@ export class AssertCondition<O extends object = {}> extends Dialog<O> implements
      */
     public description: StringExpression;
 
+    /**
+     * Description of assertion.
+     *
+     * @param property Properties that extend RecognizerConfiguration.
+     * @returns Expression converter.
+     *
+     */
     public getConverter(property: keyof AssertConditionConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'condition':

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/actions/assertCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/actions/assertCondition.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */
@@ -50,11 +51,12 @@ export class AssertCondition<O extends object = {}> extends Dialog<O> implements
 
     /**
      * Called when the dialog is started and pushed onto the dialog stack.
+     *
      * @param dc The DialogContext for the current turn of the conversation.
-     * @param options Additional information to pass to the prompt being started.
+     * @param _options Additional information to pass to the prompt being started.
      * @returns A Promise representing the asynchronous operation.
      */
-    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+    public async beginDialog(dc: DialogContext, _options?: O): Promise<DialogTurnResult> {
         const { value } = this.condition.tryEvaluate(dc.state);
         if (!value) {
             let desc = this.description && this.description.getValue(dc.state);
@@ -68,6 +70,7 @@ export class AssertCondition<O extends object = {}> extends Dialog<O> implements
 
     /**
      * @protected
+     * @returns String of the condition which must be true.
      */
     protected onComputeId(): string {
         return `AssertCondition[${this.condition.toString()}]`;

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/adaptiveTestBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/adaptiveTestBotComponent.ts
@@ -28,7 +28,14 @@ import { SettingStringMock } from './settingMocks/settingStringMock';
 import { TestScript } from './testScript';
 import { UserTokenBasicMock } from './userTokenMocks';
 
+/**
+ * Adaptive Testing of BotComponent.
+ */
 export class AdaptiveTestBotComponent extends BotComponent {
+    /**
+     * @param services Services collection to mimic dependency injection.
+     * @param _configuration Configuration for the bot component.
+     */
     configureServices(services: ServiceCollection, _configuration: Configuration): void {
         services.composeFactory<ComponentDeclarativeTypes[]>('declarativeTypes', (declarativeTypes) =>
             declarativeTypes.concat({

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/dialogInspector.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/dialogInspector.ts
@@ -127,7 +127,7 @@ export class DialogInspector {
         }
 
         if (!this.conversationState) {
-            throw new Error(`The bot's 'conversationState' has not been configured.`);
+            throw new Error("The bot's 'conversationState' has not been configured.");
         }
         botStateSet.add(this.conversationState);
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestMock.ts
@@ -9,6 +9,9 @@
 import { Configurable, Converter } from 'botbuilder-dialogs';
 import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
 
+/**
+ * Base class for all http request mocks.
+ */
 export abstract class HttpRequestMock extends Configurable {
     public abstract setup(): void;
 }
@@ -17,8 +20,15 @@ export abstract class HttpRequestMock extends Configurable {
  * The type converters for UserTokenMock.
  */
 export class HttpRequestMocksConverter implements Converter<string[], HttpRequestMock[]> {
+    /**
+     * @param _resourceExplorer The resource to access the content.
+     */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
+    /**
+     * @param value Array of strings and Setting Mock elements.
+     * @returns Array of Setting Mocks.
+     */
     public convert(value: (string | HttpRequestMock)[]): HttpRequestMock[] {
         return value.map((item: string | HttpRequestMock) => {
             if (typeof item === 'string') {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockHttpRequestMiddleware.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockHttpRequestMiddleware.ts
@@ -46,6 +46,10 @@ export class MockHttpRequestMiddleware implements Middleware {
         this._httpRequestMocks = httpRequestMocks;
     }
 
+    /**
+     * @param context The content oject for this turn.
+     * @param next The delegate to call to continue the bot middleware pipeline.
+     */
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         context.turnState.set(MockHttpRequestMiddlewareKey, this);
         await next();

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockHttpRequestMiddleware.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockHttpRequestMiddleware.ts
@@ -47,7 +47,7 @@ export class MockHttpRequestMiddleware implements Middleware {
     }
 
     /**
-     * @param context The content oject for this turn.
+     * @param context The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline.
      */
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisExtensions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisLoader.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisLoader.ts
@@ -26,6 +26,11 @@ export class MockLuisLoader implements CustomDeserializer<MockLuisRecognizer, Lu
      */
     public constructor(private _resourceExplorer: ResourceExplorer, private _configuration?: Record<string, string>) {}
 
+    /**
+     * @param config Config to recognize intents and entities in a users utterance.
+     * @param type Cached LUIS responses for testing.
+     * @returns The new object created from the object parameter.
+     */
     public load(config: LuisAdaptiveRecognizerConfiguration, type: Newable<MockLuisRecognizer>): MockLuisRecognizer {
         const recognizer = new LuisAdaptiveRecognizer().configure(config as Record<string, unknown>);
         const externalEntityRecognizer = config.externalEntityRecognizer;

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisRecognizer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockLuisRecognizer.ts
@@ -74,6 +74,13 @@ export class MockLuisRecognizer extends Recognizer {
         }
     }
 
+    /**
+     * @param dialogContext Dialog context.
+     * @param activity Activity to recognize.
+     * @param telemetryProperties Additional properties to be logged to telemetry with the LuisResult event.
+     * @param telemetryMetrics Additional metrics to be logged to telemetry with the LuisResult event.
+     * @returns Analysis of utterance.
+     */
     public async recognize(
         dialogContext: DialogContext,
         activity: Activity,

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockSettingsMiddleware.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/mocks/mockSettingsMiddleware.ts
@@ -37,6 +37,12 @@ export class MockSettingsMiddleware implements Middleware {
         });
     }
 
+    /**
+     * Processes an incoming activity.
+     *
+     * @param context The context object for this turn.
+     * @param next The delegate to call to continue the bot middleware pipeline.
+     */
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         if (!this._configured) {
             if (this._mockData.size) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/setTestOptionsMiddleware.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/setTestOptionsMiddleware.ts
@@ -13,6 +13,7 @@ const CONVERSATION_STATE = 'ConversationState';
 export class SetTestOptionsMiddleware implements Middleware {
     /**
      * Processes an incoming event activity.
+     *
      * @param context The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline
      */

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/setTestOptionsMiddleware.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/setTestOptionsMiddleware.ts
@@ -10,6 +10,9 @@ import { Middleware, TurnContext, ActivityTypes } from 'botbuilder-core';
 
 const CONVERSATION_STATE = 'ConversationState';
 
+/**
+ * Middleware that catch "SetTestOptions" event and save into "Conversation.TestOptions".
+ */
 export class SetTestOptionsMiddleware implements Middleware {
     /**
      * Processes an incoming event activity.

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/settingMocks/settingMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/settingMocks/settingMock.ts
@@ -18,8 +18,15 @@ export abstract class SettingMock extends Configurable {}
  * The type converters for SettingMock.
  */
 export class SettingMocksConverter implements Converter<string[], SettingMock[]> {
+    /**
+     * @param _resourceExplorer Parameter to access content resources.
+     */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
+    /**
+     * @param value Array of strings and Setting Mock elements.
+     * @returns Array of Setting Mocks.
+     */
     public convert(value: (string | SettingMock)[]): SettingMock[] {
         return value.map((item: string | SettingMock) => {
             if (typeof item === 'string') {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertNoActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertNoActivity.ts
@@ -36,14 +36,14 @@ export class AssertNoActivity extends TestAction implements AssertNoActivityConf
     /**
      * Execute the test.
      *
-     * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param adapter Adapter to execute against.
+     * @param _callback Logic for the bot to use.
+     * @param _inspector Inspector for dialog context.
      */
     public async execute(
         adapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<void>,
-        inspector?: Inspector
+        _callback: (context: TurnContext) => Promise<void>,
+        _inspector?: Inspector
     ): Promise<void> {
         if (adapter.activeQueue.length > 0) {
             throw new Error(this.getConditionDescription());

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReply.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReply.ts
@@ -44,7 +44,7 @@ export class AssertReply extends AssertReplyActivity implements AssertReplyConfi
      *
      * @param activity The activity to verify.
      */
-    public validateReply(activity: Activity): void {
+    public validateReply(activity: Activity) {
         if (this.text) {
             if (this.exact) {
                 if (activity.type == ActivityTypes.Message && activity.text != this.text) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReply.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReply.ts
@@ -32,6 +32,7 @@ export class AssertReply extends AssertReplyActivity implements AssertReplyConfi
 
     /**
      * Gets the text to assert for an activity.
+     *
      * @returns String.
      */
     public getConditionDescription(): string {
@@ -40,9 +41,10 @@ export class AssertReply extends AssertReplyActivity implements AssertReplyConfi
 
     /**
      * Validates the reply of an activity.
+     *
      * @param activity The activity to verify.
      */
-    public validateReply(activity: Activity) {
+    public validateReply(activity: Activity): void {
         if (this.text) {
             if (this.exact) {
                 if (activity.type == ActivityTypes.Message && activity.text != this.text) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-constant-condition */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */
@@ -79,6 +78,7 @@ export class AssertReplyActivity extends TestAction implements AssertReplyActivi
         _inspector?: Inspector
     ): Promise<any> {
         const start = new Date();
+        /* eslint-disable no-constant-condition */
         while (true) {
             const current = new Date();
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyActivity.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-constant-condition */
 /**
  * @module botbuilder-dialogs-adaptive-testing
  */
@@ -39,6 +40,7 @@ export class AssertReplyActivity extends TestAction implements AssertReplyActivi
 
     /**
      * Gets the text to assert for an activity.
+     *
      * @returns String.
      */
     public getConditionDescription(): string {
@@ -47,6 +49,7 @@ export class AssertReplyActivity extends TestAction implements AssertReplyActivi
 
     /**
      * Validates the reply of an activity.
+     *
      * @param activity The activity to verify.
      */
     public validateReply(activity: Activity): void {
@@ -64,15 +67,16 @@ export class AssertReplyActivity extends TestAction implements AssertReplyActivi
 
     /**
      * Execute the test.
+     *
      * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param _callback Logic for the bot to use.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
         testAdapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<any>,
-        inspector?: Inspector
+        _callback: (context: TurnContext) => Promise<any>,
+        _inspector?: Inspector
     ): Promise<any> {
         const start = new Date();
         while (true) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyOneOf.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertReplyOneOf.ts
@@ -32,6 +32,7 @@ export class AssertReplyOneOf extends AssertReplyActivity implements AssertReply
 
     /**
      * Gets the text to assert for an activity.
+     *
      * @returns String.
      */
     public getConditionDescription(): string {
@@ -40,6 +41,7 @@ export class AssertReplyOneOf extends AssertReplyActivity implements AssertReply
 
     /**
      * Validates the reply of an activity.
+     *
      * @param activity The activity to verify.
      */
     public validateReply(activity: Activity): void {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertTelemetryContains.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/assertTelemetryContains.ts
@@ -33,14 +33,15 @@ export class AssertTelemetryContains extends TestAction implements AssertTelemet
 
     /**
      * Execute the test.
-     * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
+     *
+     * @param _adapter Adapter to execute against.
+     * @param _callback Logic for the bot to use.
      * @param inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
-        adapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<void>,
+        _adapter: TestAdapter,
+        _callback: (context: TurnContext) => Promise<void>,
         inspector?: Inspector
     ): Promise<void> {
         if (inspector) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/customEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/customEvent.ts
@@ -28,15 +28,16 @@ export class CustomEvent<T = unknown> extends TestAction implements CustomEventC
 
     /**
      * Execute the test.
+     *
      * @param testAdapter Adapter to execute against.
      * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
         testAdapter: TestAdapter,
         callback: (context: TurnContext) => Promise<void>,
-        inspector?: Inspector
+        _inspector?: Inspector
     ): Promise<void> {
         if (!this.name) {
             throw Error('You must define the event name.');

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/customEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/customEvent.ts
@@ -14,6 +14,9 @@ export interface CustomEventConfiguration {
     value?: unknown;
 }
 
+/**
+ * Action to script sending custom event to the bot.
+ */
 export class CustomEvent<T = unknown> extends TestAction implements CustomEventConfiguration {
     public static $kind = 'Microsoft.Test.CustomEvent';
     /**

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/memoryAssertions.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/memoryAssertions.ts
@@ -33,14 +33,15 @@ export class MemoryAssertions extends TestAction implements MemoryAssertionsConf
 
     /**
      * Execute the test.
-     * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
+     *
+     * @param _adapter Adapter to execute against.
+     * @param _callback Logic for the bot to use.
      * @param inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
-        adapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<void>,
+        _adapter: TestAdapter,
+        _callback: (context: TurnContext) => Promise<void>,
         inspector?: Inspector
     ): Promise<void> {
         if (inspector) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/setProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/setProperties.ts
@@ -57,14 +57,15 @@ export class SetProperties extends TestAction {
 
     /**
      * Execute the test.
-     * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
+     *
+     * @param _adapter Adapter to execute against.
+     * @param _callback Logic for the bot to use.
      * @param inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
-        adapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<void>,
+        _adapter: TestAdapter,
+        _callback: (context: TurnContext) => Promise<void>,
         inspector?: Inspector
     ): Promise<void> {
         if (inspector) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/setProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/setProperties.ts
@@ -46,6 +46,10 @@ export class SetProperties extends TestAction {
      */
     public assignments: PropertyAssignment[] = [];
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof SetPropertiesConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'assignments':

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userConversationUpdate.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userConversationUpdate.ts
@@ -32,15 +32,16 @@ export class UserConversationUpdate extends TestAction implements UserConversati
 
     /**
      * Execute the test.
+     *
      * @param testAdapter Adapter to execute against.
      * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
         testAdapter: TestAdapter,
         callback: (context: TurnContext) => Promise<void>,
-        inspector?: Inspector
+        _inspector?: Inspector
     ): Promise<void> {
         const activity = testAdapter.makeActivity();
         activity.type = ActivityTypes.ConversationUpdate;

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userDelay.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userDelay.ts
@@ -26,15 +26,16 @@ export class UserDelay extends TestAction implements UserDelayConfiguration {
 
     /**
      * Execute the test.
-     * @param testAdapter Adapter to execute against.
-     * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     *
+     * @param _testAdapter Adapter to execute against.
+     * @param _callback Logic for the bot to use.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
-        testAdapter: TestAdapter,
-        callback: (context: TurnContext) => Promise<any>,
-        inspector?: Inspector
+        _testAdapter: TestAdapter,
+        _callback: (context: TurnContext) => Promise<any>,
+        _inspector?: Inspector
     ): Promise<void> {
         await Promise.resolve((resolve) => setTimeout(resolve, this.timespan));
     }

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userSays.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userSays.ts
@@ -37,15 +37,16 @@ export class UserSays extends TestAction implements UserSaysConfiguration {
 
     /**
      * Execute the test.
+     *
      * @param testAdapter Adapter to execute against.
      * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
         testAdapter: TestAdapter,
         callback: (context: TurnContext) => Promise<void>,
-        inspector?: Inspector
+        _inspector?: Inspector
     ): Promise<void> {
         if (!this.text) {
             throw new Error('You must define the text property');

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userTyping.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userTyping.ts
@@ -27,15 +27,16 @@ export class UserTyping extends Configurable implements TestAction, UserTypingCo
 
     /**
      * Execute the test.
+     *
      * @param testAdapter Adapter to execute against.
      * @param callback Logic for the bot to use.
-     * @param inspector Inspector for dialog context.
+     * @param _inspector Inspector for dialog context.
      * @returns A Promise that represents the work queued to execute.
      */
     public async execute(
         testAdapter: TestAdapter,
         callback: (context: TurnContext) => Promise<any>,
-        inspector?: Inspector
+        _inspector?: Inspector
     ): Promise<any> {
         const typing = testAdapter.makeActivity();
         typing.type = ActivityTypes.Typing;

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testScript.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testScript.ts
@@ -132,6 +132,10 @@ export class TestScript extends Configurable implements TestScriptConfiguration 
      */
     public enableTrace = false;
 
+    /**
+     * @param property The key of the conditional selector configuration.
+     * @returns The converter for the selector configuration.
+     */
     public getConverter(property: keyof TestScriptConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'dialog':

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testScript.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testScript.ts
@@ -44,7 +44,7 @@ import { SettingMock, SettingMocksConverter } from './settingMocks/settingMock';
 import { TestTelemetryClient } from './testTelemetryClient';
 
 class DialogConverter implements Converter<string, Dialog> {
-    public constructor(private readonly _resourceExplorer: ResourceExplorer) { }
+    public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
     public convert(value: string | Dialog): Dialog {
         if (value instanceof Dialog) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testTelemetryClient.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testTelemetryClient.ts
@@ -17,7 +17,7 @@ export class TestTelemetryClient implements BotTelemetryClient {
      *
      * @param _settings Optional. Settings for the telemetry client.
      */
-    constructor(_settings?: unknown) {
+    constructor(_settings?: any) {
         // noop
     }
 
@@ -26,7 +26,7 @@ export class TestTelemetryClient implements BotTelemetryClient {
      *
      * @param _telemetry An object implementing [TelemetryDependency](xref:botbuilder-core.TelemetryDependency).
      */
-    trackDependency(_telemetry: TelemetryDependency): void {
+    trackDependency(_telemetry: TelemetryDependency) {
         // noop
     }
 
@@ -35,7 +35,7 @@ export class TestTelemetryClient implements BotTelemetryClient {
      *
      * @param telemetry An object implementing [TelemetryEvent](xref:botbuilder-core.TelemetryEvent).
      */
-    trackEvent(telemetry: TelemetryEvent): void {
+    trackEvent(telemetry: TelemetryEvent) {
         this.invocations.push(telemetry.name);
     }
 
@@ -44,7 +44,7 @@ export class TestTelemetryClient implements BotTelemetryClient {
      *
      * @param _telemetry An object implementing [TelemetryException](xref:botbuilder-core.TelemetryException).
      */
-    trackException(_telemetry: TelemetryException): void {
+    trackException(_telemetry: TelemetryException) {
         // noop
     }
 
@@ -53,14 +53,14 @@ export class TestTelemetryClient implements BotTelemetryClient {
      *
      * @param _telemetry An object implementing [TelemetryTrace](xref:botbuilder-core.TelemetryTrace).
      */
-    trackTrace(_telemetry: TelemetryTrace): void {
+    trackTrace(_telemetry: TelemetryTrace) {
         // noop
     }
 
     /**
      * Flushes the in-memory buffer and any metrics being pre-aggregated.
      */
-    flush(): void {
+    flush() {
         // noop
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testTelemetryClient.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testTelemetryClient.ts
@@ -10,53 +10,57 @@ import {
  * A test bot telemetry client that implements [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient).
  */
 export class TestTelemetryClient implements BotTelemetryClient {
-
     //Trace all events happened in trackEvents method
     public invocations: string[] = [];
     /**
      * Creates a new instance of the [TestTelemetryClient](xref:botbuilder-dialogs-adaptive-testing.TestTelemetryClient) class.
-     * @param settings Optional. Settings for the telemetry client.
+     *
+     * @param _settings Optional. Settings for the telemetry client.
      */
-    constructor(settings?: any) {
+    constructor(_settings?: unknown) {
         // noop
     }
 
     /**
      * Sends information about an external dependency (outgoing call) in the application.
-     * @param telemetry An object implementing [TelemetryDependency](xref:botbuilder-core.TelemetryDependency).
+     *
+     * @param _telemetry An object implementing [TelemetryDependency](xref:botbuilder-core.TelemetryDependency).
      */
-    trackDependency(telemetry: TelemetryDependency) {
+    trackDependency(_telemetry: TelemetryDependency): void {
         // noop
     }
 
     /**
      * Logs custom events with extensible named fields.
+     *
      * @param telemetry An object implementing [TelemetryEvent](xref:botbuilder-core.TelemetryEvent).
      */
-    trackEvent(telemetry: TelemetryEvent) {
+    trackEvent(telemetry: TelemetryEvent): void {
         this.invocations.push(telemetry.name);
     }
 
     /**
      * Logs a system exception.
-     * @param telemetry An object implementing [TelemetryException](xref:botbuilder-core.TelemetryException).
+     *
+     * @param _telemetry An object implementing [TelemetryException](xref:botbuilder-core.TelemetryException).
      */
-    trackException(telemetry: TelemetryException) {
+    trackException(_telemetry: TelemetryException): void {
         // noop
     }
 
     /**
      * Sends a trace message.
-     * @param telemetry An object implementing [TelemetryTrace](xref:botbuilder-core.TelemetryTrace).
+     *
+     * @param _telemetry An object implementing [TelemetryTrace](xref:botbuilder-core.TelemetryTrace).
      */
-    trackTrace(telemetry: TelemetryTrace) {
+    trackTrace(_telemetry: TelemetryTrace): void {
         // noop
     }
 
     /**
      * Flushes the in-memory buffer and any metrics being pre-aggregated.
      */
-    flush() {
+    flush(): void {
         // noop
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testUtils.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testUtils.ts
@@ -15,6 +15,7 @@ import { TestScript } from './testScript';
 export class TestUtils {
     /**
      * Runs a test script with the specified name.
+     *
      * @param resourceExplorer Resource explorer used in test.
      * @param testName Test name.
      * @param adapter Test adapter.

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/userTokenMocks/userTokenBasicMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/userTokenMocks/userTokenBasicMock.ts
@@ -50,6 +50,7 @@ export class UserTokenBasicMock extends UserTokenMock implements UserTokenBasicM
 
     /**
      * Method to setup this mock for an adapter.
+     *
      * @param adapter The test adapter to use for mocking.
      */
     public setup(adapter: TestAdapter): void {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/userTokenMocks/userTokenMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/userTokenMocks/userTokenMock.ts
@@ -24,8 +24,15 @@ export abstract class UserTokenMock extends Configurable {
  * The type converters for UserTokenMock.
  */
 export class UserTokenMocksConverter implements Converter<string[], UserTokenMock[]> {
+    /**
+     * @param _resourceExplorer Parameter to access content resources.
+     */
     public constructor(private readonly _resourceExplorer: ResourceExplorer) {}
 
+    /**
+     * @param value Array of strings and Setting Mock elements.
+     * @returns Array of Setting Mocks.
+     */
     public convert(value: (string | UserTokenMock)[]): UserTokenMock[] {
         return value.map((item: string | UserTokenMock) => {
             if (typeof item === 'string') {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -112,31 +112,31 @@ describe('ActionTests', function () {
         resourceExplorer = makeResourceExplorer('ActionTests', LanguageGenerationBotComponent);
     });
 
-    it('AttachmentInput', async () => {
+    it('AttachmentInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_AttachmentInput');
     });
 
-    it('BeginDialog', async () => {
+    it('BeginDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialog');
     });
 
-    it('BeginDialogWithExpr', async () => {
+    it('BeginDialogWithExpr', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialogWithExpr');
     });
 
-    it('BeginDialogWithExpr2', async () => {
+    it('BeginDialogWithExpr2', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialogWithExpr2');
     });
 
-    it('BeginDialogWithExpr3', async () => {
+    it('BeginDialogWithExpr3', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialogWithExpr3');
     });
 
-    it('BeginDialogWithActivity', async () => {
+    it('BeginDialogWithActivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialogWithActivity');
     });
 
-    it('BeginSkill', async () => {
+    it('BeginSkill', async function () {
         await TestUtils.runTestScript(
             resourceExplorer,
             'Action_BeginSkill',
@@ -147,7 +147,7 @@ describe('ActionTests', function () {
         );
     });
 
-    it('BeginSkillEndDialog', async () => {
+    it('BeginSkillEndDialog', async function () {
         await TestUtils.runTestScript(
             resourceExplorer,
             'Action_BeginSkillEndDialog',
@@ -158,163 +158,163 @@ describe('ActionTests', function () {
         );
     });
 
-    it('CancelAllDialogs', async () => {
+    it('CancelAllDialogs', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_CancelAllDialogs');
     });
 
-    it('CancelAllDialogs_DoubleCancel', async () => {
+    it('CancelAllDialogs_DoubleCancel', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_CancelAllDialogs_DoubleCancel');
     });
 
-    it('CancelDialog', async () => {
+    it('CancelDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_CancelDialog');
     });
 
-    it('CancelDialogs_Processed', async () => {
+    it('CancelDialogs_Processed', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_CancelDialog_Processed');
     });
 
-    it('ChoiceInput', async () => {
+    it('ChoiceInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput');
     });
 
-    it('ChoiceInputWithLocale', async () => {
+    it('ChoiceInputWithLocale', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput_WithLocale');
     });
 
-    it('ChoicesInMemory', async () => {
+    it('ChoicesInMemory', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoicesInMemory');
     });
 
-    it('ChoiceInputSimpleTemplate_en', async () => {
+    it('ChoiceInputSimpleTemplate_en', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput_SimpleTemplate_en');
     });
 
-    it('ChoiceInputSimpleTemplate_es', async () => {
+    it('ChoiceInputSimpleTemplate_es', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput_SimpleTemplate_es');
     });
 
-    it('ChoiceInputComplexTemplate_en', async () => {
+    it('ChoiceInputComplexTemplate_en', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput_ComplexTemplate_en');
     });
 
-    it('ChoiceInputComplexTemplate_es', async () => {
+    it('ChoiceInputComplexTemplate_es', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceInput_ComplexTemplate_es');
     });
 
-    it('ChoiceStringInMemory', async () => {
+    it('ChoiceStringInMemory', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceStringInMemory');
     });
 
-    it('ConfirmInput', async () => {
+    it('ConfirmInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput');
     });
 
-    it('DeleteActivity', async () => {
+    it('DeleteActivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DeleteActivity');
     });
 
-    it('DatetimeInput', async () => {
+    it('DatetimeInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DatetimeInput');
     });
 
-    it('ConfirmInputSimpleTemplate_en', async () => {
+    it('ConfirmInputSimpleTemplate_en', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput_SimpleTemplate_en');
     });
 
-    it('ConfirmInputComplexTemplate_en', async () => {
+    it('ConfirmInputComplexTemplate_en', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput_ComplexTemplate_en');
     });
 
-    it('ConfirmInputSimpleTemplate_es', async () => {
+    it('ConfirmInputSimpleTemplate_es', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput_SimpleTemplate_es');
     });
 
-    it('ConfirmInputComplexTemplate_es', async () => {
+    it('ConfirmInputComplexTemplate_es', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput_ComplexTemplate_es');
     });
 
-    it('DeleteProperties', async () => {
+    it('DeleteProperties', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DeleteProperties');
     });
 
-    it('DeleteProperty', async () => {
+    it('DeleteProperty', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DeleteProperty');
     });
 
-    it('DoActions', async () => {
+    it('DoActions', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DoActions');
     });
 
-    it('DynamicBeginDialog', async () => {
+    it('DynamicBeginDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_DynamicBeginDialog');
     });
 
-    it('EditActionAppendActions', async () => {
+    it('EditActionAppendActions', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_EditActionAppendActions');
     });
 
-    it('EditActionInsertActions', async () => {
+    it('EditActionInsertActions', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_EditActionInsertActions');
     });
 
-    it('EditActionReplaceSequence', async () => {
+    it('EditActionReplaceSequence', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_EditActionReplaceSequence');
     });
 
-    it('EmitEvent', async () => {
+    it('EmitEvent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_EmitEvent');
     });
 
-    it('EndDialog', async () => {
+    it('EndDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_EndDialog');
     });
 
-    it('Foreach_Nested', async () => {
+    it('Foreach_Nested', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach_Nested');
     });
 
-    it('Foreach', async () => {
+    it('Foreach', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach');
     });
 
-    it('Foreach_Empty', async () => {
+    it('Foreach_Empty', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach_Empty');
     });
 
-    it('Foreach_Object', async () => {
+    it('Foreach_Object', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach_Object');
     });
 
-    it('ForeachPage_Empty', async () => {
+    it('ForeachPage_Empty', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ForeachPage_Empty');
     });
 
-    it('ForeachPage_Nested', async () => {
+    it('ForeachPage_Nested', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ForeachPage_Nested');
     });
 
-    it('ForeachPage_Partial', async () => {
+    it('ForeachPage_Partial', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ForeachPage_Partial');
     });
 
-    it('ForeachPage', async () => {
+    it('ForeachPage', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ForeachPage');
     });
 
-    it('GetActivityMembers', async () => {
+    it('GetActivityMembers', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_GetActivityMembers');
     });
 
-    it('GetConversationMembers', async () => {
+    it('GetConversationMembers', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_GetConversationMembers');
     });
 
-    it('GotoAction', async () => {
+    it('GotoAction', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_GotoAction');
     });
 
-    it('HttpRequest', async () => {
+    it('HttpRequest', async function () {
         nock('http://foo.com').post('/', 'Joe is 52').reply(200, 'string');
         nock('http://foo.com').post('/', { text: 'Joe is 52', age: 52 }).reply(200, 'object');
         nock('http://foo.com')
@@ -332,39 +332,39 @@ describe('ActionTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_HttpRequest');
     });
 
-    it('IfCondition', async () => {
+    it('IfCondition', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_IfCondition');
     });
 
-    it('InputDialog_ActivityProcessed', async () => {
+    it('InputDialog_ActivityProcessed', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'InputDialog_ActivityProcessed');
     });
 
-    it('NumerInput', async () => {
+    it('NumerInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_NumberInput');
     });
 
-    it('NumerInputWithDefaultValue', async () => {
+    it('NumerInputWithDefaultValue', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_NumberInputWithDefaultValue');
     });
 
-    it('NumberInputWithValueExpression', async () => {
+    it('NumberInputWithValueExpression', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_NumberInputWithValueExpression');
     });
 
-    it('RepeatDialog', async () => {
+    it('RepeatDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_RepeatDialog');
     });
 
-    it('RepeatDialogLoop', async () => {
+    it('RepeatDialogLoop', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_RepeatDialogLoop');
     });
 
-    it('ReplaceDialog', async () => {
+    it('ReplaceDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ReplaceDialog');
     });
 
-    it('ReplaceDialogDifferentLevel', async () => {
+    it('ReplaceDialogDifferentLevel', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ReplaceDialogDifferentLevel');
     });
 
@@ -374,83 +374,83 @@ describe('ActionTests', function () {
     });
     */
 
-    it('ReplaceDialogRoot', async () => {
+    it('ReplaceDialogRoot', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ReplaceDialogRoot');
     });
 
-    it('SendActivity', async () => {
+    it('SendActivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SendActivity');
     });
 
-    it('SendActivityWithLGAlias', async () => {
+    it('SendActivityWithLGAlias', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SendActivity_LGAlias');
     });
 
-    it('SetProperties', async () => {
+    it('SetProperties', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SetProperties');
     });
 
-    it('SetProperty', async () => {
+    it('SetProperty', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SetProperty');
     });
 
-    it('SignOutUser', async () => {
+    it('SignOutUser', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SignOutUser');
     });
 
-    it('Switch_Bool', async () => {
+    it('Switch_Bool', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Switch_Bool');
     });
 
-    it('Switch_Default', async () => {
+    it('Switch_Default', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Switch_Default');
     });
 
-    it('Switch_Number', async () => {
+    it('Switch_Number', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Switch_Number');
     });
 
-    it('Switch', async () => {
+    it('Switch', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Switch');
     });
 
-    it('TextInput', async () => {
+    it('TextInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInput');
     });
 
-    it('TextInputWithEmptyPrompt', async () => {
+    it('TextInputWithEmptyPrompt', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInput_WithEmptyPrompt');
     });
 
-    it('TextInputWithInvalidPrompt', async () => {
+    it('TextInputWithInvalidPrompt', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithInvalidPrompt');
     });
 
-    it('TextInputWithValueExpression', async () => {
+    it('TextInputWithValueExpression', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithValueExpression');
     });
 
-    it('TextInputWithInvalidResponse', async () => {
+    it('TextInputWithInvalidResponse', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithInvalidResponse');
     });
 
-    it('TextInputWithNonStringInput', async () => {
+    it('TextInputWithNonStringInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithNonStringInput');
     });
 
-    it('TraceActivity', async () => {
+    it('TraceActivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TraceActivity');
     });
 
-    it('ThrowException', async () => {
+    it('ThrowException', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ThrowException');
     });
 
-    it('UpdateActivity', async () => {
+    it('UpdateActivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_UpdateActivity');
     });
 
-    it('WaitForInput', async () => {
+    it('WaitForInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_WaitForInput');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/actionScope.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/actionScope.test.js
@@ -7,31 +7,31 @@ describe('ActionScopeTests', function () {
         resourceExplorer = makeResourceExplorer('ActionScopeTests');
     });
 
-    it('Break', async () => {
+    it('Break', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Break');
     });
 
-    it('Continue', async () => {
+    it('Continue', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Continue');
     });
 
-    it('Goto_Nowhere', async () => {
+    it('Goto_Nowhere', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Goto_Nowhere');
     });
 
-    it('Goto_OnIntent', async () => {
+    it('Goto_OnIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Goto_OnIntent');
     });
 
-    it('Goto_Parent', async () => {
+    it('Goto_Parent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Goto_Parent');
     });
 
-    it('Goto_Switch', async () => {
+    it('Goto_Switch', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Goto_Switch');
     });
 
-    it('Goto', async () => {
+    it('Goto', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ActionScope_Goto');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/crossTrainedRecognizerSet.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/crossTrainedRecognizerSet.test.js
@@ -33,47 +33,47 @@ describe('CrossTrainedRecognizerSetTests', function () {
         resourceExplorer = makeResourceExplorer('CrossTrainedRecognizerSetTests');
     });
 
-    it('AllNone', async () => {
+    it('AllNone', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_AllNone');
     });
 
-    it('CircleDefer', async () => {
+    it('CircleDefer', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_CircleDefer');
     });
 
-    it('DoubleDefer', async () => {
+    it('DoubleDefer', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_DoubleDefer');
     });
 
-    it('DoubleIntent', async () => {
+    it('DoubleIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_DoubleIntent');
     });
 
-    it('Empty', async () => {
+    it('Empty', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_Empty');
     });
 
-    it('NoneWithIntent', async () => {
+    it('NoneWithIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_NoneWithIntent');
     });
 
-    it('EntitiesWithNoneIntent', async () => {
+    it('EntitiesWithNoneIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CrossTrainedRecognizerSetTests_NoneIntentWithEntities');
     });
 
-    describe('Telemetry', () => {
+    describe('Telemetry', function () {
         const recognizer = createRecognizer();
         let spy;
 
-        beforeEach(() => {
+        beforeEach(function () {
             spy = spyOnTelemetryClientTrackEvent(recognizer);
         });
 
-        afterEach(() => {
+        afterEach(function () {
             spy.restore();
         });
 
-        it('should log PII when logPersonalInformation is true', async () => {
+        it('should log PII when logPersonalInformation is true', async function () {
             recognizer.logPersonalInformation = true;
 
             await recognizeIntentAndValidateTelemetry({
@@ -91,7 +91,7 @@ describe('CrossTrainedRecognizerSetTests', function () {
             });
         });
 
-        it('should not log PII when logPersonalInformation is false', async () => {
+        it('should not log PII when logPersonalInformation is false', async function () {
             recognizer.logPersonalInformation = false;
 
             await recognizeIntentAndValidateTelemetry({
@@ -109,7 +109,7 @@ describe('CrossTrainedRecognizerSetTests', function () {
             });
         });
 
-        it('should refrain from logging PII by default', async () => {
+        it('should refrain from logging PII by default', async function () {
             const recognizerWithDefaultLogPii = createRecognizer();
             const trackEventSpy = spyOnTelemetryClientTrackEvent(recognizerWithDefaultLogPii);
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/functions.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/functions.test.js
@@ -7,11 +7,11 @@ describe('ActionScopeTests', function () {
         resourceExplorer = makeResourceExplorer('FunctionsTests');
     });
 
-    it('HasPendingActions', async () => {
+    it('HasPendingActions', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'hasPendingActions');
     });
 
-    it('IsDialogActive', async () => {
+    it('IsDialogActive', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'isDialogActive');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/injectLG.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/injectLG.test.js
@@ -7,7 +7,7 @@ describe('ActionScopeTests', function () {
         resourceExplorer = makeResourceExplorer('InjectLGTests');
     });
 
-    it('InjectLGTest', async () => {
+    it('InjectLGTest', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'inject');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/lgGenerators.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/lgGenerators.test.js
@@ -7,31 +7,31 @@ describe('LGGeneratorTests', function () {
         resourceExplorer = makeResourceExplorer('LGGeneratorTests');
     });
 
-    it('MultiLandE2E', async () => {
+    it('MultiLandE2E', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLangE2E');
     });
 
-    it('LGMiddleWare', async () => {
+    it('LGMiddleWare', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'LGMiddleWare');
     });
 
-    it('LGScopeAccess', async () => {
+    it('LGScopeAccess', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'LGScopeAccess');
     });
 
-    it('No Language Generator', async () => {
+    it('No Language Generator', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'NoLanguageGeneration');
     });
 
-    it('Customize Language Policy', async () => {
+    it('Customize Language Policy', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'CustomizeLanguagePolicy');
     });
 
-    it('LocaleInExpr', async () => {
+    it('LocaleInExpr', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'LocaleInExpr');
     });
 
-    it('Manually set locale', async () => {
+    it('Manually set locale', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'manuallySetLocale');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/luisAdaptiveRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/luisAdaptiveRecognizer.test.js
@@ -4,7 +4,7 @@ const { MockLuisLoader, MockLuisRecognizer, TestUtils, useMockLuisSettings } = r
 const { makeResourceExplorer } = require('./utils');
 
 describe('LuisAdaptiveRecognizerTests', function () {
-    it('Dynamic lists', async () => {
+    it('Dynamic lists', async function () {
         const resourceDir = path.join(__dirname, 'resources/LuisAdaptiveRecognizerTests');
         const config = useMockLuisSettings(resourceDir);
         const explorer = makeResourceExplorer('LuisAdaptiveRecognizerTests', LuisBotComponent);
@@ -12,7 +12,7 @@ describe('LuisAdaptiveRecognizerTests', function () {
         await TestUtils.runTestScript(explorer, 'DynamicLists', undefined, config);
     });
 
-    it('Dynamic lists expression', async () => {
+    it('Dynamic lists expression', async function () {
         const resourceDir = path.join(__dirname, 'resources/LuisAdaptiveRecognizerTests');
         const config = useMockLuisSettings(resourceDir);
         const explorer = makeResourceExplorer('LuisAdaptiveRecognizerTests', LuisBotComponent);
@@ -20,7 +20,7 @@ describe('LuisAdaptiveRecognizerTests', function () {
         await TestUtils.runTestScript(explorer, 'DynamicListsExpression', undefined, config);
     });
 
-    it('ExternalEntities', async () => {
+    it('ExternalEntities', async function () {
         const resourceDir = path.join(__dirname, 'resources/LuisAdaptiveRecognizerTests');
         const config = useMockLuisSettings(resourceDir);
         const explorer = makeResourceExplorer('LuisAdaptiveRecognizerTests', LuisBotComponent);
@@ -28,7 +28,7 @@ describe('LuisAdaptiveRecognizerTests', function () {
         await TestUtils.runTestScript(explorer, 'ExternalEntities', undefined, config);
     });
 
-    it('Cached Luis Result', async () => {
+    it('Cached Luis Result', async function () {
         const resourceDir = path.join(__dirname, 'resources/LuisAdaptiveRecognizerTests');
         const config = useMockLuisSettings(resourceDir);
         const explorer = makeResourceExplorer('LuisAdaptiveRecognizerTests', LuisBotComponent);

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/misc.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/misc.test.js
@@ -7,11 +7,11 @@ describe('MiscTests', function () {
         resourceExplorer = makeResourceExplorer('MiscTests');
     });
 
-    it('IfCondition_EndDialog', async () => {
+    it('IfCondition_EndDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'IfCondition_EndDialog');
     });
 
-    it('Rule_Reprompt', async () => {
+    it('Rule_Reprompt', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Rule_Reprompt');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/multiLanguageGeneratorTests.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/multiLanguageGeneratorTests.test.js
@@ -7,19 +7,19 @@ describe('MultiLanguageGeneratorTests', function () {
         resourceExplorer = makeResourceExplorer('MultiLanguageGeneratorTests');
     });
 
-    it('Switch Language Activity', async () => {
+    it('Switch Language Activity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SwitchLanguageActivity');
     });
 
-    it('Switch Language Conversation', async () => {
+    it('Switch Language Conversation', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SwitchLanguageConversation');
     });
 
-    it('Switch Language Turn', async () => {
+    it('Switch Language Turn', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SwitchLanguageTurn');
     });
 
-    it('Switch Language Turn Activity', async () => {
+    it('Switch Language Turn Activity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SwitchLanguageTurnActivity');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/multiLanguageRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/multiLanguageRecognizer.test.js
@@ -29,54 +29,54 @@ describe('MultiLanguageRecognizerTests', function () {
         resourceExplorer = makeResourceExplorer('MultiLanguageRecognizerTests');
     });
 
-    it('DefaultFallback', async () => {
+    it('DefaultFallback', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_DefaultFallback');
     });
 
-    it('EnFallback', async () => {
+    it('EnFallback', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_EnFallback');
     });
 
-    it('EnGbFallback', async () => {
+    it('EnGbFallback', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_EnGbFallback');
     });
 
-    it('EnUsFallback', async () => {
+    it('EnUsFallback', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_EnUsFallback');
     });
 
-    it('EnUsFallback_AcitivtyLocaleCasing', async () => {
+    it('EnUsFallback_AcitivtyLocaleCasing', async function () {
         await TestUtils.runTestScript(
             resourceExplorer,
             'MultiLanguageRecognizerTest_EnUsFallback_ActivityLocaleCasing'
         );
     });
 
-    it('LanguagePolicy', async () => {
+    it('LanguagePolicy', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_LanguagePolicy');
     });
 
-    it('Locale case insensitivity', async () => {
+    it('Locale case insensitivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_LocaleCaseInsensitivity');
     });
 
-    it('Recognizer case insensitivity', async () => {
+    it('Recognizer case insensitivity', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'MultiLanguageRecognizerTest_RecognizerCaseInsensitivity');
     });
 
-    describe('Telemetry', () => {
+    describe('Telemetry', function () {
         const recognizer = createRecognizer();
         let spy;
 
-        beforeEach(() => {
+        beforeEach(function () {
             spy = spyOnTelemetryClientTrackEvent(recognizer);
         });
 
-        afterEach(() => {
+        afterEach(function () {
             spy.restore();
         });
 
-        it('Merge - should log PII when logPersonalInformation is true', async () => {
+        it('Merge - should log PII when logPersonalInformation is true', async function () {
             recognizer.logPersonalInformation = true;
 
             await recognizeIntentAndValidateTelemetry({
@@ -87,7 +87,7 @@ describe('MultiLanguageRecognizerTests', function () {
             });
         });
 
-        it('Merge - should not log PII when logPersonalInformation is false', async () => {
+        it('Merge - should not log PII when logPersonalInformation is false', async function () {
             recognizer.logPersonalInformation = false;
 
             await recognizeIntentAndValidateTelemetry({
@@ -98,7 +98,7 @@ describe('MultiLanguageRecognizerTests', function () {
             });
         });
 
-        it('should refrain from logging PII by default', async () => {
+        it('should refrain from logging PII by default', async function () {
             const recognizerWithDefaultLogPii = createRecognizer();
             const trackEventSpy = spyOnTelemetryClientTrackEvent(recognizerWithDefaultLogPii);
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/qnaMakerRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/qnaMakerRecognizer.test.js
@@ -12,14 +12,14 @@ describe('QnAMakerRecognizerTests', function () {
 
     const hostname = 'https://dummy-hostname.azurewebsites.net';
 
-    it('returns answer', async () => {
+    it('returns answer', async function () {
         nock(hostname)
             .post(/knowledgebases/)
             .replyWithFile(200, path.join(__dirname, 'resources/QnAMakerRecognizerTests/QnaMaker_ReturnsAnswer.json'));
         await TestUtils.runTestScript(resourceExplorer, 'QnAMakerRecognizerTests_ReturnsAnswer');
     });
 
-    it('returns answer with intent', async () => {
+    it('returns answer with intent', async function () {
         nock(hostname)
             .post(/knowledgebases/)
             .replyWithFile(
@@ -29,7 +29,7 @@ describe('QnAMakerRecognizerTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'QnAMakerRecognizerTests_ReturnsAnswerWithIntent');
     });
 
-    it('returns no answer', async () => {
+    it('returns no answer', async function () {
         nock(hostname)
             .post(/knowledgebases/)
             .replyWithFile(

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/recognizerSet.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/recognizerSet.test.js
@@ -53,27 +53,27 @@ describe('RecognizerSetTests', function () {
         resourceExplorer = makeResourceExplorer('RecognizerSetTests');
     });
 
-    it('Merge', async () => {
+    it('Merge', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'RecognizerSetTests_Merge');
     });
 
-    it('None', async () => {
+    it('None', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'RecognizerSetTests_None');
     });
 
-    describe('Telemetry', () => {
+    describe('Telemetry', function () {
         const recognizer = createRecognizer();
         let spy;
 
-        beforeEach(() => {
+        beforeEach(function () {
             spy = spyOnTelemetryClientTrackEvent(recognizer);
         });
 
-        afterEach(() => {
+        afterEach(function () {
             spy.restore();
         });
 
-        it('Merge - should log PII when logPersonalInformation is true', async () => {
+        it('Merge - should log PII when logPersonalInformation is true', async function () {
             recognizer.logPersonalInformation = true;
 
             await recognizeIntentAndValidateTelemetry({
@@ -97,7 +97,7 @@ describe('RecognizerSetTests', function () {
             });
         });
 
-        it('Merge - should not log PII when logPersonalInformation is false', async () => {
+        it('Merge - should not log PII when logPersonalInformation is false', async function () {
             recognizer.logPersonalInformation = false;
 
             await recognizeIntentAndValidateTelemetry({
@@ -121,7 +121,7 @@ describe('RecognizerSetTests', function () {
             });
         });
 
-        it('should refrain from logging PII by default', async () => {
+        it('should refrain from logging PII by default', async function () {
             const recognizerWithDefaultLogPii = createRecognizer();
             const trackEventSpy = spyOnTelemetryClientTrackEvent(recognizerWithDefaultLogPii);
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/recognizerTelemetryUtils.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/recognizerTelemetryUtils.js
@@ -63,7 +63,7 @@ async function recognizeIntentAndValidateTelemetry({ text, callCount, recognizer
     const dialogContext = createContext(text);
     const activity = dialogContext.context.activity;
 
-    let result = await recognizer.recognize(dialogContext, activity);
+    const result = await recognizer.recognize(dialogContext, activity);
 
     validateIntent(text, result);
     validateTelemetry({
@@ -88,7 +88,7 @@ async function recognizeIntentAndValidateTelemetry_withCustomActivity({ text, ca
     customActivity.text = text;
     customActivity.locale = 'en-us';
 
-    let result = await recognizer.recognize(dialogContext, customActivity);
+    const result = await recognizer.recognize(dialogContext, customActivity);
 
     validateIntent(text, result);
     validateTelemetry({

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/regexRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/regexRecognizer.test.js
@@ -7,7 +7,7 @@ describe('RegexRecognizerTests', function () {
         resourceExplorer = makeResourceExplorer('RegexRecognizerTests');
     });
 
-    it('Entities', async () => {
+    it('Entities', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'RegexRecognizerTests_Entities');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/selector.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/selector.test.js
@@ -7,39 +7,39 @@ describe('SelectorTests', function () {
         resourceExplorer = makeResourceExplorer('SelectorTests');
     });
 
-    it('ConditionalSelector', async () => {
+    it('ConditionalSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_ConditionalSelector');
     });
 
-    it('FirstSelector', async () => {
+    it('FirstSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_FirstSelector');
     });
 
-    it('MostSpecificFirstSelector', async () => {
+    it('MostSpecificFirstSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_MostSpecificFirstSelector');
     });
 
-    it('MostSpecificRandomSelector', async () => {
+    it('MostSpecificRandomSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_MostSpecificRandomSelector');
     });
 
-    it('Priority', async () => {
+    it('Priority', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_Priority');
     });
 
-    it('Priority', async () => {
+    it('Priority', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_Float_Priority');
     });
 
-    it('RandomSelector', async () => {
+    it('RandomSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_RandomSelector');
     });
 
-    it('RunOnce', async () => {
+    it('RunOnce', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_RunOnce');
     });
 
-    it('TrueSelector', async () => {
+    it('TrueSelector', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_TrueSelector');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/settingsState.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/settingsState.test.js
@@ -11,11 +11,11 @@ describe('SettingsStateTests', function () {
     process.env['MicrosoftAppPassword'] = 'MICROSOFT_APP_PASSWORD';
     process.env['ApplicationInsights:InstrumentationKey'] = '00000000-0000-0000-0000-000000000000';
 
-    it('SettingsTest', async () => {
+    it('SettingsTest', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SettingsStateTests_SettingsTest');
     });
 
-    it('TestTurnStateAcrossBoundaries', async () => {
+    it('TestTurnStateAcrossBoundaries', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'SettingsStateTests_TestTurnStateAcrossBoundaries');
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/valueRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/valueRecognizer.test.js
@@ -7,11 +7,11 @@ describe('ValueRecognizerTests', function () {
         resourceExplorer = makeResourceExplorer('ValueRecognizerTests');
     });
 
-    it('WithIntent', async () => {
+    it('WithIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ValueRecognizerTests_WithIntent');
     });
 
-    it('WithNoIntent', async () => {
+    it('WithNoIntent', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ValueRecognizerTests_WithNoIntent');
     });
 });


### PR DESCRIPTION
Addresses # 4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the botbuilder-dialogs-adaptive-testing library.

## Specific Changes
- Applied auto-fixes with yarn lint --fix
	- Fix spacing
	- Fix indentation
	- Add blank line in between comments
	- Fix quoting
	- Add trailing commas
- Applied manual fixes for:
	- Missing documentation.
	- Unused parameters and imports
	- Disabling detect-non-literal-fs-filename rule to allow dynamic path for files
	- Disabling no-constant-condition rule to allow while (true) loop

## Testing
_Eslint and tests status_

<img width="163" alt="image" src="https://user-images.githubusercontent.com/64815358/166565779-1ac5b488-5be7-4b57-8aae-59b5b17f704d.png">
<img width="156" alt="image" src="https://user-images.githubusercontent.com/64815358/166565804-676da222-85cc-4451-b54b-05ff8ffa21b8.png">



