### PR TITLE
feat: [#4349] Add new method to expose same functionality as BotFrameworkAdapter.processActivityDirect

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -10,6 +10,7 @@ import { ActivityHandlerBase } from 'botbuilder-core';
 import { AppBasedLinkQuery } from 'botbuilder-core';
 import { AppCredentials } from 'botframework-connector';
 import { AttachmentData } from 'botbuilder-core';
+import { AuthenticateRequestResult } from 'botframework-connector';
 import { AuthenticationConfiguration } from 'botframework-connector';
 import { BotAdapter } from 'botbuilder-core';
 import { BotFrameworkAuthentication } from 'botframework-connector';
@@ -232,6 +233,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
     connectNamedPipe(pipeName: string, logic: (context: TurnContext) => Promise<void>, appId: string, audience: string, callerId?: string, retryCount?: number): Promise<void>;
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
+    processActivityDirect(authorization: string | AuthenticateRequestResult, activity: Activity, logic: (context: TurnContext) => Promise<void>): Promise<void>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "CloudChannelServiceHandler" needs to be exported by the entry point index.d.ts

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -1280,6 +1280,8 @@ export class BotFrameworkAdapter
     /**
      * Asynchronously creates a turn context and runs the middleware pipeline for an incoming activity.
      *
+     * Use [CloudAdapter.processActivityDirect] instead.
+     *
      * @param activity The activity to process.
      * @param logic The function to call at the end of the middleware pipeline.
      *

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -133,7 +133,6 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
         }
 
         const authHeader = z.string().parse(req.headers.Authorization ?? req.headers.authorization ?? '');
-
         try {
             const invokeResponse = await this.processActivity(authHeader, activity, logic);
             return end(invokeResponse?.status ?? StatusCodes.OK, invokeResponse?.body);
@@ -142,6 +141,28 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
                 err instanceof AuthenticationError ? StatusCodes.UNAUTHORIZED : StatusCodes.INTERNAL_SERVER_ERROR,
                 err.message ?? err
             );
+        }
+    }
+
+    /**
+     * Asynchronously process an activity running the provided logic function.
+     *
+     * @param authorization The authorization header in the format: "Bearer [longString]" or the AuthenticateRequestResult for this turn.
+     * @param activity The activity to process.
+     * @param logic The logic function to apply.
+     * @returns a promise representing the asynchronous operation.
+     */
+    async processActivityDirect(
+        authorization: string | AuthenticateRequestResult,
+        activity: Activity,
+        logic: (context: TurnContext) => Promise<void>
+    ): Promise<void> {
+        try {
+            typeof authorization === 'string'
+                ? await this.processActivity(authorization, activity, logic)
+                : await this.processActivity(authorization, activity, logic);
+        } catch (err) {
+            throw new Error(`CloudAdapter.processActivityDirect(): ERROR\n ${err.stack}`);
         }
     }
 

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -5,9 +5,10 @@ const assert = require('assert');
 const httpMocks = require('node-mocks-http');
 const net = require('net');
 const sinon = require('sinon');
-const { BotFrameworkAuthenticationFactory } = require('botframework-connector');
-const { CloudAdapter, ActivityTypes, INVOKE_RESPONSE_KEY } = require('..');
+const { BotFrameworkAuthenticationFactory, AuthenticationConstants } = require('botframework-connector');
+const { CloudAdapter, ActivityTypes, INVOKE_RESPONSE_KEY, ConfigurationBotFrameworkAuthentication } = require('..');
 const { NamedPipeServer } = require('botframework-streaming');
+const { CallerIdConstants } = require('../../botbuilder-core/lib/index');
 
 const FakeBuffer = () => Buffer.from([]);
 const FakeNodeSocket = () => new net.Socket();
@@ -42,6 +43,34 @@ describe('CloudAdapter', function () {
     });
 
     describe('process', function () {
+        class TestConfiguration {
+            static DefaultConfig = {
+                // [AuthenticationConstants.ChannelService]: undefined,
+                ValidateAuthority: true,
+                ToChannelFromBotLoginUrl: AuthenticationConstants.ToChannelFromBotLoginUrl,
+                ToChannelFromBotOAuthScope: AuthenticationConstants.ToChannelFromBotOAuthScope,
+                ToBotFromChannelTokenIssuer: AuthenticationConstants.ToBotFromChannelTokenIssuer,
+                ToBotFromEmulatorOpenIdMetadataUrl: AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
+                CallerId: CallerIdConstants.PublicAzureChannel,
+                ToBotFromChannelOpenIdMetadataUrl: AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
+                OAuthUrl: AuthenticationConstants.OAuthUrl,
+                // [AuthenticationConstants.OAuthUrlKey]: 'test',
+                [AuthenticationConstants.BotOpenIdMetadataKey]: null,
+            };
+
+            constructor(config = {}) {
+                this.configuration = Object.assign({}, TestConfiguration.DefaultConfig, config);
+            }
+
+            get(_path) {
+                return this.configuration;
+            }
+
+            set(_path, _val) {}
+        }
+
+        const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
+        const authorization = 'Bearer Authorization';
         it('delegates to connect', async function () {
             const req = {};
             const socket = FakeNodeSocket();
@@ -58,9 +87,6 @@ describe('CloudAdapter', function () {
         });
 
         it('delegates to processActivity', async function () {
-            const authorization = 'Bearer Authorization';
-            const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
-
             const req = httpMocks.createRequest({
                 method: 'POST',
                 headers: { authorization },
@@ -86,6 +112,78 @@ describe('CloudAdapter', function () {
             await adapter.process(req, res, logic);
 
             mock.verify();
+        });
+
+        it('calls processActivityDirect with string authorization', async function () {
+            const logic = async (context) => {
+                context.turnState.set(INVOKE_RESPONSE_KEY, {
+                    type: ActivityTypes.InvokeResponse,
+                    value: {
+                        status: 200,
+                        body: 'invokeResponse',
+                    },
+                });
+            };
+
+            const mock = sandbox.mock(adapter);
+            mock.expects('processActivity').withArgs(authorization, activity, logic).once().resolves();
+            mock.expects('connect').never();
+
+            await adapter.processActivityDirect(authorization, activity, logic);
+
+            mock.verify();
+        });
+
+        it('calls processActivityDirect with AuthenticateRequestResult authorization', async function () {
+            const claimsIdentity = adapter.createClaimsIdentity('appId');
+            const audience = AuthenticationConstants.ToChannelFromBotOAuthScope;
+            const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(
+                TestConfiguration.DefaultConfig
+            );
+            const connectorFactory = botFrameworkAuthentication.createConnectorFactory(claimsIdentity);
+            //AuthenticateRequestResult
+            const authentication = {
+                audience: audience,
+                claimsIdentity: claimsIdentity,
+                callerId: 'callerdId',
+                connectorFactory: connectorFactory,
+            };
+            const logic = async (context) => {
+                context.turnState.set(INVOKE_RESPONSE_KEY, {
+                    type: ActivityTypes.InvokeResponse,
+                    value: {
+                        status: 200,
+                        body: 'invokeResponse',
+                    },
+                });
+            };
+
+            const mock = sandbox.mock(adapter);
+            mock.expects('processActivity').withArgs(authentication, activity, logic).once().resolves();
+            mock.expects('connect').never();
+
+            await adapter.processActivityDirect(authentication, activity, logic);
+
+            mock.verify();
+        });
+
+        it('calls processActivityDirect with error', async function () {
+            const logic = async (context) => {
+                context.turnState.set(INVOKE_RESPONSE_KEY, {
+                    type: ActivityTypes.InvokeResponse,
+                    value: {
+                        status: 200,
+                        body: 'invokeResponse',
+                    },
+                });
+            };
+
+            sandbox.stub(adapter, 'processActivity').throws({ stack: 'error stack' });
+
+            await assert.rejects(
+                adapter.processActivityDirect(authorization, activity, logic),
+                new Error('CloudAdapter.processActivityDirect(): ERROR\n error stack')
+            );
         });
     });
 


### PR DESCRIPTION
Fixes # 4349
#minor

## Description
This PR exposes the same functionality as the _processActivityDirect_ method of the deprecated BotFrameworkAdapter class. For that, adds a new method that doesn't use HTTP req and res parameters.

## Specific Changes
- New _processActivityDirect_ method that exposes the same functionality that the ones in BotFrameworkAdapter.

## Testing
- All unit tests passed
- Added unit test for the new method
![image](https://user-images.githubusercontent.com/64815358/204356933-a4592b8f-7ae8-4922-bf04-32d1300b6384.png)

