### PR TITLE
fix: [#4449] CloudAdapter always builds Connector with MicrosoftAppCredentials (never CertificateAppCredentials) -- certificate auth flow broken

### DIFF
--- a/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
+++ b/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
@@ -88,6 +88,16 @@ const TypedOptions = z
          * A value for the CallerId.
          */
         CallerId: z.string(),
+
+        /**
+         * Certificate thumbprint to authenticate the appId against AAD.
+         */
+        [AuthenticationConstants.CertificateThumbprint]: z.string(),
+
+        /**
+         * Certificate key to authenticate the appId against AAD.
+         */
+        [AuthenticationConstants.CertificatePrivateKey]: z.string(),
     })
     .partial();
 

--- a/libraries/botbuilder-core/tests/configurationServiceClientCredentialFactory.test.js
+++ b/libraries/botbuilder-core/tests/configurationServiceClientCredentialFactory.test.js
@@ -6,6 +6,7 @@ const {
     ConfigurationServiceClientCredentialFactory,
     createServiceClientCredentialFactoryFromConfiguration,
 } = require('../');
+const { CertificateAppCredentials } = require('botframework-connector');
 
 describe('ConfigurationServiceClientCredentialFactory', function () {
     class TestConfiguration {
@@ -96,6 +97,52 @@ describe('ConfigurationServiceClientCredentialFactory', function () {
         createServiceClientCredentialFactoryFromConfiguration(config);
     });
 
+    it('createServiceClientCredentialFactoryFromConfiguration() with certificate', async function () {
+        const config = new TestConfiguration({
+            CertificateThumbprint: 'CertificateThumbprint',
+            CertificatePrivateKey: 'CertificatePrivateKey',
+        });
+
+        const serviceClient = createServiceClientCredentialFactoryFromConfiguration(config);
+        const credentialClient = await serviceClient.createCredentials(TestConfiguration.DefaultConfig.MicrosoftAppId);
+        assert(credentialClient instanceof CertificateAppCredentials);
+    });
+
+    it('createServiceClientCredentialFactoryFromConfiguration() with certificate and no MicrosoftAppId', async function () {
+        const config = new TestConfiguration({
+            MicrosoftAppId: undefined,
+            CertificateThumbprint: 'CertificateThumbprint',
+            CertificatePrivateKey: 'CertificatePrivateKey',
+        });
+
+        assert.throws(() => createServiceClientCredentialFactoryFromConfiguration(config), {
+            name: 'AssertionError',
+            message: 'MicrosoftAppId is required for MultiTenant when using a Certificate in configuration.',
+        });
+    });
+
+    it('createServiceClientCredentialFactoryFromConfiguration() with certificate and no CertificatePrivateKey', async function () {
+        const config = new TestConfiguration({
+            CertificateThumbprint: 'CertificateThumbprint',
+        });
+
+        assert.throws(() => createServiceClientCredentialFactoryFromConfiguration(config), {
+            name: 'AssertionError',
+            message: 'CertificatePrivateKey is required when using a Certificate in configuration.',
+        });
+    });
+
+    it('createServiceClientCredentialFactoryFromConfiguration() with certificate and no CertificateThumbprint', async function () {
+        const config = new TestConfiguration({
+            CertificatePrivateKey: 'CertificatePrivateKey',
+        });
+
+        assert.throws(() => createServiceClientCredentialFactoryFromConfiguration(config), {
+            name: 'AssertionError',
+            message: 'CertificateThumbprint is required when using a Certificate in configuration.',
+        });
+    });
+
     it('createServiceClientCredentialFactoryFromConfiguration() with casing-string MicrosoftAppType configuration should work', function () {
         const config = new TestConfiguration({ ...SingleTenantConfig, MicrosoftAppType: 'singletenant' });
 
@@ -135,6 +182,18 @@ describe('ConfigurationServiceClientCredentialFactory', function () {
             name: 'AssertionError',
             message: 'MicrosoftAppPassword is required for SingleTenant in configuration.',
         });
+    });
+
+    it('createServiceClientCredentialFactoryFromConfiguration() singleTenant with certificate', async function () {
+        const config = new TestConfiguration({
+            ...SingleTenantConfig,
+            CertificateThumbprint: 'CertificateThumbprint',
+            CertificatePrivateKey: 'CertificatePrivateKey',
+        });
+
+        const serviceClient = createServiceClientCredentialFactoryFromConfiguration(config);
+        const credentialClient = await serviceClient.createCredentials(SingleTenantConfig.MicrosoftAppId);
+        assert(credentialClient instanceof CertificateAppCredentials);
     });
 
     it('createServiceClientCredentialFactoryFromConfiguration() manageIdentityApp with config should work', function () {

--- a/libraries/botframework-connector/src/auth/authenticationConstants.ts
+++ b/libraries/botframework-connector/src/auth/authenticationConstants.ts
@@ -181,4 +181,14 @@ export namespace AuthenticationConstants {
      * Indicates that bot identity is anonymous (no appId and password were provided).
      */
     export const AnonymousAuthType = 'anonymous';
+
+    /**
+     * Certificate thumbprint to authenticate the appId against AAD.
+     */
+    export const CertificateThumbprint = 'CertificateThumbprint';
+
+    /**
+     * Certificate key to authenticate the appId against AAD.
+     */
+    export const CertificatePrivateKey = 'CertificatePrivateKey';
 }

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -36,7 +36,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
             'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint.'
         );
         ok(
-            certificateThumbprint?.trim(),
+            certificatePrivateKey?.trim(),
             'CertificateServiceClientCredentialsFactory.constructor(): missing certificatePrivateKey.'
         );
 
@@ -67,7 +67,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
     async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
         ok(
             await this.isValidAppId(appId),
-            'ManagedIdentityServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.'
+            'CertificateServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.'
         );
 
         return new CertificateAppCredentials(

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -1,0 +1,81 @@
+/**
+ * @module botframework-connector
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { ok } from 'assert';
+import { CertificateAppCredentials } from './certificateAppCredentials';
+
+/**
+ * A Certificate implementation of the [ServiceClientCredentialsFactory](xref:botframework-connector.ServiceClientCredentialsFactory) abstract class.
+ */
+export class CertificateServiceClientCredentialsFactory extends ServiceClientCredentialsFactory {
+    private readonly appId: string;
+    private readonly certificateThumbprint: string;
+    private readonly certificatePrivateKey: string;
+    private readonly tenantId: string | null;
+
+    /**
+     * Initializes a new instance of the CertificateServiceClientCredentialsFactory class.
+     *
+     * @param appId Microsoft application Id related to the certificate.
+     * @param certificateThumbprint A hex encoded thumbprint of the certificate.
+     * @param certificatePrivateKey A PEM encoded certificate private key.
+     * @param tenantId Optional. The oauth token tenant.
+     */
+    constructor(appId: string, certificateThumbprint: string, certificatePrivateKey: string, tenantId?: string) {
+        super();
+        ok(appId?.trim(), 'CertificateServiceClientCredentialsFactory.constructor(): missing appId.');
+        ok(
+            certificateThumbprint?.trim(),
+            'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint.'
+        );
+        ok(
+            certificateThumbprint?.trim(),
+            'CertificateServiceClientCredentialsFactory.constructor(): missing certificatePrivateKey.'
+        );
+
+        this.appId = appId;
+        this.certificateThumbprint = certificateThumbprint;
+        this.certificatePrivateKey = certificatePrivateKey;
+        this.tenantId = tenantId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isValidAppId(appId: string): Promise<boolean> {
+        return appId === this.appId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isAuthenticationDisabled(): Promise<boolean> {
+        // Auth is always enabled for Certificate.
+        return;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
+        ok(
+            await this.isValidAppId(appId),
+            'ManagedIdentityServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.'
+        );
+
+        return new CertificateAppCredentials(
+            this.appId,
+            this.certificateThumbprint,
+            this.certificatePrivateKey,
+            this.tenantId,
+            audience
+        );
+    }
+}

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -15,6 +15,7 @@ export * from './authenticateRequestResult';
 export * from './botFrameworkAuthentication';
 export * from './botFrameworkAuthenticationFactory';
 export * from './certificateAppCredentials';
+export * from './certificateServiceClientCredentialsFactory';
 export * from './channelValidation';
 export * from './claimsIdentity';
 export * from './connectorFactory';


### PR DESCRIPTION
Fixes # 4449
#minor

## Description
This PR adds support for the CloudAdapter's configuration process to authenticate using certificates is _MultiTenant_ and _SingleTenant_ apps.

## Specific Changes
- Added `CertificateServiceClientCredentialsFactory` class, to instantiate and configure the `CertificateAppCredentials` class, so the process knows how to authenticate with certificates.
- Added `ConfigurationServiceClientCredentialFactory` unit tests, validating the different code paths when using certificates.
- Added `CertificateThumbprint` and `CertificatePrivateKey` constants to the `AuthenticationConstants`, `ConfigurationBotFrameworkAuthentication` and `ConfigurationServiceClientCredentialFactory` classes.
- Updated `ConfigurationServiceClientCredentialFactory` to detect when a certificate is provided, and execute the proper functionality to authenticate with certificates (instead of a password) in _MultiTenant_ and _SingleTenant_ apps.

## Testing
The following images show the bot and unit tests working as expected.
![image](https://user-images.githubusercontent.com/62260472/233693156-eed7aca4-d9f4-487b-8424-a514f8f53a3f.png)
![image](https://user-images.githubusercontent.com/62260472/233693173-32249313-8dc5-4296-bff9-d130b331925e.png)