### PR TITLE
fix: Remove request package from botbuilder-core tests

### DIFF
--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "chatdown": "^1.2.4",
-    "request": "^2.88.2",
     "unzipper": "^0.10.9"
   },
   "scripts": {

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -35,6 +35,7 @@
     "zod": "~1.11.17"
   },
   "devDependencies": {
+    "axios": "^0.25.0",
     "chatdown": "^1.2.4",
     "unzipper": "^0.10.9"
   },

--- a/libraries/botbuilder-core/tests/transcriptUtilities.js
+++ b/libraries/botbuilder-core/tests/transcriptUtilities.js
@@ -9,7 +9,7 @@ const path = require('path');
 const url = require('url');
 const promisify = require('util').promisify;
 const readFileAsync = promisify(fs.readFile);
-const request = require('request');
+const axios = require('axios');
 const unzip = require('unzipper');
 const rimraf = require('rimraf');
 
@@ -138,33 +138,37 @@ function downloadAndExtractOnce(url) {
                 const writeStream = fs.createWriteStream(zipPath);
 
                 // download
-                request
-                    .get(url)
-                    .on('end', function () {
-                        // unzip
-                        console.log(`\tUnzipping ${zipPath} into ${outputPath}`);
-                        decompressZip(zipPath, outputPath, function (unzipErr) {
-                            fs.unlinkSync(zipPath); // delete zip
-                            if (unzipErr) {
-                                // error while extracting
-                                return reject(unzipErr);
-                            }
+                axios
+                    .get(url, { responseType: 'stream' })
+                    .then((response) => {
+                        response.data
+                            .on('end', function () {
+                                // unzip
+                                console.log(`\tUnzipping ${zipPath} into ${outputPath}`);
+                                decompressZip(zipPath, outputPath, function (unzipErr) {
+                                    fs.unlinkSync(zipPath); // delete zip
+                                    if (unzipErr) {
+                                        // error while extracting
+                                        return reject(unzipErr);
+                                    }
 
-                            // get branch's inner folder
-                            const childDirectories = getDirectories(outputPath);
-                            let firstDirectory = childDirectories[0];
-                            if (!firstDirectory) {
-                                return reject('Downloaded ZIP did not contain a branch folder.');
-                            }
+                                    // get branch's inner folder
+                                    const childDirectories = getDirectories(outputPath);
+                                    let firstDirectory = childDirectories[0];
+                                    if (!firstDirectory) {
+                                        return reject('Downloaded ZIP did not contain a branch folder.');
+                                    }
 
-                            firstDirectory = path.join(firstDirectory, zipTranscriptsRelativePath);
+                                    firstDirectory = path.join(firstDirectory, zipTranscriptsRelativePath);
 
-                            console.log(`\tTranscripts extracted at ${firstDirectory}`);
-                            return resolve(firstDirectory);
-                        });
+                                    console.log(`\tTranscripts extracted at ${firstDirectory}`);
+                                    return resolve(firstDirectory);
+                                });
+                            })
+                            .on('error', (e) => reject(e)) // reject on download error
+                            .pipe(writeStream);
                     })
-                    .on('error', (e) => reject(e)) // reject on download error
-                    .pipe(writeStream);
+                    .catch((e) => reject(e));
             });
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10998,7 +10998,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0, request@^2.88.2:
+request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
#minor

## Description
This PR replaces the **_request_** package in `botbuilder-core/tests/transcriptUtilities.js` with **_axios_**.

## Specific Changes
- Replaced _request_ get with _axios_ get in the `downloadAndExtractOnce` function used for the transcript tests.
- Removed _request_ dependency from `package.json`
- Updated `yarn.lock` file

## Testing
This image shows one of the tests that are using the _transcriptUtilities_, working after the changes.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/a7bfeb99-3d1a-43a5-948e-acb84382c9e2)
