### PR TITLE
fix: [CodeQL] SM01511 - Improve password hash security

### DIFF
--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -31,7 +31,9 @@
     "@azure/cosmos": "^3.3.1",
     "azure-storage": "2.10.7",
     "botbuilder": "4.1.6",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "bcrypt": "^5.0.1",
+    "@types/bcrypt": "^5.0.0"
   },
   "devDependencies": {
     "fs-extra": "^7.0.1",

--- a/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as crypto from 'crypto';
+import { hashSync } from 'bcrypt';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CosmosDbKeyEscape {
@@ -73,11 +73,8 @@ export namespace CosmosDbKeyEscape {
             }
 
             if (key.length > maxKeyLength) {
-                const hash = crypto.createHash('sha256');
-                hash.update(key);
-                // combine truncated key with hash of self for extra uniqueness
-                const hex = hash.digest('hex');
-                key = key.substr(0, maxKeyLength - hex.length) + hex;
+                const saltRounds = 10;
+                key = hashSync(key, saltRounds);
             }
             return key;
         }


### PR DESCRIPTION
Fixes # 4335
#minor

## Description
This PR fixes the SM01511 alerts which were related to the use of password hash with insufficient computational effort in microsoft/microsoft/botbuilder-js/botbuilder-js.
To fix it, we replaced the current password hashing scheme crypto with [bcrypt](https://github.com/kelektiv/node.bcrypt.js).

## Specific Changes
- Replace the current crypto library with bcrypt in botbuilder-azure/src/cosmosDbKeyEscape.ts.

## Testing
- [x] All unit tests passed
![image](https://user-images.githubusercontent.com/64815358/200414775-59b89c50-a7b4-4efa-8016-13182912e4db.png)