### PR TITLE
port: [#4276] Add Teams read receipt event (#6356)

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -51,6 +51,7 @@ import { NodeWebSocketFactoryBase } from 'botframework-streaming';
 import { O365ConnectorCardActionQuery } from 'botbuilder-core';
 import { PagedMembersResult } from 'botbuilder-core';
 import { PagedResult } from 'botbuilder-core';
+import { ReadReceiptInfo } from 'botframework-connector';
 import { RequestHandler } from 'botframework-streaming';
 import { ResourceResponse } from 'botbuilder-core';
 import { SigninStateVerificationQuery } from 'botbuilder-core';
@@ -395,6 +396,8 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsMembersAddedEvent(handler: (membersAdded: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMembersRemoved(context: TurnContext): Promise<void>;
     onTeamsMembersRemovedEvent(handler: (membersRemoved: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsReadReceipt(context: TurnContext): Promise<void>;
+    onTeamsReadReceiptEvent(handler: (receiptInfo: ReadReceiptInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamArchived(context: any): Promise<void>;
     onTeamsTeamArchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamDeleted(context: any): Promise<void>;

--- a/libraries/botframework-connector/src/teams/index.ts
+++ b/libraries/botframework-connector/src/teams/index.ts
@@ -24,3 +24,4 @@
 export * from './teamsConnectorClient';
 export * from './teamsConnectorClientContext';
 export * from './models';
+export * from './readReceiptInfo';

--- a/libraries/botframework-connector/src/teams/readReceiptInfo.ts
+++ b/libraries/botframework-connector/src/teams/readReceiptInfo.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * General information about a read receipt.
+ */
+export class ReadReceiptInfo {
+    /**
+     * The id of the last read message.
+     */
+    lastReadMessageId: string;
+
+    /**
+     * Initializes a new instance of the ReadReceiptInfo class.
+     *
+     * @param lastReadMessageId Optional. The id of the last read message.
+     */
+    constructor(lastReadMessageId?: string) {
+        this.lastReadMessageId = lastReadMessageId;
+    }
+
+    /**
+     * Helper method useful for determining if a message has been read. This method
+     * converts the strings to numbers. If the compareMessageId is less than or equal to
+     * the lastReadMessageId, then the message has been read.
+     *
+     * @param compareMessageId The id of the message to compare.
+     * @param lastReadMessageId The id of the last message read by the user.
+     * @returns True if the compareMessageId is less than or equal to the lastReadMessageId.
+     */
+    static isMessageRead(compareMessageId: string, lastReadMessageId: string): boolean {
+        if (
+            compareMessageId &&
+            compareMessageId.trim().length > 0 &&
+            lastReadMessageId &&
+            lastReadMessageId.trim().length > 0
+        ) {
+            const compareMessageIdNum = Number(compareMessageId);
+            const lastReadMessageIdNum = Number(lastReadMessageId);
+
+            if (compareMessageIdNum && lastReadMessageIdNum) {
+                return compareMessageIdNum <= lastReadMessageIdNum;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Helper method useful for determining if a message has been read.
+     * If the compareMessageId is less than or equal to the lastReadMessageId, then the message has been read.
+     *
+     * @param compareMessageId The id of the message to compare.
+     * @returns True if the compareMessageId is less than or equal to the lastReadMessageId.
+     */
+    isMessageRead(compareMessageId: string): boolean {
+        return ReadReceiptInfo.isMessageRead(compareMessageId, this.lastReadMessageId);
+    }
+}

--- a/libraries/botframework-connector/tests/teams/readReceiptInfo.test.js
+++ b/libraries/botframework-connector/tests/teams/readReceiptInfo.test.js
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const { ReadReceiptInfo } = require('../..');
+
+describe('ReadReceiptInfo', function () {
+    const testCases = [
+        { title: 'compare msg equal to last', compare: '1000', lastRead: '1000', isRead: true },
+        { title: 'compare msg < than last', compare: '1000', lastRead: '1001', isRead: true },
+        { title: 'compare msg > than last', compare: '1001', lastRead: '1000', isRead: false },
+        { title: 'null compare msg', compare: null, lastRead: '1000', isRead: false },
+        { title: 'null last msg', compare: '1000', lastRead: null, isRead: false },
+    ];
+
+    testCases.map((testData) => {
+        it(testData.title, function () {
+            const readReceipt = new ReadReceiptInfo(testData.lastRead);
+
+            assert.strictEqual(readReceipt.lastReadMessageId, testData.lastRead);
+            assert.strictEqual(readReceipt.isMessageRead(testData.compare), testData.isRead);
+            assert.strictEqual(ReadReceiptInfo.isMessageRead(testData.compare, testData.lastRead), testData.isRead);
+        });
+    });
+});


### PR DESCRIPTION
Fixes # 4276
#minor

## Description
This PR ports the changes in [PR#6356](https: //github.com/microsoft/botbuilder-dotnet/pull/ 6356) adding support for Teams read receipt event.

## Specific Changes
- Added `onTeamsReadReceiptEvent` handler method in the **_teamsActivityHandler_** class.
- Added the new `ReadReceiptInfo` class in **_botframework-connector/teams_**.
- Added unit tests for the new class and methods.
- Updated `botbuilder.api.md` with the new method.

## Testing
These images show the new unit tests passing.
![image](https://user-images.githubusercontent.com/44245136/181264824-50664792-77e1-4660-b88b-d8d3096c1752.png)
