### PR TITLE
port: [#6588][#4482] UserId not being passed to AzureDiagnostics

### DIFF
--- a/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
+++ b/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
@@ -589,6 +589,7 @@ export interface QnAMakerOptions {
     strictFiltersJoinOperator?: JoinOperator;
     timeout?: number;
     top?: number;
+    userId?: string;
 }
 
 // @public

--- a/libraries/botbuilder-ai/src/customQuestionAnswering.ts
+++ b/libraries/botbuilder-ai/src/customQuestionAnswering.ts
@@ -269,7 +269,8 @@ export class CustomQuestionAnswering implements QnAMakerClient, QnAMakerTelemetr
         telemetryMetrics: { [key: string]: number }
     ): Promise<QnAMakerResults> {
         const question: string = this.getTrimmedMessageText(context);
-        const queryOptions: QnAMakerOptions = { ...this._options, ...options } as QnAMakerOptions;
+        const userId = context?.activity?.from?.id;
+        const queryOptions: QnAMakerOptions = { ...this._options, ...options, userId } as QnAMakerOptions;
 
         let result: QnAMakerResults;
 

--- a/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerOptions.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerOptions.ts
@@ -83,4 +83,9 @@ export interface QnAMakerOptions {
      * includeUnstructuredSources - option to fetch answers from unsrtuctured sources
      */
     includeUnstructuredSources?: boolean;
+
+    /**
+     * Channel id for the user or bot on this channel
+     */
+    userId?: string;
 }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
@@ -99,6 +99,7 @@ export class LanguageServiceUtils {
             context: queryOptions.context,
             answerSpanRequest: { enable: queryOptions.enablePreciseAnswer },
             includeUnstructuredSources: queryOptions.includeUnstructuredSources,
+            userId: options.userId,
         });
 
         const qnaResults = await this.httpRequestUtils.executeHttpRequest(

--- a/libraries/botbuilder-ai/tests/languageService.test.js
+++ b/libraries/botbuilder-ai/tests/languageService.test.js
@@ -255,7 +255,7 @@ describe('LanguageService', function () {
 
         it('sorts the answers in the qna results from highest to lowest score', async function () {
             const qna = new CustomQuestionAnswering(endpoint);
-            const context = new TestContext({ text: "what's your favorite animal?" });
+            const context = new TestContext({ text: "what's your favorite animal?", from: { id: 'user' } });
             const options = { top: 5 };
 
             const results = await qna.getAnswers(context, options);


### PR DESCRIPTION
#minor

## Description
This PR allows adding the _userId_ property which was empty when displaying the _AzureDiagnostics_ table in the Log Analytics workspace resource.

## Specific Changes
  - Added **_userId_** property to the _queryKnowledgebaseRaw_ request in the _LanguageServiceUtils_ file.
  - Added **_userId_** property to the _QnAMakerOptions_ interface.
  - Updated parameter sending of _queryKnowledgebaseRaw_, allowing to send the userId to the _QnAMakerOptions_ using the context activity

## Testing
The following image shows the _AzureDiagnostics_ log with the _userId_ value.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/6e74e7ce-e02f-4ef5-98cc-5c9922502cda)