### PR TITLE
fix: [CodeQL] SM02383 - Fix alerts

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestSequenceMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestSequenceMock.ts
@@ -85,7 +85,7 @@ export class HttpRequestSequenceMock extends HttpRequestMock implements HttpRequ
         path = path.startsWith('/') ? path : '/' + path;
         if (path.includes('*')) {
             // eslint-disable-next-line security/detect-non-literal-regexp
-            path = new RegExp(path.replace('*', '.*'));
+            path = new RegExp(path.split('*').join('.*'));
         }
         if (this.method) {
             nock(url.origin)

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -266,7 +266,10 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
                 for (const refValue of templateRefValues.get(templateRefValueKey)) {
                     tempRes.push(
                         JSON.parse(
-                            JSON.stringify(res).replace(templateRefValueKey, refValue.toString().replace(/"|\\/g, '\\"'))
+                            JSON.stringify(res).replace(
+                                templateRefValueKey,
+                                refValue.toString().replace(/"|\\/g, '\\"')
+                            )
                         )
                     );
                 }

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -266,7 +266,7 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
                 for (const refValue of templateRefValues.get(templateRefValueKey)) {
                     tempRes.push(
                         JSON.parse(
-                            JSON.stringify(res).replace(templateRefValueKey, refValue.toString().replace(/"/g, '\\"'))
+                            JSON.stringify(res).replace(templateRefValueKey, refValue.toString().replace(/"|\\/g, '\\"'))
                         )
                     );
                 }

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -264,17 +264,10 @@ export class Expander extends AbstractParseTreeVisitor<unknown[]> implements LGT
             const tempRes: Record<string, unknown>[] = [];
             for (const res of finalResult) {
                 for (const refValue of templateRefValues.get(templateRefValueKey)) {
-                    tempRes.push(
-                        JSON.parse(
-                            JSON.stringify(res).replace(
-                                templateRefValueKey,
-                                refValue.toString().replace(/"|\\/g, '\\"')
-                            )
-                        )
-                    );
+                    const currentRefValue = refValue.toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                    tempRes.push(JSON.parse(JSON.stringify(res).replace(templateRefValueKey, currentRefValue)));
                 }
             }
-
             finalResult = tempRes;
         }
 

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -703,6 +703,21 @@ describe('LG', function () {
         });
     });
 
+    it('TestExpandTemplateWithBackSlash', function () {
+        const templates = preloaded.Expand;
+
+        const evaled = templates.expandTemplate('ExpanderT1BackSlash');
+        assert.strictEqual(evaled.length, 2);
+        const expectedResults = [
+            '{"lgType":"MyStruct","text":"Hi \\"backslash\\" allowed","speak":"how old are you?"}',
+            '{"lgType":"MyStruct","text":"Hi \\"backslash\\" allowed","speak":"what\'s your age?"}',
+        ];
+
+        expectedResults.forEach((value, index) => {
+            assert.strictEqual(JSON.stringify(evaled[index]), JSON.stringify(JSON.parse(value)));
+        });
+    });
+
     it('TestExpandTemplateWithEscapeCharacter', function () {
         const templates = preloaded.EscapeCharacter;
         let evaled = templates.expandTemplate('wPhrase');

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -709,12 +709,12 @@ describe('LG', function () {
         const evaled = templates.expandTemplate('ExpanderT1BackSlash');
         assert.strictEqual(evaled.length, 2);
         const expectedResults = [
-            '{"lgType":"MyStruct","text":"Hi \\"backslash\\" allowed","speak":"how old are you?"}',
-            '{"lgType":"MyStruct","text":"Hi \\"backslash\\" allowed","speak":"what\'s your age?"}',
+            '{"lgType":"MyStruct","text":"Hi \\\\backslash\\\\ allowed","speak":"how old are you?"}',
+            '{"lgType":"MyStruct","text":"Hi \\\\backslash\\\\ allowed","speak":"what\'s your age?"}',
         ];
 
         expectedResults.forEach((value, index) => {
-            assert.strictEqual(JSON.stringify(evaled[index]), JSON.stringify(JSON.parse(value)));
+            assert.strictEqual(JSON.stringify(evaled[index]), value);
         });
     });
 

--- a/libraries/botbuilder-lg/tests/testData/examples/Expand.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/Expand.lg
@@ -96,6 +96,12 @@ They are ${ShowAlarm(alarms[1])}
     ${ExpanderT2()}
 ]
 
+# ExpanderT1BackSlash
+[MyStruct
+    Text = Hi \backslash\ allowed
+    ${ExpanderT2()}
+]
+
 # ExpanderT2
 [MyStruct
     Speak = ${GetAge()}

--- a/tools/scripts/unit-arm.js
+++ b/tools/scripts/unit-arm.js
@@ -55,7 +55,7 @@ args.push('5000000');
 files.forEach(function (file) {
   if (file.length > 0 && file.trim()[0] !== '#') {
     // trim trailing \r if it exists
-    file = file.replace('\r', '');
+    file = file.replaceAll('\r', '');
 
     if (root) {
       args.push('test/' + file);

--- a/tools/scripts/unit-arm.js
+++ b/tools/scripts/unit-arm.js
@@ -1,30 +1,30 @@
 #!/usr/bin/env node
-// 
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 const fs = require('fs');
 const path = require('path');
 
-var args = (process.ARGV || process.argv);
+var args = process.ARGV || process.argv;
 
 var reporter = 'list';
 var xunitOption = Array.prototype.indexOf.call(args, '-xunit');
 if (xunitOption !== -1) {
-  reporter = 'xunit';
-  args.splice(xunitOption, 1);
+    reporter = 'xunit';
+    args.splice(xunitOption, 1);
 }
 
 var testList = args.pop();
@@ -32,15 +32,15 @@ var testList = args.pop();
 var fileContent;
 var root = false;
 
-if  (!fs.existsSync) {
-  fs.existsSync = require('path').existsSync;
+if (!fs.existsSync) {
+    fs.existsSync = require('path').existsSync;
 }
 
 if (fs.existsSync(testList)) {
-  fileContent = fs.readFileSync(testList).toString();
+    fileContent = fs.readFileSync(testList).toString();
 } else {
-  fileContent = fs.readFileSync('./test/' + testList).toString();
-  root = true;
+    fileContent = fs.readFileSync('./test/' + testList).toString();
+    root = true;
 }
 
 var files = fileContent.split('\n');
@@ -53,16 +53,16 @@ args.push('-t');
 args.push('5000000');
 
 files.forEach(function (file) {
-  if (file.length > 0 && file.trim()[0] !== '#') {
-    // trim trailing \r if it exists
-    file = file.replaceAll('\r', '');
+    if (file.length > 0 && file.trim()[0] !== '#') {
+        // trim trailing \r if it exists
+        file.endsWith('\r') ? file.slice(0, -1) : file;
 
-    if (root) {
-      args.push('test/' + file);
-    } else {
-      args.push(file);
+        if (root) {
+            args.push('test/' + file);
+        } else {
+            args.push(file);
+        }
     }
-  }
 });
 
 args.push('-R');

--- a/tools/scripts/unit-coverage.js
+++ b/tools/scripts/unit-coverage.js
@@ -1,30 +1,30 @@
 #!/usr/bin/env node
-// 
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 const fs = require('fs');
 const path = require('path');
 
-var args = (process.ARGV || process.argv);
+var args = process.ARGV || process.argv;
 
 var reporter = 'list';
 var xunitOption = Array.prototype.indexOf.call(args, '-xunit');
 if (xunitOption !== -1) {
-  reporter = 'xunit';
-  args.splice(xunitOption, 1);
+    reporter = 'xunit';
+    args.splice(xunitOption, 1);
 }
 
 var testList = args.pop();
@@ -33,22 +33,22 @@ var testListArm = args.pop();
 var fileContent, fileContentArm;
 var root = false;
 
-if  (!fs.existsSync) {
-  fs.existsSync = require('path').existsSync;
+if (!fs.existsSync) {
+    fs.existsSync = require('path').existsSync;
 }
 
 if (fs.existsSync(testList)) {
-  fileContent = fs.readFileSync(testList).toString();
+    fileContent = fs.readFileSync(testList).toString();
 } else {
-  fileContent = fs.readFileSync('./test/' + testList).toString();
-  root = true;
+    fileContent = fs.readFileSync('./test/' + testList).toString();
+    root = true;
 }
 
 if (fs.existsSync(testListArm)) {
-  fileContentArm = fs.readFileSync(testListArm).toString();
+    fileContentArm = fs.readFileSync(testListArm).toString();
 } else {
-  fileContentArm = fs.readFileSync('./test/' + testListArm).toString();
-  root = true;
+    fileContentArm = fs.readFileSync('./test/' + testListArm).toString();
+    root = true;
 }
 
 var files = fileContent.split('\n').concat(fileContentArm.split('\n'));
@@ -66,16 +66,16 @@ args.push('-t');
 args.push('200000');
 
 files.forEach(function (file) {
-  if (file.length > 0 && file.trim()[0] !== '#') {
-    // trim trailing \r if it exists
-    file = file.replaceAll('\r', '');
+    if (file.length > 0 && file.trim()[0] !== '#') {
+        // trim trailing \r if it exists
+        file.endsWith('\r') ? file.slice(0, -1) : file;
 
-    if (root) {
-      args.push('test/' + file);
-    } else {
-      args.push(file);
+        if (root) {
+            args.push('test/' + file);
+        } else {
+            args.push(file);
+        }
     }
-  }
 });
 
 var defaultStorageAccount = 'ciserversdk';
@@ -84,83 +84,91 @@ var defaultSubscription = 'db1ab6f0-4769-4b27-930e-01e2ef9c123c';
 var defaultAccessToken = 'access_token';
 
 if (!process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
+    process.env.AZURE_APNS_CERTIFICATE = Buffer.from(
+        fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])
+    ).toString('base64');
 } else if (process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICATE_KEY_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_KEY_FILE']).toString();
+    process.env.AZURE_APNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_KEY_FILE']).toString();
 } else if (process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICATE_KEY_FILE) {
-  throw new Error('Only one of AZURE_APNS_CERTIFICATE_KEY or AZURE_APNS_CERTIFICATE_KEY_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_APNS_CERTIFICATE_KEY or AZURE_APNS_CERTIFICATE_KEY_FILE can be set. Not both.');
 }
 
-
 if (!process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
+    process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(
+        fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])
+    ).toString('base64');
 } else if (process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_MPNS_CERTIFICATE_KEY && process.env.AZURE_MPNS_CERTIFICATE_KEY_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_KEY_FILE']).toString();
+    process.env.AZURE_MPNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_KEY_FILE']).toString();
 } else if (process.env.AZURE_MPNS_CERTIFICATE_KEY && process.env.AZURE_MPNS_CERTIFICATE_KEY_FILE) {
-  throw new Error('Only one of AZURE_MPNS_CERTIFICATE_KEY or AZURE_MPNS_CERTIFICATE_KEY_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_MPNS_CERTIFICATE_KEY or AZURE_MPNS_CERTIFICATE_KEY_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_ACCESS_TOKEN) {
-  process.env.AZURE_ACCESS_TOKEN = defaultAccessToken;
+    process.env.AZURE_ACCESS_TOKEN = defaultAccessToken;
 }
 
 if (!process.env.AZURE_CERTIFICATE_PEM_FILE) {
-  process.env.AZURE_CERTIFICATE_PEM_FILE = path.join(__dirname, '../test/data/certificate.pem');
+    process.env.AZURE_CERTIFICATE_PEM_FILE = path.join(__dirname, '../test/data/certificate.pem');
 }
 
 if (!process.env.NOCK_OFF && !process.env.AZURE_NOCK_RECORD) {
-  process.env.AZURE_APNS_CERTIFICATE = 'fake_certificate';
-  process.env.AZURE_APNS_CERTIFICATE_KEY = 'fake_certificate_key';
+    process.env.AZURE_APNS_CERTIFICATE = 'fake_certificate';
+    process.env.AZURE_APNS_CERTIFICATE_KEY = 'fake_certificate_key';
 
-  process.env.AZURE_WNS_PACKAGE_SID = 'sid';
-  process.env.AZURE_WNS_SECRET_KEY = 'key';
+    process.env.AZURE_WNS_PACKAGE_SID = 'sid';
+    process.env.AZURE_WNS_SECRET_KEY = 'key';
 
-  process.env.AZURE_GCM_KEY = 'fakekey'.toString('base64');
+    process.env.AZURE_GCM_KEY = 'fakekey'.toString('base64');
 
-  process.env.AZURE_MPNS_CERTIFICATE = 'fake_certificate';
-  process.env.AZURE_MPNS_CERTIFICATE_KEY = 'fake_certificate_key';
+    process.env.AZURE_MPNS_CERTIFICATE = 'fake_certificate';
+    process.env.AZURE_MPNS_CERTIFICATE_KEY = 'fake_certificate_key';
 
-  if (process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
-    process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
-  }
+    if (process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
+        process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
+    }
 
-  process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
+    process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
 
-  if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
-    process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
-    process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
-  }
+    if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
+        process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
+        process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
+    }
 
-  if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
-    process.env.AZURE_SUBSCRIPTION_ID = defaultSubscription;
-    process.env.AZURE_CERTIFICATE = 'fake_certificate';
-    process.env.AZURE_CERTIFICATE_KEY = 'fake_certificate_key';
-  }
+    if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
+        process.env.AZURE_SUBSCRIPTION_ID = defaultSubscription;
+        process.env.AZURE_CERTIFICATE = 'fake_certificate';
+        process.env.AZURE_CERTIFICATE_KEY = 'fake_certificate_key';
+    }
 } else {
-  if (!process.env.NOCK_OFF && process.env.AZURE_NOCK_RECORD) {
-    // If in record mode, and environment variables are set, make sure they are the expected one for recording
-    // NOTE: For now, only the Core team can update recordings. For non-core team PRs, the recordings will be updated
-    // after merge
-    if (process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
-      throw new Error('Storage recordings can only be made with the account ' + defaultStorageAccount);
-    }
+    if (!process.env.NOCK_OFF && process.env.AZURE_NOCK_RECORD) {
+        // If in record mode, and environment variables are set, make sure they are the expected one for recording
+        // NOTE: For now, only the Core team can update recordings. For non-core team PRs, the recordings will be updated
+        // after merge
+        if (process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
+            throw new Error('Storage recordings can only be made with the account ' + defaultStorageAccount);
+        }
 
-    if (process.env.AZURE_SERVICEBUS_NAMESPACE && process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
-      throw new Error('Service Bus recordings can only be made with the namespace ' + defaultServiceBusAccount);
-    }
+        if (
+            process.env.AZURE_SERVICEBUS_NAMESPACE &&
+            process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount
+        ) {
+            throw new Error('Service Bus recordings can only be made with the namespace ' + defaultServiceBusAccount);
+        }
 
-    if (process.env.AZURE_SUBSCRIPTION_ID && process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
-      throw new Error('Service Management recordings can only be made with the subscription ' + defaultSubscription);
+        if (process.env.AZURE_SUBSCRIPTION_ID && process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
+            throw new Error(
+                'Service Management recordings can only be made with the subscription ' + defaultSubscription
+            );
+        }
     }
-  }
 }
 
 require('../node_modules/nyc/bin/nyc');

--- a/tools/scripts/unit-coverage.js
+++ b/tools/scripts/unit-coverage.js
@@ -68,7 +68,7 @@ args.push('200000');
 files.forEach(function (file) {
   if (file.length > 0 && file.trim()[0] !== '#') {
     // trim trailing \r if it exists
-    file = file.replace('\r', '');
+    file = file.replaceAll('\r', '');
 
     if (root) {
       args.push('test/' + file);

--- a/tools/scripts/unit.js
+++ b/tools/scripts/unit.js
@@ -1,30 +1,30 @@
 #!/usr/bin/env node
-// 
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 const fs = require('fs');
 const path = require('path');
 
-var args = (process.ARGV || process.argv);
+var args = process.ARGV || process.argv;
 
 var reporter = 'list';
 var xunitOption = Array.prototype.indexOf.call(args, '-xunit');
 if (xunitOption !== -1) {
-  reporter = 'xunit';
-  args.splice(xunitOption, 1);
+    reporter = 'xunit';
+    args.splice(xunitOption, 1);
 }
 
 var testList = args.pop();
@@ -32,15 +32,15 @@ var testList = args.pop();
 var fileContent;
 var root = false;
 
-if  (!fs.existsSync) {
-  fs.existsSync = require('path').existsSync;
+if (!fs.existsSync) {
+    fs.existsSync = require('path').existsSync;
 }
 
 if (fs.existsSync(testList)) {
-  fileContent = fs.readFileSync(testList).toString();
+    fileContent = fs.readFileSync(testList).toString();
 } else {
-  fileContent = fs.readFileSync('./test/' + testList).toString();
-  root = true;
+    fileContent = fs.readFileSync('./test/' + testList).toString();
+    root = true;
 }
 
 var files = fileContent.split('\n');
@@ -53,16 +53,16 @@ args.push('-t');
 args.push('200000');
 
 files.forEach(function (file) {
-  if (file.length > 0 && file.trim()[0] !== '#') {
-    // trim trailing \r if it exists
-    file = file.replaceAll('\r', '');
+    if (file.length > 0 && file.trim()[0] !== '#') {
+        // trim trailing \r if it exists
+        file.endsWith('\r') ? file.slice(0, -1) : file;
 
-    if (root) {
-      args.push('test/' + file);
-    } else {
-      args.push(file);
+        if (root) {
+            args.push('test/' + file);
+        } else {
+            args.push(file);
+        }
     }
-  }
 });
 
 args.push('-R');
@@ -74,83 +74,91 @@ var defaultSubscription = 'db1ab6f0-4769-4b27-930e-01e2ef9c123c';
 var defaultAccessToken = 'access_token';
 
 if (!process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
+    process.env.AZURE_APNS_CERTIFICATE = Buffer.from(
+        fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])
+    ).toString('base64');
 } else if (process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICATE_KEY_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_KEY_FILE']).toString();
+    process.env.AZURE_APNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_KEY_FILE']).toString();
 } else if (process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICATE_KEY_FILE) {
-  throw new Error('Only one of AZURE_APNS_CERTIFICATE_KEY or AZURE_APNS_CERTIFICATE_KEY_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_APNS_CERTIFICATE_KEY or AZURE_APNS_CERTIFICATE_KEY_FILE can be set. Not both.');
 }
 
-
 if (!process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
+    process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(
+        fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])
+    ).toString('base64');
 } else if (process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_MPNS_CERTIFICATE_KEY && process.env.AZURE_MPNS_CERTIFICATE_KEY_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_KEY_FILE']).toString();
+    process.env.AZURE_MPNS_CERTIFICATE_KEY = fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_KEY_FILE']).toString();
 } else if (process.env.AZURE_MPNS_CERTIFICATE_KEY && process.env.AZURE_MPNS_CERTIFICATE_KEY_FILE) {
-  throw new Error('Only one of AZURE_MPNS_CERTIFICATE_KEY or AZURE_MPNS_CERTIFICATE_KEY_FILE can be set. Not both.');
+    throw new Error('Only one of AZURE_MPNS_CERTIFICATE_KEY or AZURE_MPNS_CERTIFICATE_KEY_FILE can be set. Not both.');
 }
 
 if (!process.env.AZURE_ACCESS_TOKEN) {
-  process.env.AZURE_ACCESS_TOKEN = defaultAccessToken;
+    process.env.AZURE_ACCESS_TOKEN = defaultAccessToken;
 }
 
 if (!process.env.AZURE_CERTIFICATE_PEM_FILE) {
-  process.env.AZURE_CERTIFICATE_PEM_FILE = path.join(__dirname, '../test/data/certificate.pem');
+    process.env.AZURE_CERTIFICATE_PEM_FILE = path.join(__dirname, '../test/data/certificate.pem');
 }
 
 if (!process.env.NOCK_OFF && !process.env.AZURE_NOCK_RECORD) {
-  process.env.AZURE_APNS_CERTIFICATE = 'fake_certificate';
-  process.env.AZURE_APNS_CERTIFICATE_KEY = 'fake_certificate_key';
+    process.env.AZURE_APNS_CERTIFICATE = 'fake_certificate';
+    process.env.AZURE_APNS_CERTIFICATE_KEY = 'fake_certificate_key';
 
-  process.env.AZURE_WNS_PACKAGE_SID = 'sid';
-  process.env.AZURE_WNS_SECRET_KEY = 'key';
+    process.env.AZURE_WNS_PACKAGE_SID = 'sid';
+    process.env.AZURE_WNS_SECRET_KEY = 'key';
 
-  process.env.AZURE_GCM_KEY = 'fakekey'.toString('base64');
+    process.env.AZURE_GCM_KEY = 'fakekey'.toString('base64');
 
-  process.env.AZURE_MPNS_CERTIFICATE = 'fake_certificate';
-  process.env.AZURE_MPNS_CERTIFICATE_KEY = 'fake_certificate_key';
+    process.env.AZURE_MPNS_CERTIFICATE = 'fake_certificate';
+    process.env.AZURE_MPNS_CERTIFICATE_KEY = 'fake_certificate_key';
 
-  if (process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
-    process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
-  }
+    if (process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
+        process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
+    }
 
-  process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
+    process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
 
-  if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
-    process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
-    process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
-  }
+    if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
+        process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
+        process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
+    }
 
-  if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
-    process.env.AZURE_SUBSCRIPTION_ID = defaultSubscription;
-    process.env.AZURE_CERTIFICATE = 'fake_certificate';
-    process.env.AZURE_CERTIFICATE_KEY = 'fake_certificate_key';
-  }
+    if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
+        process.env.AZURE_SUBSCRIPTION_ID = defaultSubscription;
+        process.env.AZURE_CERTIFICATE = 'fake_certificate';
+        process.env.AZURE_CERTIFICATE_KEY = 'fake_certificate_key';
+    }
 } else {
-  if (!process.env.NOCK_OFF && process.env.AZURE_NOCK_RECORD) {
-    // If in record mode, and environment variables are set, make sure they are the expected one for recording
-    // NOTE: For now, only the Core team can update recordings. For non-core team PRs, the recordings will be updated
-    // after merge
-    if (process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
-      throw new Error('Storage recordings can only be made with the account ' + defaultStorageAccount);
-    }
+    if (!process.env.NOCK_OFF && process.env.AZURE_NOCK_RECORD) {
+        // If in record mode, and environment variables are set, make sure they are the expected one for recording
+        // NOTE: For now, only the Core team can update recordings. For non-core team PRs, the recordings will be updated
+        // after merge
+        if (process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCOUNT !== defaultStorageAccount) {
+            throw new Error('Storage recordings can only be made with the account ' + defaultStorageAccount);
+        }
 
-    if (process.env.AZURE_SERVICEBUS_NAMESPACE && process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
-      throw new Error('Service Bus recordings can only be made with the namespace ' + defaultServiceBusAccount);
-    }
+        if (
+            process.env.AZURE_SERVICEBUS_NAMESPACE &&
+            process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount
+        ) {
+            throw new Error('Service Bus recordings can only be made with the namespace ' + defaultServiceBusAccount);
+        }
 
-    if (process.env.AZURE_SUBSCRIPTION_ID && process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
-      throw new Error('Service Management recordings can only be made with the subscription ' + defaultSubscription);
+        if (process.env.AZURE_SUBSCRIPTION_ID && process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {
+            throw new Error(
+                'Service Management recordings can only be made with the subscription ' + defaultSubscription
+            );
+        }
     }
-  }
 }
 
 require('../node_modules/mocha/bin/mocha');

--- a/tools/scripts/unit.js
+++ b/tools/scripts/unit.js
@@ -55,7 +55,7 @@ args.push('200000');
 files.forEach(function (file) {
   if (file.length > 0 && file.trim()[0] !== '#') {
     // trim trailing \r if it exists
-    file = file.replace('\r', '');
+    file = file.replaceAll('\r', '');
 
     if (root) {
       args.push('test/' + file);


### PR DESCRIPTION
Fixes # 4336, 4337, 4338, 4339, 4340
#minor

## Description
This PR fixes the SM02383 alerts which were related to incomplete string escaping or encoding.
To correct them, we replaced the _replace_ method with _replaceAll_ (where it was allowed). In case it wasn't allowed, we fixed the issue by updating the regex related and using methods like _split_ and _join_ instead of _replace_.

## Specific Changes
- Replace method replaced by split and join ones in _botbuilder-dialogs-adaptive-testing_
- Updated regex in _botbuilder-lg_ to escape `"` and `\\`
- New unit test case for _botbuilder-lg_
- Use _endsWith_ and _slice_ methods to trim trailing \r instead of use replace in _scripts_

## Testing
- [x] All unit tests passed

This image shows the new unit test for the _botbuilder-lg_ library.
![image](https://user-images.githubusercontent.com/64815358/199306996-ee9790e7-60ab-44b1-b9b2-16c10a0f0623.png)

