### PR TITLE
fix: [#4466] Fix telemetry activityId and conversationId properties

### DIFF
--- a/libraries/botbuilder-core/src/telemetryConstants.ts
+++ b/libraries/botbuilder-core/src/telemetryConstants.ts
@@ -79,4 +79,9 @@ export class TelemetryConstants {
      * The telemetry property value for activity type.
      */
     static readonly activityTypeProperty: string = 'type';
+
+    /**
+     * The telemetry property value for activity id.
+     */
+    static readonly activityIdProperty: string = 'activityId';
 }

--- a/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
+++ b/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
@@ -227,6 +227,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.recipientIdProperty] = activity.recipient?.id ?? '';
             properties[TelemetryConstants.recipientNameProperty] = activity.recipient?.name ?? '';
             properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
+            properties[TelemetryConstants.activityIdProperty] = activity.id ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (this.logPersonalInformation) {
@@ -283,6 +284,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
             properties[TelemetryConstants.localeProperty] = activity.locale ?? '';
             properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
+            properties[TelemetryConstants.activityIdProperty] = activity.id ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (this.logPersonalInformation) {
@@ -337,6 +339,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
             properties[TelemetryConstants.localeProperty] = activity.locale ?? '';
             properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
+            properties[TelemetryConstants.activityIdProperty] = activity.id ?? '';
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
             if (this.logPersonalInformation) {
@@ -375,6 +378,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
             properties[TelemetryConstants.conversationIdProperty] = activity.conversation?.id ?? '';
             properties[TelemetryConstants.conversationNameProperty] = activity.conversation?.name ?? '';
             properties[TelemetryConstants.activityTypeProperty] = activity.type ?? '';
+            properties[TelemetryConstants.activityIdProperty] = activity.id ?? '';
 
             // Additional Properties can override "stock" properties.
             if (telemetryProperties) {

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -546,6 +546,11 @@ export class TurnContext {
             } else {
                 const responses = await this.adapter.sendActivities(this, output);
 
+                for (let index = 0; index < responses.length; index++) {
+                    const activity = output[index];
+                    activity.id = responses[index].id;
+                }
+
                 // Set responded flag
                 if (sentNonTraceActivity) {
                     this.responded = true;

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -546,7 +546,7 @@ export class TurnContext {
             } else {
                 const responses = await this.adapter.sendActivities(this, output);
 
-                for (let index = 0; index < responses.length; index++) {
+                for (let index = 0; index < responses?.length; index++) {
                     const activity = output[index];
                     activity.id = responses[index].id;
                 }

--- a/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
@@ -43,9 +43,11 @@ describe('TelemetryMiddleware', function () {
 
         const expectTrackEvent = (name, properties = {}) => {
             expectExactEvent(name, {
+                conversationId: sinon.match.string,
                 conversationName: sinon.match.string,
                 recipientId: sinon.match.string,
                 type: sinon.match.string,
+                activityId: sinon.match.string,
                 ...properties,
             });
         };


### PR DESCRIPTION
Fixes # 4466

## Description
This PR adds the `activityId` and `conversationId` properties to the `TelemetryLoggerMiddleware` functionality. Additionally, it fixes a port issue where the `activity.id` property wasn't being available after sending the activities.

## Specific Changes

- Added `activityId` key property to the telemetry constants class.
- Added `activityId` property to the `TelemetryLoggerMiddleware` class.
- Fixed a port issue where the `activity.id` property wasn't available after sending the activities.
- Updated unit tests to assert over the `conversationId` and `activityId` properties.

## Testing
The following image shows how the `activityId` and `conversationId` properties are displayed correctly.
![image](https://user-images.githubusercontent.com/62260472/235733513-98d247e2-6709-4625-bf5c-672dbed9bc6e.png)
