### PR TITLE
fix: [CodeQL] SM01524 - Information exposure through a stack trace

### DIFF
--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -402,7 +402,8 @@ export class ChannelServiceRoutes {
                 }
             } else {
                 let requestData = '';
-                req.on('data', (chunk) => {
+                // eslint-disable-next-line prettier/prettier
+                req.on('data', (chunk) => { // lgtm[js/stack-trace-exposure]
                     requestData += chunk;
                 });
                 req.on('end', () => {


### PR DESCRIPTION
Fixes # 4342
#minor

## Description
This PR fixes the SM01524 alerts which were related to information exposure through a stack trace in _microsoft/microsoft/botbuilder-js/botbuilder-js_.
To fix it, we suppressed the alert by following the CodeQL [documentation ](https://codeql.github.com/codeql-query-help/javascript/js-stack-trace-exposure/)and adding the proper comment.

## Specific Changes
- Add the comment _lgtm[js/stack-trace-exposure]_ to line 405 in _microsoft/microsoft/botbuilder-js/botbuilder-js_.

## Testing
![image](https://user-images.githubusercontent.com/64815358/201423191-71a8a337-1d9c-48a0-a478-dabc9597d271.png)
