### PR TITLE
fix: [#4204] Fix remaining eslint warnings - Rest of botbuilder-dialogs libraries - adaptive runtime

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/configurationResourceExplorer.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/configurationResourceExplorer.ts
@@ -5,7 +5,14 @@ import { Configuration } from './configuration';
 import { ComponentDeclarativeTypes, ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import { ok } from 'assert';
 
+/**
+ * Class which gives access to content resources by specifying configuration and declarativeTypes.
+ */
 export class ConfigurationResourceExporer extends ResourceExplorer {
+    /**
+     * @param configuration Additional configuration methods.
+     * @param declarativeTypes Registered declarative types.
+     */
     constructor(configuration: Configuration, declarativeTypes: ComponentDeclarativeTypes[]) {
         super({ declarativeTypes });
 

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
@@ -22,7 +22,22 @@ import {
     useTelemetry,
 } from 'botbuilder-dialogs-adaptive';
 
+/**
+ * Implements an instance of CoreBot.
+ */
 export class CoreBot extends ActivityHandler {
+    /**
+     * @param resourceExplorer Services to access resources.
+     * @param userState Stored user state.
+     * @param conversationState Stored conversation state.
+     * @param botFrameworkAuthentication Cloud environment to authenticate Bot Framework Protocol network calls within this environment.
+     * @param skillConversationIdFactory Methods to create unique conversation IDs for skill conversations.
+     * @param botTelemetryClient Bot client to telemetry.
+     * @param defaultLocale The default locale used to determine language-specific behavior.
+     * @param defaultRootDialog Default bot root dialog.
+     * @param memoryScopes Named root-level objects, which can exist in the dialog context or outside the turn state.
+     * @param pathResolvers Shortcut behavior for transform paths.
+     */
     constructor(
         resourceExplorer: ResourceExplorer,
         userState: UserState,

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
@@ -4,7 +4,15 @@
 import { BotFrameworkAuthentication } from 'botframework-connector';
 import { CloudAdapter, ConversationState, UserState, useBotState } from 'botbuilder';
 
+/**
+ *An adapter that implements the Core Bot and can be hosted in different cloud environments both public and private.
+ */
 export class CoreBotAdapter extends CloudAdapter {
+    /**
+     * @param botFrameworkAuthentication BotFrameworkAuthentication](xref:botframework-connector.BotFrameworkAuthentication) instance.
+     * @param conversationState State management object for conversation state.
+     * @param userState Stored user state.
+     */
     constructor(
         botFrameworkAuthentication: BotFrameworkAuthentication,
         private readonly conversationState: ConversationState,

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
@@ -5,7 +5,7 @@ import { BotFrameworkAuthentication } from 'botframework-connector';
 import { CloudAdapter, ConversationState, UserState, useBotState } from 'botbuilder';
 
 /**
- *An adapter that implements the Core Bot and can be hosted in different cloud environments both public and private.
+ * An adapter that implements the Core Bot and can be hosted in different cloud environments both public and private.
  */
 export class CoreBotAdapter extends CloudAdapter {
     /**


### PR DESCRIPTION
Addresses # 4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the botbuilder-dialogs-adaptive-runtime library.

## Specific Changes
- Applied auto-fixes with yarn lint --fix
	- Fix spacing
	- Fix indentation
	- Add blank line in between comments
- Applied manual fixes for:
	- Missing documentation

## Testing
_Library eslint status_
![Screenshot 2022-05-04 141033](https://user-images.githubusercontent.com/64815358/166745180-0d0cf63e-25cb-4965-be4a-5cfb15ecdc3b.jpg)

_Library tests status_
![Screenshot 2022-05-04 141015](https://user-images.githubusercontent.com/64815358/166745193-02ab949f-7f69-41d8-8508-7dad28e0691f.jpg)

