### PR TITLE
port: [#4245] Mark deprecated channels as obsolete in Channels enum

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -446,12 +446,13 @@ export enum Channels {
     // (undocumented)
     Omni = "omnichannel",
     // (undocumented)
+    Outlook = "outlook",
+    // (undocumented)
     Skype = "skype",
     // @deprecated (undocumented)
     Skypeforbusiness = "skypeforbusiness",
     // (undocumented)
     Slack = "slack",
-    // (undocumented)
     Sms = "sms",
     // (undocumented)
     Telegram = "telegram",
@@ -459,7 +460,7 @@ export enum Channels {
     Telephony = "telephony",
     // (undocumented)
     Test = "test",
-    // (undocumented)
+    // @deprecated (undocumented)
     Twilio = "twilio-sms",
     // (undocumented)
     Webchat = "webchat"

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -442,8 +442,6 @@ export enum Channels {
     // (undocumented)
     Groupme = "groupme",
     // @deprecated (undocumented)
-    Kaizala = "kaizala",
-    // @deprecated (undocumented)
     Kik = "kik",
     // (undocumented)
     Line = "line",

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -423,7 +423,7 @@ export interface ChannelInfo {
 export enum Channels {
     // (undocumented)
     Alexa = "alexa",
-    // (undocumented)
+    // @deprecated (undocumented)
     Console = "console",
     // (undocumented)
     Directline = "directline",
@@ -437,7 +437,7 @@ export enum Channels {
     Facebook = "facebook",
     // (undocumented)
     Groupme = "groupme",
-    // (undocumented)
+    // @deprecated (undocumented)
     Kik = "kik",
     // (undocumented)
     Line = "line",
@@ -447,7 +447,7 @@ export enum Channels {
     Omni = "omnichannel",
     // (undocumented)
     Skype = "skype",
-    // (undocumented)
+    // @deprecated (undocumented)
     Skypeforbusiness = "skypeforbusiness",
     // (undocumented)
     Slack = "slack",
@@ -455,7 +455,7 @@ export enum Channels {
     Sms = "sms",
     // (undocumented)
     Telegram = "telegram",
-    // (undocumented)
+    // @deprecated (undocumented)
     Telephony = "telephony",
     // (undocumented)
     Test = "test",

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -423,8 +423,10 @@ export interface ChannelInfo {
 export enum Channels {
     // (undocumented)
     Alexa = "alexa",
-    // @deprecated (undocumented)
+    // (undocumented)
     Console = "console",
+    // @deprecated (undocumented)
+    Cortana = "cortana",
     // (undocumented)
     Directline = "directline",
     // (undocumented)
@@ -433,10 +435,14 @@ export enum Channels {
     Email = "email",
     // (undocumented)
     Emulator = "emulator",
+    // @deprecated (undocumented)
+    EnterpriseChannel = "enterprisechannel",
     // (undocumented)
     Facebook = "facebook",
     // (undocumented)
     Groupme = "groupme",
+    // @deprecated (undocumented)
+    Kaizala = "kairzala",
     // @deprecated (undocumented)
     Kik = "kik",
     // (undocumented)
@@ -456,7 +462,7 @@ export enum Channels {
     Sms = "sms",
     // (undocumented)
     Telegram = "telegram",
-    // @deprecated (undocumented)
+    // (undocumented)
     Telephony = "telephony",
     // (undocumented)
     Test = "test",

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -442,7 +442,7 @@ export enum Channels {
     // (undocumented)
     Groupme = "groupme",
     // @deprecated (undocumented)
-    Kaizala = "kairzala",
+    Kaizala = "kaizala",
     // @deprecated (undocumented)
     Kik = "kik",
     // (undocumented)

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2433,7 +2433,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2238,7 +2238,7 @@ export enum SemanticActionStateTypes {
 /**
  * Defines values for ChannelIds for Channels.
  * Possible values include: 'alexa', 'console', 'cortana', 'directline', 'directlinespeech', 'email',
- * 'emulator', 'enterprisechannel', 'facebook', 'groupme', 'kaizala', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
+ * 'emulator', 'enterprisechannel', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
  * 'slack', 'sms', 'telegram', 'test', 'twilio-sms', 'webchat'
  *
  * @readonly
@@ -2261,10 +2261,6 @@ export enum Channels {
     EnterpriseChannel = 'enterprisechannel',
     Facebook = 'facebook',
     Groupme = 'groupme',
-    /**
-     * @deprecated This channel is no longer available for bot developers.
-     */
-    Kaizala = 'kaizala',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2238,7 +2238,7 @@ export enum SemanticActionStateTypes {
 /**
  * Defines values for ChannelIds for Channels.
  * Possible values include: 'alexa', 'console', 'cortana', 'directline', 'directlinespeech', 'email',
- * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
+ * 'emulator', 'enterprisechannel', 'facebook', 'groupme', 'kaizala', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
  * 'slack', 'sms', 'telegram', 'test', 'twilio-sms', 'webchat'
  *
  * @readonly
@@ -2264,7 +2264,7 @@ export enum Channels {
     /**
      * @deprecated This channel is no longer available for bot developers.
      */
-    Kaizala = 'kairzala',
+    Kaizala = 'kaizala',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2238,7 +2238,7 @@ export enum SemanticActionStateTypes {
 /**
  * Defines values for ChannelIds for Channels.
  * Possible values include: 'alexa', 'console', 'cortana', 'directline', 'directlinespeech', 'email',
- * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'skype', 'skypeforbusiness',
+ * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
  * 'slack', 'sms', 'telegram', 'test', 'twilio-sms', 'webchat'
  *
  * @readonly
@@ -2263,12 +2263,16 @@ export enum Channels {
     Line = 'line',
     Msteams = 'msteams',
     Omni = 'omnichannel',
+    Outlook = 'outlook',
     Skype = 'skype',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */
     Skypeforbusiness = 'skypeforbusiness',
     Slack = 'slack',
+    /**
+     * SMS (Twilio) channel.
+     */
     Sms = 'sms',
     Telegram = 'telegram',
     /**
@@ -2276,6 +2280,9 @@ export enum Channels {
      */
     Telephony = 'telephony',
     Test = 'test',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Twilio = 'twilio-sms',
     Webchat = 'webchat',
 }
@@ -2426,7 +2433,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2246,6 +2246,9 @@ export enum SemanticActionStateTypes {
  */
 export enum Channels {
     Alexa = 'alexa',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Console = 'console',
     Directline = 'directline',
     DirectlineSpeech = 'directlinespeech',
@@ -2253,15 +2256,24 @@ export enum Channels {
     Emulator = 'emulator',
     Facebook = 'facebook',
     Groupme = 'groupme',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Kik = 'kik',
     Line = 'line',
     Msteams = 'msteams',
     Omni = 'omnichannel',
     Skype = 'skype',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Skypeforbusiness = 'skypeforbusiness',
     Slack = 'slack',
     Sms = 'sms',
     Telegram = 'telegram',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Telephony = 'telephony',
     Test = 'test',
     Twilio = 'twilio-sms',
@@ -2414,7 +2426,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2426,7 +2426,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2246,16 +2246,25 @@ export enum SemanticActionStateTypes {
  */
 export enum Channels {
     Alexa = 'alexa',
+    Console = 'console',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */
-    Console = 'console',
+    Cortana = 'cortana',
     Directline = 'directline',
     DirectlineSpeech = 'directlinespeech',
     Email = 'email',
     Emulator = 'emulator',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
+    EnterpriseChannel = 'enterprisechannel',
     Facebook = 'facebook',
     Groupme = 'groupme',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
+    Kaizala = 'kairzala',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */
@@ -2275,9 +2284,6 @@ export enum Channels {
      */
     Sms = 'sms',
     Telegram = 'telegram',
-    /**
-     * @deprecated This channel is no longer available for bot developers.
-     */
     Telephony = 'telephony',
     Test = 'test',
     /**


### PR DESCRIPTION
Fixes # 4245
#minor

## Description
This PR marks the unsupported channels as deprecated and adds support for new channels.

Unsupported channels:
- Console
- Cortana
- Kik
- SkypeForBusiness
- Telephony
- Twilio-sms

New supported channels:
- Outlook

## Specific Changes
  - Unsupported channels marked as deprecated in BotFramework-schema.

## Testing
This screenshot shows the unit tests passing
<img width="516" alt="image" src="https://user-images.githubusercontent.com/64815358/170067163-1c0e5929-1857-4312-b766-ee0d239a70c5.png">
