### PR TITLE
fix: [#4440][Bot node.js] Compile error for accessing "conversation" and "organizer" fields for get meeting details bot API

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -40,6 +40,7 @@ import { InvokeResponse } from 'botbuilder-core';
 import { IReceiveRequest } from 'botframework-streaming';
 import { IStreamingTransportServer } from 'botframework-streaming';
 import { MeetingEndEventDetails } from 'botbuilder-core';
+import { MeetingInfo } from 'botbuilder-core';
 import { MeetingNotification } from 'botbuilder-core';
 import { MeetingNotificationResponse } from 'botbuilder-core';
 import { MeetingStartEventDetails } from 'botbuilder-core';
@@ -446,7 +447,7 @@ export function teamsGetTenant(activity: Activity): TenantInfo | null;
 
 // @public
 export class TeamsInfo {
-    static getMeetingInfo(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo>;
+    static getMeetingInfo(context: TurnContext, meetingId?: string): Promise<MeetingInfo>;
     static getMeetingParticipant(context: TurnContext, meetingId?: string, participantId?: string, tenantId?: string): Promise<TeamsMeetingParticipant>;
     static getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount>;
     // @deprecated

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -20,7 +20,7 @@ import {
     ConversationParameters,
     ConversationReference,
     TeamsMeetingParticipant,
-    TeamsMeetingInfo,
+    MeetingInfo,
     Channels,
     MeetingNotification,
     MeetingNotificationResponse,
@@ -92,9 +92,9 @@ export class TeamsInfo {
      *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param meetingId The BASE64-encoded id of the Teams meeting.
-     * @returns The [TeamsMeetingInfo](xref:botbuilder-core.TeamsMeetingInfo) fetched
+     * @returns The [MeetingInfo](xref:botframework-schema.MeetingInfo) fetched
      */
-    static async getMeetingInfo(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo> {
+    static async getMeetingInfo(context: TurnContext, meetingId?: string): Promise<MeetingInfo> {
         if (!context) {
             throw new Error('context is required.');
         }

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -7,7 +7,7 @@ import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/m
 import {
     ConversationList,
     TeamDetails,
-    TeamsMeetingInfo,
+    MeetingInfo,
     MeetingNotificationResponse,
     TeamsMeetingParticipant,
 } from 'botframework-schema';
@@ -109,7 +109,7 @@ export interface TeamsFetchMeetingParticipantOptionalParams extends RequestOptio
 /**
  * Contains response data for the fetchMeetingInfo operation.
  */
-export type TeamsMeetingInfoResponse = TeamsMeetingInfo & {
+export type TeamsMeetingInfoResponse = MeetingInfo & {
     /**
      * The underlying HTTP response.
      */


### PR DESCRIPTION
Fixes # 4440
#minor

## Description
This PR fixes the compile error in TS when trying to access the properties returned by the _getMeetingInfo_ function.
It replaces the **_TeamsMeetingInfo_** return type with the correct **_MeetingInfo_** type, also matching with the .NET implementation.

_**Note**: Although this would be a breaking change, as the method's signature was updated, the data returned by the method remained the same. Anyone using the old interface wouldn't be able to access its properties anyway._

## Specific Changes
- Replaced **_TeamsMeetingInfo_** with **_MeetingInfo_** as return type in _getMeetingInfo_ function.
- Updated **_TeamsMeetingInfoResponse_** type to use the correct _MeetingInfo_ interface.
- Updated method's signature in **_botbuilder.api.md_**.

## Testing
These images show the compile error solved and the meeting info properly returned by the method.
![image](https://user-images.githubusercontent.com/44245136/225093892-11599360-93e6-43d2-a264-a7e8a4f6b68a.png)