### PR TITLE
fix: [#4408] Cloud adapter is not working with teams SSO

### DIFF
--- a/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
+++ b/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
@@ -140,8 +140,6 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
         let tokenExchangeResponse: TokenResponse;
         const tokenExchangeRequest: TokenExchangeInvokeRequest = context.activity.value;
 
-        const tokenProvider = ExchangeToken.safeParse(context.adapter);
-
         try {
             const userTokenClient = context.turnState.get<UserTokenClient>(
                 (context.adapter as CloudAdapterBase).UserTokenClientKey
@@ -153,15 +151,15 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
                     context.activity.channelId,
                     { token: tokenExchangeRequest.token }
                 );
-            } else if (tokenProvider.success) {
-                tokenExchangeResponse = await tokenProvider.data.exchangeToken(
+            } else if (ExchangeToken.check(context.adapter)) {
+                tokenExchangeResponse = await context.adapter.exchangeToken(
                     context,
                     this.oAuthConnectionName,
                     context.activity.channelId,
                     { token: tokenExchangeRequest.token }
                 );
             } else {
-                new Error('The provided token is not supported by the current adapter.');
+                new Error('Token Exchange is not supported by the current adapter.');
             }
         } catch (_err) {
             // Ignore Exceptions

--- a/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
+++ b/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
@@ -142,7 +142,6 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
 
         const tokenProvider = ExchangeToken.safeParse(context.adapter);
 
-        // TODO(jgummersall) convert to new user token client provider when available
         try {
             const userTokenClient = context.turnState.get<UserTokenClient>(
                 (context.adapter as CloudAdapterBase).UserTokenClientKey
@@ -153,7 +152,7 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
                     this.oAuthConnectionName,
                     context.activity.channelId,
                     { token: tokenExchangeRequest.token }
-                )
+                );
             } else if (tokenProvider.success) {
                 tokenExchangeResponse = await tokenProvider.data.exchangeToken(
                     context,
@@ -162,7 +161,7 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
                     { token: tokenExchangeRequest.token }
                 );
             } else {
-                new Error('The provided token is not supported.');
+                new Error('The provided token is not supported by the current adapter.');
             }
         } catch (_err) {
             // Ignore Exceptions

--- a/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
+++ b/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
@@ -146,7 +146,7 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
             const userTokenClient = context.turnState.get<UserTokenClient>(
                 (context.adapter as CloudAdapterBase).UserTokenClientKey
             );
-            if (userTokenClient != null) {
+            if (userTokenClient) {
                 tokenExchangeResponse = await userTokenClient.exchangeToken(
                     context.activity.from.id,
                     this.oAuthConnectionName,


### PR DESCRIPTION
Fixes # 4408
#minor

## Description
This PR allows the SSO Teams bots to work with CloudAdapter. It also adds the unit tests for the different adapter cases.

## Specific Changes
- Updated teamsSSOTokenExchangeMiddleware to allow UserTokenClient tokens.
- Added unit tests for _botFrameworkAdapter_ and _cloudAdapter_ cases.

## Testing
Added unit tests for the _exchangedToken_ method.
![image (200)](https://user-images.githubusercontent.com/64815358/216707896-507df4cb-8a36-4f9d-ac65-661bbb785370.png)
