### PR TITLE
fix: Force lodash.trimend v4.17.21 to avoid security alert in botbuilder-dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "resolutions": {
     "adal-node": "0.2.3",
     "async": "3.2.3",
+    "lodash.trimend": "https://github.com/lodash/lodash.git#4.17",
     "minimist": "^1.2.6",
     "mixme": "0.5.2",
     "ms-rest-azure": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8380,10 +8380,9 @@ lodash.tonumber@^4.0.3:
   resolved "https://registry.yarnpkg.com/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz#0b96b31b35672793eb7f5a63ee791f1b9e9025d9"
   integrity sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk=
 
-lodash.trimend@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/lodash.trimend/-/lodash.trimend-4.5.1.tgz#12804437286b98cad8996b79414e11300114082f"
-  integrity sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8=
+lodash.trimend@^4.5.1, "lodash.trimend@https://github.com/lodash/lodash.git#4.17":
+  version "4.17.21"
+  resolved "https://github.com/lodash/lodash.git#f299b52f39486275a9e6483b60a410e06520c538"
 
 lodash@^4.1.2, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.15, lodash@~4.17.19:
   version "4.17.21"
@@ -8393,7 +8392,7 @@ lodash@^4.1.2, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.1
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
-  integrity sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=
+  integrity sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==
 
 log-symbols@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
#minor

## Description
This PR fixes [CVE-2020-28500](https://github.com/advisories/GHSA-29mw-wpgm-hmr9) alert by forcing version 4.17.21 of **_lodash.trimend_** in packages.json resolutions (this package is referenced via recognizers-text-number dependency).
As the latest released version of _lodash.trimend_ is 4.5.1, we used a github branch to import the package. **_This is a workaround_** and should be replaced with the release version once it's available.

Related issue in lodash: https: //github.com/lodash/lodash/issues/ 5643
Related issue in Recognizers-Text: https: //github.com/microsoft/Recognizers-Text/issues/ 3122

## Specific Changes
- Added **_lodash.trimend_** to package.json's resolutions using the version from [branch 4.17](https://github.com/lodash/lodash/tree/4.17).

## Testing
This image shows the resolved version for lodash.trimend package. The security alert was no longer shown after the change.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/031c7f72-e41f-4fa3-97c7-a02be4c744e0)
