### PR TITLE
fix: Replace Map with WeakMap to avoid memory leak

### DIFF
--- a/libraries/adaptive-expressions/src/parser/expressionParser.ts
+++ b/libraries/adaptive-expressions/src/parser/expressionParser.ts
@@ -27,7 +27,7 @@ export class ExpressionParser implements ExpressionParserInterface {
      */
     readonly EvaluatorLookup: EvaluatorLookup;
 
-    private static expressionDict: Map<string, ParseTree> = new Map<string, ParseTree>();
+    private static expressionDict: WeakMap<any, ParseTree> = new WeakMap<any, ParseTree>();
 
     private readonly ExpressionTransformer = class
         extends AbstractParseTreeVisitor<Expression>
@@ -279,8 +279,8 @@ export class ExpressionParser implements ExpressionParserInterface {
      * @returns A ParseTree.
      */
     protected static antlrParse(expression: string): ParseTree {
-        if (ExpressionParser.expressionDict.has(expression)) {
-            return ExpressionParser.expressionDict.get(expression);
+        if (ExpressionParser.expressionDict.has({ key: expression })) {
+            return ExpressionParser.expressionDict.get({ key: expression });
         }
 
         const inputStream: ANTLRInputStream = new ANTLRInputStream(expression);
@@ -297,7 +297,7 @@ export class ExpressionParser implements ExpressionParserInterface {
         if (file !== undefined) {
             expressionContext = file.expression();
         }
-        ExpressionParser.expressionDict.set(expression, expressionContext);
+        ExpressionParser.expressionDict.set({ key: expression }, expressionContext);
 
         return expressionContext;
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -36,7 +36,7 @@ export const languagePolicyKey = Symbol('LanguagePolicy');
  * Extension methods for language generator.
  */
 export class LanguageGeneratorExtensions {
-    private static readonly _languageGeneratorManagers = new Map<ResourceExplorer, LanguageGeneratorManager>();
+    private static readonly _languageGeneratorManagers = new WeakMap<ResourceExplorer, LanguageGeneratorManager>();
 
     /**
      * Register default LG file or a language generator as default language generator.


### PR DESCRIPTION
#minor

## Description
This PR replaces the use of **Map** with **WeakMap** in the _LanguageGeneratorExtensions_ and _ExpressionParser_ classes due to a memory leak issue reported in a JS Composer bot.

## Specific Changes
- Replaced _Map_ `_languageGeneratorManagers` with _WeakMap_ in `LanguageGeneratorExtensions`.
- Replaced _Map_ `expressionDict` with _WeakMap_ in `ExpressionParser`. Also, changed the type of the key as _WeakMap_ only supports objects.

## Testing
The unit tests passed after the changes.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/6d5cda42-75bd-4372-b13c-e174561c8d27)
