### PR TITLE
feat: [#4446] Azure Blob Storage should support Identity authentication 

### DIFF
--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -17,7 +17,7 @@ import { TranscriptStore } from 'botbuilder-core';
 
 // @public
 export class BlobsStorage implements Storage_2 {
-    constructor(connectionString: string, containerName: string, url?: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobsStorageOptions);
+    constructor(connectionString: string, containerName: string, options?: BlobsStorageOptions, url?: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential);
     delete(keys: string[]): Promise<void>;
     read(keys: string[]): Promise<StoreItems>;
     write(changes: StoreItems): Promise<void>;

--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -5,16 +5,19 @@
 ```ts
 
 import { Activity } from 'botbuilder-core';
+import { AnonymousCredential } from '@azure/storage-blob';
 import { PagedResult } from 'botbuilder-core';
 import { Storage as Storage_2 } from 'botbuilder-core';
 import { StoragePipelineOptions } from '@azure/storage-blob';
+import { StorageSharedKeyCredential } from '@azure/storage-blob';
 import { StoreItems } from 'botbuilder-core';
+import { TokenCredential } from '@azure/core-http';
 import { TranscriptInfo } from 'botbuilder-core';
 import { TranscriptStore } from 'botbuilder-core';
 
 // @public
 export class BlobsStorage implements Storage_2 {
-    constructor(connectionString: string, containerName: string, options?: BlobsStorageOptions);
+    constructor(connectionString: string, containerName: string, url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobsStorageOptions);
     delete(keys: string[]): Promise<void>;
     read(keys: string[]): Promise<StoreItems>;
     write(changes: StoreItems): Promise<void>;

--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -17,7 +17,7 @@ import { TranscriptStore } from 'botbuilder-core';
 
 // @public
 export class BlobsStorage implements Storage_2 {
-    constructor(connectionString: string, containerName: string, url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobsStorageOptions);
+    constructor(connectionString: string, containerName: string, url?: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobsStorageOptions);
     delete(keys: string[]): Promise<void>;
     read(keys: string[]): Promise<StoreItems>;
     write(changes: StoreItems): Promise<void>;

--- a/libraries/botbuilder-azure-blobs/package.json
+++ b/libraries/botbuilder-azure-blobs/package.json
@@ -32,7 +32,8 @@
     "botbuilder-stdlib": "4.1.6",
     "get-stream": "^6.0.0",
     "p-map": "^4.0.0",
-    "zod": "~1.11.17"
+    "zod": "~1.11.17",
+    "@azure/core-http": "^1.2.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
+++ b/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
@@ -13,7 +13,7 @@ import {
 import { Storage, StoreItems } from 'botbuilder-core';
 import { ignoreError, isStatusCodeError } from './ignoreError';
 import { sanitizeBlobKey } from './sanitizeBlobKey';
-import { TokenCredential } from '@azure/core-http';
+import { TokenCredential, isTokenCredential } from '@azure/core-http';
 
 /**
  * Optional settings for BlobsStorage
@@ -27,7 +27,7 @@ export interface BlobsStorageOptions {
 }
 
 function isCredentialType(value: any): value is TokenCredential {
-    return 'getToken' in value || 'create' in value;
+    return isTokenCredential(value) || 'create' in value;
 }
 
 /**
@@ -43,16 +43,16 @@ export class BlobsStorage implements Storage {
      *
      * @param {string} connectionString Azure Blob Storage connection string
      * @param {string} containerName Azure Blob Storage container name
+     * @param {BlobsStorageOptions} options Other options for BlobsStorage
      * @param {string} url Azure Blob Storage container url
      * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential Azure credential to access the resource
-     * @param {BlobsStorageOptions} options Other options for BlobsStorage
      */
     constructor(
         connectionString: string,
         containerName: string,
+        options?: BlobsStorageOptions,
         url = '',
-        credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
-        options?: BlobsStorageOptions
+        credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential
     ) {
         if (url != '' && credential != null) {
             z.object({ url: z.string() }).parse({

--- a/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
+++ b/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
@@ -27,7 +27,9 @@ export interface BlobsStorageOptions {
 }
 
 function isCredentialType(value: any): value is TokenCredential {
-    return isTokenCredential(value) || 'create' in value;
+    return (
+        isTokenCredential(value) || value instanceof StorageSharedKeyCredential || value instanceof AnonymousCredential
+    );
 }
 
 /**

--- a/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
+++ b/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
@@ -50,11 +50,11 @@ export class BlobsStorage implements Storage {
     constructor(
         connectionString: string,
         containerName: string,
-        url: string,
+        url: string = "",
         credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
         options?: BlobsStorageOptions
     ) {
-        if (url && credential != null) {
+        if (url != "" && credential != null) {
             z.object({ url: z.string() }).parse({
                 url,
             });

--- a/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
+++ b/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
@@ -4,7 +4,12 @@
 import * as z from 'zod';
 import getStream from 'get-stream';
 import pmap from 'p-map';
-import { AnonymousCredential, ContainerClient, StoragePipelineOptions, StorageSharedKeyCredential } from '@azure/storage-blob';
+import {
+    AnonymousCredential,
+    ContainerClient,
+    StoragePipelineOptions,
+    StorageSharedKeyCredential,
+} from '@azure/storage-blob';
 import { Storage, StoreItems } from 'botbuilder-core';
 import { ignoreError, isStatusCodeError } from './ignoreError';
 import { sanitizeBlobKey } from './sanitizeBlobKey';
@@ -38,23 +43,23 @@ export class BlobsStorage implements Storage {
      *
      * @param {string} connectionString Azure Blob Storage connection string
      * @param {string} containerName Azure Blob Storage container name
+     * @param {string} url Azure Blob Storage container url
+     * @param {StorageSharedKeyCredential | AnonymousCredential | TokenCredential} credential Azure credential to access the resource
      * @param {BlobsStorageOptions} options Other options for BlobsStorage
      */
-    constructor
-        (
-            connectionString: string,
-            containerName: string,
-            url: string,
-            credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
-            options?: BlobsStorageOptions
-        ) {
-
+    constructor(
+        connectionString: string,
+        containerName: string,
+        url: string,
+        credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
+        options?: BlobsStorageOptions
+    ) {
         if (url && credential != null) {
             z.object({ url: z.string() }).parse({
-                url
+                url,
             });
 
-            if (typeof credential != "object" || !isCredentialType(credential)) {
+            if (typeof credential != 'object' || !isCredentialType(credential)) {
                 throw new ReferenceError('Invalid credential type.');
             }
 
@@ -70,7 +75,11 @@ export class BlobsStorage implements Storage {
                 containerName,
             });
 
-            this._containerClient = new ContainerClient(connectionString, containerName, options?.storagePipelineOptions);
+            this._containerClient = new ContainerClient(
+                connectionString,
+                containerName,
+                options?.storagePipelineOptions
+            );
 
             // At most one promise at a time to be friendly to local emulator users
             if (connectionString.trim() === 'UseDevelopmentStorage=true;') {

--- a/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
+++ b/libraries/botbuilder-azure-blobs/src/blobsStorage.ts
@@ -50,11 +50,11 @@ export class BlobsStorage implements Storage {
     constructor(
         connectionString: string,
         containerName: string,
-        url: string = "",
+        url = '',
         credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential,
         options?: BlobsStorageOptions
     ) {
-        if (url != "" && credential != null) {
+        if (url != '' && credential != null) {
             z.object({ url: z.string() }).parse({
                 url,
             });

--- a/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
@@ -23,8 +23,11 @@ describe('BlobsStorage', function () {
         it('throws for bad args', function () {
             assert.throws(() => new BlobsStorage(), 'throws for missing connectionString');
             assert.throws(() => new BlobsStorage('connectionString'), 'throws for missing containerName');
-            assert.throws(() => new BlobsStorage(null, null, [], {}), 'throws for missing url');
-            assert.throws(() => new BlobsStorage(null, null, 'url', {}), ReferenceError('Invalid credential type.'));
+            assert.throws(() => new BlobsStorage(null, null, null, [], {}), 'throws for missing url');
+            assert.throws(
+                () => new BlobsStorage(null, null, null, 'url', {}),
+                ReferenceError('Invalid credential type.')
+            );
         });
 
         it('succeeds for good args using connection string', function () {
@@ -33,6 +36,7 @@ describe('BlobsStorage', function () {
 
         it('succeeds for good args using credential', function () {
             new BlobsStorage(
+                null,
                 null,
                 null,
                 'https://test.blob.core.windows.net/blob',

--- a/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
@@ -4,6 +4,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const { BlobsStorage } = require('../');
+const { StorageSharedKeyCredential } = require('@azure/storage-blob');
 
 const connectionString = process.env.AZURE_BLOB_STORAGE_CONNECTION_STRING;
 const containerName = process.env.AZURE_BLOB_STORAGE_CONTAINER;
@@ -22,10 +23,16 @@ describe('BlobsStorage', function () {
         it('throws for bad args', function () {
             assert.throws(() => new BlobsStorage(), 'throws for missing connectionString');
             assert.throws(() => new BlobsStorage('connectionString'), 'throws for missing containerName');
+            assert.throws(() => new BlobsStorage(null, null, [], {}), "throws for missing url");
+            assert.throws(() => new BlobsStorage(null, null, 'url', {}), ReferenceError('Invalid credential type.'));
         });
 
-        it('succeeds for good args', function () {
+        it('succeeds for good args using connection string', function () {
             new BlobsStorage('UseDevelopmentStorage=true;', 'container');
+        });
+
+        it('succeeds for good args using credential', function () {
+            new BlobsStorage(null, null, 'https://test.blob.core.windows.net/blob', new StorageSharedKeyCredential("accountName", "accountKey"));
         });
     });
 

--- a/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
@@ -23,7 +23,7 @@ describe('BlobsStorage', function () {
         it('throws for bad args', function () {
             assert.throws(() => new BlobsStorage(), 'throws for missing connectionString');
             assert.throws(() => new BlobsStorage('connectionString'), 'throws for missing containerName');
-            assert.throws(() => new BlobsStorage(null, null, [], {}), "throws for missing url");
+            assert.throws(() => new BlobsStorage(null, null, [], {}), 'throws for missing url');
             assert.throws(() => new BlobsStorage(null, null, 'url', {}), ReferenceError('Invalid credential type.'));
         });
 
@@ -32,7 +32,12 @@ describe('BlobsStorage', function () {
         });
 
         it('succeeds for good args using credential', function () {
-            new BlobsStorage(null, null, 'https://test.blob.core.windows.net/blob', new StorageSharedKeyCredential("accountName", "accountKey"));
+            new BlobsStorage(
+                null,
+                null,
+                'https://test.blob.core.windows.net/blob',
+                new StorageSharedKeyCredential('accountName', 'accountKey')
+            );
         });
     });
 


### PR DESCRIPTION
#minor

## Description
This PR allows using the MSI authentication for Azure Blob Storage.

## Specific Changes
  - Added a new option in the constructor with the necessary parameters for creating the blob storage client using a msi credentials.

## Testing
The following image shows the new validations and unit test passing.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/cc0ed518-ebb2-45ed-b5b9-1f0dd6613f83)
