### PR TITLE
add onBehalfOf property to Teams channel

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -51,6 +51,7 @@ import { MicrosoftAppCredentials } from 'botframework-connector';
 import { Middleware } from 'botbuilder-core';
 import { NodeWebSocketFactoryBase } from 'botframework-streaming';
 import { O365ConnectorCardActionQuery } from 'botbuilder-core';
+import { OnBehalfOf } from 'botbuilder-core';
 import { PagedMembersResult } from 'botbuilder-core';
 import { PagedResult } from 'botbuilder-core';
 import { ReadReceiptInfo } from 'botframework-connector';
@@ -440,6 +441,9 @@ export function teamsGetTeamInfo(activity: Activity): TeamInfo | null;
 
 // @public
 export function teamsGetTeamMeetingInfo(activity: Activity): TeamsMeetingInfo | null;
+
+// @public (undocumented)
+export function teamsGetTeamOnBehalfOf(activity: Activity): OnBehalfOf[];
 
 // @public
 export function teamsGetTenant(activity: Activity): TenantInfo | null;

--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, TeamInfo, TeamsChannelData, TeamsMeetingInfo, TenantInfo } from 'botbuilder-core';
+import { Activity, OnBehalfOf, TeamInfo, TeamsChannelData, TeamsMeetingInfo, TenantInfo } from 'botbuilder-core';
 
 function isTeamsChannelData(channelData: unknown): channelData is TeamsChannelData {
     return typeof channelData === 'object';
@@ -130,4 +130,20 @@ export function teamsNotifyUser(
     if (isTeamsChannelData(activity.channelData)) {
         activity.channelData.notification = { alert: !alertInMeeting, alertInMeeting, externalResourceUrl };
     }
+}
+
+/**
+ * @param activity The current [Activity](xref:botframework-schema.Activity).
+ * @returns The current [Activity](xref:botframework-schema.Activity)'s team's onBehalfOf list, or null.
+ */
+export function teamsGetTeamOnBehalfOf(activity: Activity): OnBehalfOf[] {
+    validateActivity(activity);
+
+    const channelData = activity.channelData;
+    if (isTeamsChannelData(channelData)) {
+        const onBehalfOf = channelData.onBehalfOf;
+        return onBehalfOf || null;
+    }
+
+    return null;
 }

--- a/libraries/botbuilder/tests/teamsHelpers.test.js
+++ b/libraries/botbuilder/tests/teamsHelpers.test.js
@@ -10,6 +10,7 @@ const {
     teamsGetTeamId,
     teamsGetTeamInfo,
     teamsNotifyUser,
+    teamsGetTeamOnBehalfOf,
 } = require('../');
 
 function createActivityTeamId() {
@@ -193,6 +194,37 @@ describe('TeamsActivityHelpers method', function () {
             const activity = { channelData: { settings: null } };
             const channelId = teamsGetSelectedChannelId(activity);
             assert.strictEqual(channelId, '');
+        });
+    });
+
+    describe('teamsGetTeamOnBehalfOf()', function () {
+        it('should return onBehalfOf list', async function () {
+            const activity = {
+                channelData: {
+                    onBehalfOf: [
+                        {
+                            itemId: 0,
+                            displayName: 'onBehalfOfTest',
+                            mentionType: 'person',
+                            mri: 'mriTest',
+                        },
+                    ],
+                },
+            };
+            const onBehalfOf = teamsGetTeamOnBehalfOf(activity)[0];
+            assert.strictEqual(onBehalfOf.displayName, 'onBehalfOfTest');
+        });
+
+        it('should return null with no channelData', async function () {
+            const activity = createActivityNoChannelData();
+            const onBehalfOf = teamsGetTeamOnBehalfOf(activity);
+            assert(onBehalfOf === null);
+        });
+
+        it('should return null with no onBehalfOf list', async function () {
+            const activity = { channelData: { onBehalfOf: null } };
+            const onBehalfOf = teamsGetTeamOnBehalfOf(activity);
+            assert.strictEqual(onBehalfOf, null);
         });
     });
 });

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1764,6 +1764,7 @@ export interface TeamsChannelData {
     eventType?: string;
     meeting?: TeamsMeetingInfo;
     notification?: NotificationInfo;
+    onBehalfOf?: OnBehalfOf[];
     settings?: TeamsChannelDataSettings;
     team?: TeamInfo;
     tenant?: TenantInfo;

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -189,8 +189,11 @@ export interface TeamsChannelData {
      * message was sent.
      */
     settings?: TeamsChannelDataSettings;
+    /**
+     * @member {OnBehalfOf} [onBehalfOf] The OnBehalfOf information of the message
+     */
+    onBehalfOf?: OnBehalfOf[];
 }
-
 /**
  * @interface
  * An interface representing TeamsChannelAccount.


### PR DESCRIPTION
Fixes #minor

## Description
This PR adds the _OnBehalfOf_ property to send messages via bots on behalf of another user in Teams.

## Specific Changes
- Added the _**OnBehalfOf**_ property in the _TeamsChannelData_ interface.
- Added the **_TeamsGetTeamOnBehalfOf_** method in _teamsActivityHelper_ to return the current activity's _OnBehalfOf_ list

## Testing
![image](https://user-images.githubusercontent.com/122501764/236292657-3c216a07-34a0-44c5-b13f-fb320416a46a.png)
