### PR TITLE
fix: [CVE-2023-0842] Force safe version of xml2js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "underscore": "1.13.1",
     "json-schema": "0.4.0",
     "@xmldom/xmldom": "0.8.6",
+    "xml2js": "^0.5.0",
     "**/botbuilder-ai/@azure/cognitiveservices-luis-runtime/@azure/ms-rest-js": "^2.7.0",
     "jsonwebtoken": "9.0.0",
     "**/request/tough-cookie": "^4.1.3",


### PR DESCRIPTION
#minor

## Description
This PR forces a safe version of the `xml2js` package to avoid the [CVE-2023-0842](https://security.snyk.io/vuln/SNYK-JS-XML2JS-5414874) security issue. This package is a dependency of the `azure-storage` package that will be removed as part of # 4503. 

## Specific Changes
- Added `xml2js` version ^0.5.0 in the resolutions section of the root's package.json file.

## Testing
These images show the Storage tests passing after the change.
[image pending...]