### PR TITLE
fix: [#4414] JS Linux Functional Test pipeline failing

### DIFF
--- a/testing/functional/functionaltestbot/template/linux/template.json
+++ b/testing/functional/functionaltestbot/template/linux/template.json
@@ -7,7 +7,7 @@
             "minLength": 2
         },
         "botSku": {
-        "defaultValue": "F0",
+        "defaultValue": "S1",
         "type": "string",
         "metadata": {
             "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."

--- a/testing/functional/functionaltestbot/template/linux/template.json
+++ b/testing/functional/functionaltestbot/template/linux/template.json
@@ -25,7 +25,7 @@
         },
         "linuxFxVersion": {
             "type": "string",
-            "defaultValue": "NODE|10.14"
+            "defaultValue": "NODE|16-lts"
         },
         "location": {
             "type": "string",
@@ -92,7 +92,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "16.18.0"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/testing/functional/tests/directLine.test.js
+++ b/testing/functional/tests/directLine.test.js
@@ -12,55 +12,62 @@ const userMessage = 'Contoso';
 const directLineSecret = process.env.DIRECT_LINE_KEY || null;
 
 const auths = {
-    AuthorizationBotConnector: new Swagger.ApiKeyAuthorization('Authorization', 'BotConnector ' + directLineSecret, 'header'),
+    AuthorizationBotConnector: new Swagger.ApiKeyAuthorization(
+        'Authorization',
+        'BotConnector ' + directLineSecret,
+        'header'
+    ),
 };
 
-function getDirectLineClient() {    
+function getDirectLineClient() {
     return new Swagger({
         spec: directLineSpec,
         usePromise: true,
-        authorizations: auths
+        authorizations: auths,
     });
 }
 
-async function sendMessage(client, conversationId) {       
+async function sendMessage(client, conversationId) {
     let status;
-    do{
+    do {
         await client.Conversations.Conversations_PostMessage({
             conversationId: conversationId,
             message: {
                 from: directLineClientName,
-                text: userMessage
-            }
-        }).then((result) => {
-            status = result.status;
-        }).catch((err)=>{
-            status = err.status;
-        }); 
-    }while(status == 502);
+                text: userMessage,
+            },
+        })
+            .then((result) => {
+                status = result.status;
+            })
+            .catch((err) => {
+                status = err.status;
+            });
+    } while (status == 502);
 }
 
-function getMessages(client, conversationId) {    
-    let watermark = null;
-    return client.Conversations.Conversations_GetMessages({ conversationId: conversationId, watermark: watermark })
-        .then((response) => {            
-            return response.obj.messages.filter((message) => message.from !== directLineClientName);       
-        });
+function getMessages(client, conversationId) {
+    const watermark = null;
+    return client.Conversations.Conversations_GetMessages({
+        conversationId: conversationId,
+        watermark: watermark,
+    }).then((response) => {
+        return response.obj.messages.filter((message) => message.from !== directLineClientName);
+    });
 }
 
 function getConversationId(client) {
-    return client.Conversations.Conversations_NewConversation()
-        .then((response) => response.obj.conversationId);
+    return client.Conversations.Conversations_NewConversation().then((response) => response.obj.conversationId);
 }
 
-describe('Test Azure Bot', function(){
-    this.timeout(60000);    
-    it('Check deployed bot answer', async function(){
-        const directLineClient = await getDirectLineClient();    
+describe('Test Azure Bot', function () {
+    this.timeout(60000);
+    it('Check deployed bot answer', async function () {
+        const directLineClient = await getDirectLineClient();
         const conversationId = await getConversationId(directLineClient);
         await sendMessage(directLineClient, conversationId);
         const messages = await getMessages(directLineClient, conversationId);
-        const result = messages.filter((message) => message.text.includes('you said'));                
-        assert(result[0].text == `you said "${ userMessage }" 0`, `test fail`);
+        const result = messages.filter((message) => message.text.includes('you said'));
+        assert(result[0].text == `you said "${userMessage}" 0`, 'test fail');
     });
 });


### PR DESCRIPTION
Fixes # 4414
#minor

## Description
This PR fixes the errors in the JS Linux Functional Test pipeline. It also applies some prettier fixes to the DirectLine tests.

The error `TypeError: Cannot read property 'text' of undefined` was fixed by upgrading the **_botSku_** from F0 to S1, as the bot was throwing an error related to the _max transactions being exceeded_.
We also had an authorization issue that was solved by upgrading the bot's **_Node version from 10 to 16._**

## Specific Changes
  - Updated the `functionaltestbot/template/linux/template.json` to upgrade the Node version to 16 and the botSku default value to S1.
  - Updated prettier issues in `testing/functional/tests/directLine.test.js`.
 
## Testing
This image shows the testing pipeline successfully executed after the changes:
![image](https://user-images.githubusercontent.com/44245136/214667521-ce55a0bf-bde1-4a1c-bb8a-22ea42200bdb.png)
