### PR TITLE
port: [#6434] Priority broken for RegexRecognizer (#6435)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -104,7 +104,7 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
             const regexp = intentPattern.regex;
             while ((matched = regexp.exec(text))) {
                 matches.push(matched);
-                if (regexp.lastIndex == text.length) {
+                if (regexp.lastIndex == text.length || !regexp.lastIndex) {
                     break; // to avoid infinite loop
                 }
             }
@@ -135,8 +135,6 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
                         });
                 }
             });
-
-            break;
         }
 
         if (this.entities) {


### PR DESCRIPTION
Fixes # 4308
#minor

## Description
This PR ports the changes in [PR#6435](https ://github.com/microsoft/botbuilder-dotnet/pull/ 6435) updating the AdaptiveDialog's _onRecognize_ method to take into consideration the priority set for the intents when there is more than one result with the same score.

## Specific Changes
- Updated the _onRecognize_ method to choose the topIntent considering both score and priority.
- Removed the break from the _recognize_ method to return all the intents that match the pattern.
- Added a unit test to cover the priority scenario in _adaptiveDialog.test_.

## Testing
These images show the bot not recognizing the correct intent before and the bot returning the right intent according to its priority after the changes.
![image](https://user-images.githubusercontent.com/44245136/189431149-ea5f37fe-72e4-4db2-b6b0-e178829fa445.png)