### PR TITLE
port: [#4432] Expired JWT token exception not being handled (#6572)

### DIFF
--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -32,6 +32,7 @@
     "botbuilder-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",
+    "botframework-schema": "4.1.6",
     "botframework-streaming": "4.1.6",
     "dayjs": "^1.10.3",
     "filenamify": "^4.1.0",

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -11,10 +11,12 @@ const {
     allowedCallersClaimsValidator,
 } = require('botframework-connector');
 const {
+    CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
+    ActivityTypes,
     createBotFrameworkAuthenticationFromConfiguration,
-} = require('botbuilder');
-const { CloudAdapter, ActivityTypes, INVOKE_RESPONSE_KEY } = require('..');
+    INVOKE_RESPONSE_KEY,
+} = require('..');
 const { NamedPipeServer } = require('botframework-streaming');
 const { StatusCodes } = require('botframework-schema');
 

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -5,9 +5,18 @@ const assert = require('assert');
 const httpMocks = require('node-mocks-http');
 const net = require('net');
 const sinon = require('sinon');
-const { BotFrameworkAuthenticationFactory } = require('botframework-connector');
+const {
+    AuthenticationConfiguration,
+    BotFrameworkAuthenticationFactory,
+    allowedCallersClaimsValidator,
+} = require('botframework-connector');
+const {
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
+} = require('botbuilder');
 const { CloudAdapter, ActivityTypes, INVOKE_RESPONSE_KEY } = require('..');
 const { NamedPipeServer } = require('botframework-streaming');
+const { StatusCodes } = require('botframework-schema');
 
 const FakeBuffer = () => Buffer.from([]);
 const FakeNodeSocket = () => new net.Socket();
@@ -16,7 +25,7 @@ const noop = () => null;
 describe('CloudAdapter', function () {
     let sandbox;
     beforeEach(function () {
-        sandbox = sinon.createSandbox({ useFakeTimers: true });
+        sandbox = sinon.createSandbox({ useFakeTimers: false });
     });
 
     afterEach(function () {
@@ -86,6 +95,56 @@ describe('CloudAdapter', function () {
             await adapter.process(req, res, logic);
 
             mock.verify();
+        });
+
+        it('throws exception on expired token', async function () {
+            // Expired token with removed AppID
+            const authorization =
+                'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjJaUXBKM1VwYmpBWVhZR2FYRUpsOGxWMFRPSSIsImtpZCI6IjJaUXBKM1VwYmpBWVhZR2FYRUpsOGxWMFRPSSJ9.eyJhdWQiOiJodHRwczovL2FwaS5ib3RmcmFtZXdvcmsuY29tIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiLyIsImlhdCI6MTY3MDM1MDQxNSwibmJmIjoxNjcwMzUwNDE1LCJleHAiOjE2NzA0MzcxMTUsImFpbyI6IkUyWmdZTkJONEpWZmxlOTJUc2wxYjhtOHBjOWpBQT09IiwiYXBwaWQiOiI5ZGRmM2QwZS02ZDRlLTQ2MWEtYjM4Yi0zMTYzZWQ3Yjg1NmIiLCJhcHBpZGFjciI6IjEiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwicmgiOiIwLkFXNEFJSlRVMXB2ejkwMmgzTldhazFoeDIwSXpMWTBwejFsSmxYY09EcS05RnJ4dUFBQS4iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJIWDlncld2bU1rMlhESTRkS3BHSEFBIiwidmVyIjoiMS4wIn0.PBLuja5sCcDfFjweoy-VucvbfHEyEcs1GyqXjekzBqgvK-mSc1UrEfqr5834qY6dLNsXVIMJzMFuH6WyPbnAfIfRcabdiVSOAl8N8e9Tex6vHfPi4h4P2F96VkXU80EtZX4QMjsJMDJ5eXbJlIDEAxXoJbAdHqgy-lHcVBx8XK7toJ_W7vSsFhis3C4CPCHI1cf1WuHVwfFXBiNwsOzj9cnRUKpea6UELV89q4C0L6aeSNdWYXehZmgq-wlo2wIaGgQ7rOXx4MlIrc83LBzMMc6TWvBJecK6O8pJWLe6BTwOltBI8Tmo2hWnY1OnsbOhbSSlfwLaZqKI7QpA50_2GQ';
+
+            const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
+
+            const req = httpMocks.createRequest({
+                method: 'POST',
+                headers: { authorization },
+                body: activity,
+            });
+
+            const res = httpMocks.createResponse();
+
+            const logic = async (context) => {
+                context.turnState.set(INVOKE_RESPONSE_KEY, {
+                    type: ActivityTypes.InvokeResponse,
+                    value: {
+                        status: 200,
+                        body: 'invokeResponse',
+                    },
+                });
+            };
+
+            const validTokenIssuers = [];
+            const claimsValidators = allowedCallersClaimsValidator(['*']);
+            const authConfig = new AuthenticationConfiguration([], claimsValidators, validTokenIssuers);
+            const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+                MicrosoftAppId: '',
+                MicrosoftAppPassword: '',
+                MicrosoftAppType: '',
+                MicrosoftAppTenantId: '',
+            });
+
+            const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(
+                null,
+                credentialsFactory,
+                authConfig,
+                undefined,
+                undefined
+            );
+
+            const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+            await adapter.process(req, res, logic);
+
+            assert.equal(StatusCodes.UNAUTHORIZED, res.statusCode);
         });
     });
 

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -196,6 +196,10 @@ export class JwtTokenExtractor {
             // from a validated JWT (see `verify` above), so no harm in doing so.
             return new ClaimsIdentity(claims, true);
         } catch (err) {
+            if (err.name === 'TokenExpiredError') {
+                console.error(err);
+                throw new AuthenticationError('The token has expired', StatusCodes.UNAUTHORIZED);
+            }
             console.error(`Error finding key for token. Available keys: ${metadata.key}`);
             throw err;
         }

--- a/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
@@ -18,7 +18,7 @@ const {
 } = require('../..');
 
 describe('JwtTokenValidation', function () {
-    afterEach(function () {
+    beforeEach(function () {
         JwtTokenExtractor.openIdMetadataCache.clear();
     });
 


### PR DESCRIPTION
#minor
Fixes # 4432

## Description
This PR ports the changes in the [PR#6572](https ://github.com/microsoft/botbuilder-dotnet/pull/ 6572) to handle expired tokens and return a most accurate error message.

## Specific Changes
- Added catch block in `jwtTokenExtractor` for _TokenExpiredErrors_.
- Added a unit test in `jwtTokenExtractor.test.js` to cover the new code.
- Added a unit test in `cloudAdapter.test.js` to verify the exception is properly thrown.

## Testing
These images show the exception being displayed to the user in Emulator and the new unit tests passing.
![image](https://user-images.githubusercontent.com/44245136/219411818-f92d4025-93cc-4128-a741-ea9f7cdaaaa3.png)

![image](https://user-images.githubusercontent.com/44245136/219411867-12807dd6-9945-44ee-88f9-8d76651d20bf.png)
