### PR TITLE
fix: [#4370] Update @azure/cognitiveservices-luis-runtime > @azure/ms-rest-js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "node-fetch": "2.6.7",
     "underscore": "1.13.1",
     "json-schema": "0.4.0",
-    "@xmldom/xmldom": "0.8.6"
+    "@xmldom/xmldom": "0.8.6",
+    "**/botbuilder-ai/@azure/cognitiveservices-luis-runtime/@azure/ms-rest-js": "^2.6.1"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,21 +248,7 @@
     uuid "^8.3.2"
     xml2js "^0.4.19"
 
-"@azure/ms-rest-js@^1.6.0":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.11.2.tgz#e83d512b102c302425da5ff03a6d76adf2aa4ae6"
-  integrity sha512-2AyQ1IKmLGKW7DU3/x3TsTBzZLcbC9YRI+yuDPuXAQrv3zar340K9wsxU413kHFIDjkWNCo9T0w5VtwcyWxhbQ==
-  dependencies:
-    "@azure/core-auth" "^1.1.4"
-    axios "^0.21.1"
-    form-data "^2.3.2"
-    tough-cookie "^2.4.3"
-    tslib "^1.9.2"
-    tunnel "0.0.6"
-    uuid "^3.2.1"
-    xml2js "^0.4.19"
-
-"@azure/ms-rest-js@^2.6.1":
+"@azure/ms-rest-js@^1.6.0", "@azure/ms-rest-js@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.6.1.tgz#4f94688a750d51afcbab4b55d6ecb9d3df4ddd94"
   integrity sha512-LLi4jRe/qy5IM8U2CkoDgSZp2OH+MgDe2wePmhz8uY84Svc53EhHaamVyoU6BjjHBxvCRh1vcD1urJDccrxqIw==
@@ -6211,7 +6197,7 @@ form-data@1.0.0-rc4:
     combined-stream "^1.0.5"
     mime-types "^2.1.10"
 
-form-data@^2.3.2, form-data@^2.5.0:
+form-data@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -13016,7 +13002,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -13109,7 +13095,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Fixes # 4370
#minor

## Description
This PR updates the [@azure/ms-rest-js](https://www.npmjs.com/package/@azure/ms-rest-js) library inside the [@azure/cognitiveservices-luis-runtime](https://www.npmjs.com/package/@azure/cognitiveservices-luis-runtime) dependency, from `1.6.0` to `2.6.1`, so the [uuid](https://www.npmjs.com/package/uuid?activeTab=readme) library is upgraded from the version `3.4.0` to `8.3.2` (the warning message is also removed).
> **Note:** upgrading the uuid from the version 3 to 8 alone wasn't possible due to deprecated imports ([more information](https://github.com/uuidjs/uuid#upgrading-from-uuid3)).

## Specific Changes
- Added a new resolutions' field at the root _package.json_ file, upgrading the ms-rest-js version to `2.6.1`.
- Updated _yarn.lock_ file with the updated ms-rest-js version.

## Testing
The following image shows the [core-bot](https://github.com/microsoft/BotBuilder-Samples/tree/1b180f025d2c233fe496ce2bf2dcd6030cc153a6/samples/javascript_nodejs/13.core-bot) working as expected in both version (v2, v3) with the changes.
![image](https://user-images.githubusercontent.com/62260472/205138220-ae355b4c-3491-4f13-8eb3-4c399d5971ab.png)


