### PR TITLE
port: [#4270] Choice options separator should be multi language (#6366)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -206,6 +206,14 @@ describe('ActionTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ChoiceStringInMemory');
     });
 
+    it('ChoicesWithChoiceOptions', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_ChoicesWithChoiceOptions');
+    });
+
+    it('ChoicesWithChoiceOptionsTemplate', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_ChoicesWithChoiceOptionsTemplate');
+    });
+
     it('ConfirmInput', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput');
     });
@@ -232,6 +240,14 @@ describe('ActionTests', function () {
 
     it('ConfirmInputComplexTemplate_es', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInput_ComplexTemplate_es');
+    });
+
+    it('ConfirmInputWithChoiceOptions', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInputWithChoiceOptions');
+    });
+
+    it('ConfirmInputWithChoiceOptionsTemplate', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_ConfirmInputWithChoiceOptionsTemplate');
     });
 
     it('DeleteProperties', async function () {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ChoicesWithChoiceOptions.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ChoicesWithChoiceOptions.test.dialog
@@ -1,0 +1,140 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "planningTest",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.ChoiceInput",
+            "choices": [
+              {
+                "value": "red"
+              },
+              {
+                "value": "green"
+              },
+              {
+                "value": "blue"
+              }
+            ],
+            "style": "inline",
+            "choiceOptions": {
+              "inlineSeparator": ", ",
+              "inlineOr": " or2 ",
+              "inlineOrMore": ", or2 ",
+              "includeNumbers": true
+            },
+            "property": "user.color",
+            "prompt": "Please select a color:",
+            "unrecognizedPrompt": "Not a color. Please select a color:"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user.color}"
+          },
+          {
+            "$kind": "Microsoft.ChoiceInput",
+            "choices": [
+              {
+                "value": "red"
+              },
+              {
+                "value": "green"
+              },
+              {
+                "value": "blue"
+              }
+            ],
+            "style": "inline",
+            "alwaysPrompt": true,
+            "choiceOptions": {
+              "inlineSeparator": ", ",
+              "inlineOr": " or2 ",
+              "inlineOrMore": ", or2 ",
+              "includeNumbers": true
+            },
+            "property": "user.color",
+            "prompt": "Please select a color:",
+            "unrecognizedPrompt": "Please select a color:"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user.color}"
+          },
+          {
+            "$kind": "Microsoft.ChoiceInput",
+            "choices": [
+              {
+                "value": "red"
+              },
+              {
+                "value": "green"
+              },
+              {
+                "value": "blue"
+              }
+            ],
+            "style": "inline",
+            "alwaysPrompt": true,
+            "choiceOptions": {
+              "inlineSeparator": ", ",
+              "inlineOr": " or2 ",
+              "inlineOrMore": ", or2 ",
+              "includeNumbers": true
+            },
+            "property": "user.color",
+            "prompt": "Please select a color:",
+            "unrecognizedPrompt": "Please select a color:"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user.color}"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Please select a color: (1) red, (2) green, or2 (3) blue"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "asdasd"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Not a color. Please select a color: (1) red, (2) green, or2 (3) blue"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "blue"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "blue"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Please select a color: (1) red, (2) green, or2 (3) blue"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "red"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "red"
+    }
+  ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ChoicesWithChoiceOptionsTemplate.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ChoicesWithChoiceOptionsTemplate.test.dialog
@@ -1,0 +1,58 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "planningTest",
+    "generator": "test.lg",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.ChoiceInput",
+            "alwaysPrompt": true,
+            "choices": "${MyChoices_simple()}",
+            "choiceOptions": "${MyChoiceOptions()}",
+            "style": "inline",
+            "property": "user.choice",
+            "prompt": "${MyChoices_Prompt()}",
+            "unrecognizedPrompt": "${MyChoices_UnknownPrompt()}"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user.choice}"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "locale": "en",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Please select (1) dog or2 (2) cat"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "kitty"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Not a dog or cat. Please select (1) dog or2 (2) cat"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "cat"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "cat"
+    }
+  ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ConfirmInputWithChoiceOptions.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ConfirmInputWithChoiceOptions.test.dialog
@@ -1,0 +1,63 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "planningTest",
+    "generator": "test.lg",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.ConfirmInput",
+            "style": "inline",
+            "alwaysPrompt": true,
+            "choiceOptions": {
+              "inlineSeparator": ", ",
+              "inlineOr": " or2 ",
+              "inlineOrMore": ", or2 ",
+              "includeNumbers": true
+            },
+            "property": "user.confirmed",
+            "prompt": "${ConfirmInput_Prompt()}",
+            "unrecognizedPrompt": "${ConfirmInput_UnknownPrompt()}",
+            "confirmChoices": "${ConfirmInput_simple()}"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "confirmation: ${user.confirmed}"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "locale": "en",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Please select (1) yep or2 (2) nope"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "asdasd"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Not yep or nope. Please select (1) yep or2 (2) nope"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "yep"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "confirmation: true"
+    }
+  ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ConfirmInputWithChoiceOptionsTemplate.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_ConfirmInputWithChoiceOptionsTemplate.test.dialog
@@ -1,0 +1,58 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "generator": "test.lg",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.ConfirmInput",
+                        "style": "inline",
+                        "alwaysPrompt": true,
+                        "property": "user.confirmed",
+                        "choiceOptions": "${MyChoiceOptions()}",
+                        "prompt": "${ConfirmInput_Prompt()}",
+                        "unrecognizedPrompt": "${ConfirmInput_UnknownPrompt()}",
+                        "confirmChoices": "${ConfirmInput_simple()}"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "confirmation: ${user.confirmed}"
+                    }
+                ]
+            }
+        ],
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "en",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Please select (1) yep or2 (2) nope"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "asdasd"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Not yep or nope. Please select (1) yep or2 (2) nope"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "yep"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "confirmation: true"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/test.en.lg
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/test.en.lg
@@ -17,6 +17,9 @@
 ]
 ```
 
+# MyChoiceOptions
+- [", "," or2 ",", or2 ",true]
+
 > CONFIRM INPUT UNIT TEST
 
 # ConfirmInput_Prompt

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -526,6 +526,20 @@ export interface ChoiceInputOptions {
     choices: Choice[];
 }
 
+// @public
+export class ChoiceOptionsSet implements ChoiceFactoryOptions, TemplateInterface<ChoiceFactoryOptions> {
+    constructor(obj: any);
+    bind(dialogContext: DialogContext, data?: any): Promise<ChoiceFactoryOptions>;
+    // (undocumented)
+    includeNumbers?: boolean;
+    // (undocumented)
+    inlineOr?: string;
+    // (undocumented)
+    inlineOrMore?: string;
+    // (undocumented)
+    inlineSeparator?: string;
+    }
+
 // @public (undocumented)
 export enum ChoiceOutputFormat {
     // (undocumented)

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ChoiceInput.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ChoiceInput.schema
@@ -170,7 +170,7 @@
                     }
                 },
                 {
-                    "$ref": "schema:#/definitions/equalsExpression"
+                    "$ref": "schema:#/definitions/stringExpression"
                 }
             ]
         },

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ConfirmInput.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ConfirmInput.schema
@@ -82,7 +82,7 @@
                     }
                 },
                 {
-                    "$ref": "schema:#/definitions/equalsExpression"
+                    "$ref": "schema:#/definitions/stringExpression"
                 }
             ]
         },

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceOptionsSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceOptionsSet.ts
@@ -1,0 +1,78 @@
+/**
+ * @module botbuilder-dialogs-adaptive
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { DialogContext, DialogStateManager, TemplateInterface, ChoiceFactoryOptions } from 'botbuilder-dialogs';
+import { LanguageGenerator } from '../languageGenerator';
+import { languageGeneratorKey } from '../languageGeneratorExtensions';
+
+/**
+ * Sets the ChoiceFactoryOptions.
+ */
+export class ChoiceOptionsSet implements ChoiceFactoryOptions, TemplateInterface<ChoiceFactoryOptions> {
+    private readonly template: string;
+    inlineSeparator?: string;
+    inlineOr?: string;
+    inlineOrMore?: string;
+    includeNumbers?: boolean;
+
+    /**
+     * Initializes a new instance of the [ChoiceOptionsSet](xref:botbuilder-dialogs-adaptive.ChoiceOptionsSet) class.
+     *
+     * @param obj Choice values.
+     */
+    constructor(obj: any) {
+        if (typeof obj === 'string') {
+            this.template = obj;
+        }
+    }
+
+    /**
+     * Bind data to template.
+     *
+     * @param dialogContext DialogContext
+     * @param data Data to bind to.
+     * @returns Data binded ChoiceFactoryOptions.
+     */
+    async bind(dialogContext: DialogContext, data?: any): Promise<ChoiceFactoryOptions> {
+        if (this.template == null) {
+            return this as ChoiceFactoryOptions;
+        }
+
+        const languageGenerator = dialogContext.services.get(languageGeneratorKey) as LanguageGenerator<
+            unknown,
+            DialogStateManager
+        >;
+
+        if (languageGenerator == null) {
+            throw new Error('language generator is missing.');
+        }
+
+        const lgResult = await languageGenerator.generate(dialogContext, this.template, data);
+        if (lgResult instanceof ChoiceOptionsSet) {
+            return lgResult as ChoiceFactoryOptions;
+        } else if (typeof lgResult === 'string') {
+            try {
+                const jObj = JSON.parse(lgResult);
+                const options = <ChoiceFactoryOptions>{
+                    inlineSeparator: jObj[0].toString(),
+                    inlineOr: jObj[1].toString(),
+                    inlineOrMore: jObj[2].toString(),
+                };
+
+                if (Object.keys(jObj).length > 3) {
+                    options.includeNumbers = Boolean(jObj[3]);
+                }
+
+                return options;
+            } catch {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/input/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/index.ts
@@ -16,3 +16,4 @@ export * from './textInput';
 export * from './dateTimeInput';
 export * from './oauthInput';
 export * from './choiceSet';
+export * from './choiceOptionsSet';

--- a/libraries/botbuilder-dialogs-adaptive/tests/choiceOptionsSet.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/choiceOptionsSet.test.js
@@ -1,0 +1,101 @@
+const assert = require('assert');
+const { stub } = require('sinon');
+const { ChoiceOptionsSet, MultiLanguageGenerator } = require('../');
+const { languageGeneratorKey } = require('../lib/languageGeneratorExtensions');
+const { MessageFactory, TurnContext, TestAdapter } = require('botbuilder');
+const { DialogContext, DialogSet } = require('botbuilder-dialogs');
+
+describe('ChoiceOptionsSet', function () {
+    this.timeout(10000);
+
+    const template = '=${options.OrSeparator()}';
+    const activity = MessageFactory.text('hi');
+
+    it('ContructorValidation', function () {
+        assert.notStrictEqual(new ChoiceOptionsSet(), null);
+        assert.notStrictEqual(new ChoiceOptionsSet(template), null);
+    });
+
+    it('BindNullTemplate', async function () {
+        const choiceOptions = new ChoiceOptionsSet(null);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+
+        const choiceFactory = await choiceOptions.bind(dc);
+
+        assert.strictEqual(choiceFactory, choiceOptions);
+    });
+
+    it('BindNullLanguageGenerator', async function () {
+        const choiceOptions = new ChoiceOptionsSet(template);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+
+        await assert.rejects(() => choiceOptions.bind(dc), new Error('language generator is missing.'));
+    });
+
+    it('BindReturnsLGResult', async function () {
+        const choiceOptions = new ChoiceOptionsSet(template);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+
+        const lg = new MultiLanguageGenerator();
+        const generateStub = stub(lg, 'generate');
+        generateStub.returns(choiceOptions);
+        dc.services.set(languageGeneratorKey, lg);
+
+        const choiceFactory = await choiceOptions.bind(dc);
+
+        assert.strictEqual(choiceFactory, choiceOptions);
+    });
+
+    it('BindReturnsChoiceFactoryOptions', async function () {
+        const choiceOptions = new ChoiceOptionsSet(template);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+        const lgResult = '[","," or",", or",true]';
+
+        const lg = new MultiLanguageGenerator();
+        const generateStub = stub(lg, 'generate');
+        generateStub.returns(lgResult);
+        dc.services.set(languageGeneratorKey, lg);
+
+        const choiceFactory = await choiceOptions.bind(dc);
+
+        assert.strictEqual(choiceFactory.inlineSeparator, ',');
+        assert.strictEqual(choiceFactory.inlineOrMore, ', or');
+        assert.strictEqual(choiceFactory.inlineOr, ' or');
+        assert.strictEqual(choiceFactory.includeNumbers, true);
+    });
+
+    it('BindThrowsJsonError', async function () {
+        const choiceOptions = new ChoiceOptionsSet(template);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+        const lgResult = '[","," or",", or",true]]';
+
+        const lg = new MultiLanguageGenerator();
+        const generateStub = stub(lg, 'generate');
+        generateStub.returns(lgResult);
+        dc.services.set(languageGeneratorKey, lg);
+
+        const choiceFactory = await choiceOptions.bind(dc);
+
+        assert.strictEqual(choiceFactory, null);
+    });
+
+    it('BindReturnsNull', async function () {
+        const choiceOptions = new ChoiceOptionsSet(template);
+        const context = new TurnContext(new TestAdapter(), activity);
+        const dc = new DialogContext(new DialogSet(), context, {});
+
+        const lg = new MultiLanguageGenerator();
+        const generateStub = stub(lg, 'generate');
+        generateStub.returns(null);
+        dc.services.set(languageGeneratorKey, lg);
+
+        const choiceFactory = await choiceOptions.bind(dc);
+
+        assert.strictEqual(choiceFactory, null);
+    });
+});

--- a/libraries/tests.schema
+++ b/libraries/tests.schema
@@ -1668,7 +1668,7 @@
               }
             },
             {
-              "$ref": "#/definitions/equalsExpression"
+              "$ref": "#/definitions/stringExpression"
             }
           ]
         },
@@ -2013,7 +2013,7 @@
               }
             },
             {
-              "$ref": "#/definitions/equalsExpression"
+              "$ref": "#/definitions/stringExpression"
             }
           ]
         },


### PR DESCRIPTION
Fixes # 4204

## Description
This PR updates the ChoiceOptions to support LG allowing to define different template expressions for each language.
It also adds unit tests to cover the new code.

## Specific Changes
- Updated `ConfirmInput` and `ChoiceInput` to get the choice options from an expression.
- Added the new class `ChoiceOptionsSet` containing the `bind` method to map the LG expression into a `ChoiceFactoryOptions` object.
- Updated `ChoiceInput` and `ConfirmInput` schemas.
- Added new tests in `ActionTests` class:
   - Action_ChoicesWithChoiceOptions.test.dialog 
   - Action_ChoicesWithChoiceOptionsTemplate.test.dialog 
   - Action_ConfirmInputWithChoiceOptions.test.dialog
   - Action_ConfirmInputWithChoiceOptionsTemplate.test.dialog
- Added new test file `choiceOptionsSet.test.js` containing all the tests related to the `ChoiceOptionsSet` class.

## Testing
The following images show the separator working as expected and the new unit tests.
![imagen](https://user-images.githubusercontent.com/62260472/179996367-01c7ae9a-ffc5-49f4-a0b6-6a7f28fdacf5.png)
![imagen](https://user-images.githubusercontent.com/62260472/179996348-a62ebb77-3306-4236-96da-38ee496e4937.png)