### PR TITLE
fix: [#4509] botbuilder-ai@4.20.0 is still installing @azure/ms-rest-js@1.11.2 for @azure/cognitiveservices-luis-runtime

### DIFF
--- a/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
+++ b/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
@@ -23,7 +23,7 @@ import { DialogTurnResult } from 'botbuilder-dialogs';
 import { EnumExpression } from 'adaptive-expressions';
 import { Expression } from 'adaptive-expressions';
 import { IntExpression } from 'adaptive-expressions';
-import { LUISRuntimeModels } from '@azure/cognitiveservices-luis-runtime';
+import * as msRest from '@azure/ms-rest-js';
 import { NumberExpression } from 'adaptive-expressions';
 import { ObjectExpression } from 'adaptive-expressions';
 import { Recognizer } from 'botbuilder-dialogs';
@@ -290,7 +290,7 @@ export class LuisComponentRegistration extends ComponentRegistration {
     }
 
 // @public
-export interface LuisPredictionOptions extends LUISRuntimeModels.PredictionResolveOptionalParams {
+export interface LuisPredictionOptions extends msRest.RequestOptionsBase {
     bingSpellCheckSubscriptionKey?: string;
     includeAllIntents?: boolean;
     includeInstanceData?: boolean;
@@ -300,6 +300,7 @@ export interface LuisPredictionOptions extends LUISRuntimeModels.PredictionResol
     staging?: boolean;
     telemetryClient?: BotTelemetryClient;
     timezoneOffset?: number;
+    verbose?: boolean;
 }
 
 // @public

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@azure/cognitiveservices-luis-runtime": "2.0.0",
+    "@azure/cognitiveservices-luis-runtime": "^4.0.0",
     "@azure/ms-rest-js": "^2.7.0",
     "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { LUISRuntimeModels as LuisModels } from '@azure/cognitiveservices-luis-runtime';
+import * as msRest from '@azure/ms-rest-js';
 
 import Url from 'url-parse';
 import { BotTelemetryClient, NullTelemetryClient, RecognizerResult, TurnContext } from 'botbuilder-core';
@@ -41,7 +41,11 @@ export interface LuisApplication {
  *
  * Options per LUIS prediction.
  */
-export interface LuisPredictionOptions extends LuisModels.PredictionResolveOptionalParams {
+export interface LuisPredictionOptions extends msRest.RequestOptionsBase {
+    /**
+     * If true, return all intents instead of just the top scoring intent.
+     */
+    verbose?: boolean;
     /**
      * (Optional) Bing Spell Check subscription key.
      */

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
@@ -8,8 +8,8 @@
 
 import fetch from 'node-fetch';
 import { RequestInfo, RequestInit } from 'node-fetch';
-import { LUISRuntimeModels as LuisModels } from '@azure/cognitiveservices-luis-runtime';
 import { LuisApplication, LuisRecognizerOptionsV3 } from './luisRecognizer';
+import { LuisResult } from './luisV2-models/luisResult';
 import { LuisRecognizerInternal } from './luisRecognizerOptions';
 import { NullTelemetryClient, TurnContext, RecognizerResult } from 'botbuilder-core';
 import { DialogContext } from 'botbuilder-dialogs';
@@ -239,7 +239,7 @@ export class LuisRecognizerV3 extends LuisRecognizerInternal {
 
     private emitTraceInfo(
         context: TurnContext,
-        luisResult: LuisModels.LuisResult,
+        luisResult: LuisResult,
         recognizerResult: RecognizerResult,
         options: LuisRecognizerOptionsV3
     ): Promise<unknown> {

--- a/libraries/botbuilder-ai/src/luisV2-models/luisMappers.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisMappers.ts
@@ -1,0 +1,309 @@
+/**
+ * @module botbuilder-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as msRest from '@azure/ms-rest-js';
+
+export const IntentModel: msRest.CompositeMapper = {
+    serializedName: 'IntentModel',
+    type: {
+        name: 'Composite',
+        className: 'IntentModel',
+        modelProperties: {
+            intent: {
+                serializedName: 'intent',
+                type: {
+                    name: 'String',
+                },
+            },
+            score: {
+                serializedName: 'score',
+                constraints: {
+                    InclusiveMaximum: 1,
+                    InclusiveMinimum: 0,
+                },
+                type: {
+                    name: 'Number',
+                },
+            },
+        },
+    },
+};
+
+export const EntityModel: msRest.CompositeMapper = {
+    serializedName: 'EntityModel',
+    type: {
+        name: 'Composite',
+        className: 'EntityModel',
+        modelProperties: {
+            entity: {
+                required: true,
+                serializedName: 'entity',
+                type: {
+                    name: 'String',
+                },
+            },
+            type: {
+                required: true,
+                serializedName: 'type',
+                type: {
+                    name: 'String',
+                },
+            },
+            startIndex: {
+                required: true,
+                serializedName: 'startIndex',
+                type: {
+                    name: 'Number',
+                },
+            },
+            endIndex: {
+                required: true,
+                serializedName: 'endIndex',
+                type: {
+                    name: 'Number',
+                },
+            },
+        },
+        additionalProperties: {
+            type: {
+                name: 'Object',
+            },
+        },
+    },
+};
+
+export const CompositeChildModel: msRest.CompositeMapper = {
+    serializedName: 'CompositeChildModel',
+    type: {
+        name: 'Composite',
+        className: 'CompositeChildModel',
+        modelProperties: {
+            type: {
+                required: true,
+                serializedName: 'type',
+                type: {
+                    name: 'String',
+                },
+            },
+            value: {
+                required: true,
+                serializedName: 'value',
+                type: {
+                    name: 'String',
+                },
+            },
+        },
+    },
+};
+
+export const CompositeEntityModel: msRest.CompositeMapper = {
+    serializedName: 'CompositeEntityModel',
+    type: {
+        name: 'Composite',
+        className: 'CompositeEntityModel',
+        modelProperties: {
+            parentType: {
+                required: true,
+                serializedName: 'parentType',
+                type: {
+                    name: 'String',
+                },
+            },
+            value: {
+                required: true,
+                serializedName: 'value',
+                type: {
+                    name: 'String',
+                },
+            },
+            children: {
+                required: true,
+                serializedName: 'children',
+                type: {
+                    name: 'Sequence',
+                    element: {
+                        type: {
+                            name: 'Composite',
+                            className: 'CompositeChildModel',
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const Sentiment: msRest.CompositeMapper = {
+    serializedName: 'Sentiment',
+    type: {
+        name: 'Composite',
+        className: 'Sentiment',
+        modelProperties: {
+            label: {
+                serializedName: 'label',
+                type: {
+                    name: 'String',
+                },
+            },
+            score: {
+                serializedName: 'score',
+                type: {
+                    name: 'Number',
+                },
+            },
+        },
+    },
+};
+
+export const LuisResult: msRest.CompositeMapper = {
+    serializedName: 'LuisResult',
+    type: {
+        name: 'Composite',
+        className: 'LuisResult',
+        modelProperties: {
+            query: {
+                serializedName: 'query',
+                type: {
+                    name: 'String',
+                },
+            },
+            alteredQuery: {
+                serializedName: 'alteredQuery',
+                type: {
+                    name: 'String',
+                },
+            },
+            topScoringIntent: {
+                serializedName: 'topScoringIntent',
+                type: {
+                    name: 'Composite',
+                    className: 'IntentModel',
+                },
+            },
+            intents: {
+                serializedName: 'intents',
+                type: {
+                    name: 'Sequence',
+                    element: {
+                        type: {
+                            name: 'Composite',
+                            className: 'IntentModel',
+                        },
+                    },
+                },
+            },
+            entities: {
+                serializedName: 'entities',
+                type: {
+                    name: 'Sequence',
+                    element: {
+                        type: {
+                            name: 'Composite',
+                            className: 'EntityModel',
+                            additionalProperties: {
+                                type: {
+                                    name: 'Object',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            compositeEntities: {
+                serializedName: 'compositeEntities',
+                type: {
+                    name: 'Sequence',
+                    element: {
+                        type: {
+                            name: 'Composite',
+                            className: 'CompositeEntityModel',
+                        },
+                    },
+                },
+            },
+            sentimentAnalysis: {
+                serializedName: 'sentimentAnalysis',
+                type: {
+                    name: 'Composite',
+                    className: 'Sentiment',
+                },
+            },
+            connectedServiceResult: {
+                serializedName: 'connectedServiceResult',
+                type: {
+                    name: 'Composite',
+                    className: 'LuisResult',
+                },
+            },
+        },
+    },
+};
+
+export const EntityWithScore: msRest.CompositeMapper = {
+    serializedName: 'EntityWithScore',
+    type: {
+        name: 'Composite',
+        className: 'EntityWithScore',
+        modelProperties: {
+            ...EntityModel.type.modelProperties,
+            score: {
+                required: true,
+                serializedName: 'score',
+                constraints: {
+                    InclusiveMaximum: 1,
+                    InclusiveMinimum: 0,
+                },
+                type: {
+                    name: 'Number',
+                },
+            },
+        },
+        additionalProperties: EntityModel.type.additionalProperties,
+    },
+};
+
+export const EntityWithResolution: msRest.CompositeMapper = {
+    serializedName: 'EntityWithResolution',
+    type: {
+        name: 'Composite',
+        className: 'EntityWithResolution',
+        modelProperties: {
+            ...EntityModel.type.modelProperties,
+            resolution: {
+                required: true,
+                serializedName: 'resolution',
+                type: {
+                    name: 'Object',
+                },
+            },
+        },
+        additionalProperties: EntityModel.type.additionalProperties,
+    },
+};
+
+export const APIError: msRest.CompositeMapper = {
+    serializedName: 'APIError',
+    type: {
+        name: 'Composite',
+        className: 'APIError',
+        modelProperties: {
+            statusCode: {
+                serializedName: 'statusCode',
+                type: {
+                    name: 'String',
+                },
+            },
+            message: {
+                serializedName: 'message',
+                type: {
+                    name: 'String',
+                },
+            },
+        },
+    },
+};

--- a/libraries/botbuilder-ai/src/luisV2-models/luisParameters.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisParameters.ts
@@ -1,0 +1,86 @@
+/**
+ * @module botbuilder-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as msRest from '@azure/ms-rest-js';
+
+export const appId: msRest.OperationURLParameter = {
+    parameterPath: 'appId',
+    mapper: {
+        required: true,
+        serializedName: 'appId',
+        type: {
+            name: 'String',
+        },
+    },
+};
+export const bingSpellCheckSubscriptionKey: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'bingSpellCheckSubscriptionKey'],
+    mapper: {
+        serializedName: 'bing-spell-check-subscription-key',
+        type: {
+            name: 'String',
+        },
+    },
+};
+export const endpoint: msRest.OperationURLParameter = {
+    parameterPath: 'endpoint',
+    mapper: {
+        required: true,
+        serializedName: 'Endpoint',
+        defaultValue: '',
+        type: {
+            name: 'String',
+        },
+    },
+    skipEncoding: true,
+};
+export const log: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'log'],
+    mapper: {
+        serializedName: 'log',
+        type: {
+            name: 'Boolean',
+        },
+    },
+};
+export const spellCheck: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'spellCheck'],
+    mapper: {
+        serializedName: 'spellCheck',
+        type: {
+            name: 'Boolean',
+        },
+    },
+};
+export const staging: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'staging'],
+    mapper: {
+        serializedName: 'staging',
+        type: {
+            name: 'Boolean',
+        },
+    },
+};
+export const timezoneOffset: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'timezoneOffset'],
+    mapper: {
+        serializedName: 'timezoneOffset',
+        type: {
+            name: 'Number',
+        },
+    },
+};
+export const verbose: msRest.OperationQueryParameter = {
+    parameterPath: ['options', 'verbose'],
+    mapper: {
+        serializedName: 'verbose',
+        type: {
+            name: 'Boolean',
+        },
+    },
+};

--- a/libraries/botbuilder-ai/src/luisV2-models/luisPrediction.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisPrediction.ts
@@ -1,0 +1,121 @@
+/**
+ * @module botbuilder-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as msRest from '@azure/ms-rest-js';
+import { LUISRuntimeClientContext } from '@azure/cognitiveservices-luis-runtime';
+import { LuisResult, PredictionResolveOptionalParams, PredictionResolveResponse } from './luisResult';
+import * as Parameters from './luisParameters';
+import * as Mappers from './luisMappers';
+
+/** Class representing a Prediction. */
+export class LuisPrediction {
+    private readonly client: LUISRuntimeClientContext;
+
+    /**
+     * Create a Prediction.
+     *
+     * @param {LUISRuntimeClientContext} client Reference to the service client.
+     */
+    constructor(client: LUISRuntimeClientContext) {
+        this.client = client;
+    }
+
+    /**
+     * Gets predictions for a given utterance, in the form of intents and entities. The current maximum
+     * query size is 500 characters.
+     *
+     * @param appId The LUIS application ID (Guid).
+     * @param query The utterance to predict.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.PredictionResolveResponse>
+     */
+    resolve(
+        appId: string,
+        query: string,
+        options?: PredictionResolveOptionalParams
+    ): Promise<PredictionResolveResponse>;
+    /**
+     * @param appId The LUIS application ID (Guid).
+     * @param query The utterance to predict.
+     * @param callback The callback
+     */
+    resolve(appId: string, query: string, callback: msRest.ServiceCallback<LuisResult>): void;
+    /**
+     * @param appId The LUIS application ID (Guid).
+     * @param query The utterance to predict.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    resolve(
+        appId: string,
+        query: string,
+        options: PredictionResolveOptionalParams,
+        callback: msRest.ServiceCallback<LuisResult>
+    ): void;
+    /**
+     * @param appId The LUIS application ID (Guid).
+     * @param query The utterance to predict.
+     * @param options The optional parameters.
+     * @param callback The callback.
+     * @returns Promise<Models.PredictionResolveResponse>.
+     */
+    resolve(
+        appId: string,
+        query: string,
+        options?: PredictionResolveOptionalParams | msRest.ServiceCallback<LuisResult>,
+        callback?: msRest.ServiceCallback<LuisResult>
+    ): Promise<PredictionResolveResponse> {
+        return this.client.sendOperationRequest(
+            {
+                appId,
+                query,
+                options,
+            },
+            resolveOperationSpec,
+            callback
+        ) as Promise<PredictionResolveResponse>;
+    }
+}
+
+// Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
+const resolveOperationSpec: msRest.OperationSpec = {
+    httpMethod: 'POST',
+    path: 'apps/{appId}',
+    urlParameters: [Parameters.endpoint, Parameters.appId],
+    queryParameters: [
+        Parameters.timezoneOffset,
+        Parameters.verbose,
+        Parameters.staging,
+        Parameters.spellCheck,
+        Parameters.bingSpellCheckSubscriptionKey,
+        Parameters.log,
+    ],
+    requestBody: {
+        parameterPath: 'query',
+        mapper: {
+            required: true,
+            serializedName: 'query',
+            constraints: {
+                MaxLength: 500,
+            },
+            type: {
+                name: 'String',
+            },
+        },
+    },
+    responses: {
+        200: {
+            bodyMapper: Mappers.LuisResult,
+        },
+        default: {
+            bodyMapper: Mappers.APIError,
+        },
+    },
+    serializer,
+};

--- a/libraries/botbuilder-ai/src/luisV2-models/luisResult.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisResult.ts
@@ -21,6 +21,9 @@ export interface LuisResult {
      * The corrected utterance (when spell checking was enabled).
      */
     alteredQuery?: string;
+    /**
+     * The intent with the higher score.
+     */
     topScoringIntent?: IntentModel;
     /**
      * All the intents (and their score) that were detected from utterance.
@@ -34,7 +37,13 @@ export interface LuisResult {
      * The composite entities extracted from the utterance.
      */
     compositeEntities?: CompositeEntityModel[];
+    /**
+     * Sentiment of the input utterance.
+     */
     sentimentAnalysis?: LuisModels.Sentiment;
+    /**
+     * Prediction, based on the input query, containing intents and entities.
+     */
     connectedServiceResult?: LuisResult;
 }
 

--- a/libraries/botbuilder-ai/src/luisV2-models/luisResult.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisResult.ts
@@ -1,0 +1,161 @@
+/**
+ * @module botbuilder-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { LUISRuntimeModels as LuisModels } from '@azure/cognitiveservices-luis-runtime';
+import * as msRest from '@azure/ms-rest-js';
+
+/**
+ * Prediction, based on the input query, containing intent(s) and entities.
+ */
+export interface LuisResult {
+    /**
+     * The input utterance that was analyzed.
+     */
+    query?: string;
+    /**
+     * The corrected utterance (when spell checking was enabled).
+     */
+    alteredQuery?: string;
+    topScoringIntent?: IntentModel;
+    /**
+     * All the intents (and their score) that were detected from utterance.
+     */
+    intents?: IntentModel[];
+    /**
+     * The entities extracted from the utterance.
+     */
+    entities?: EntityModel[];
+    /**
+     * The composite entities extracted from the utterance.
+     */
+    compositeEntities?: CompositeEntityModel[];
+    sentimentAnalysis?: LuisModels.Sentiment;
+    connectedServiceResult?: LuisResult;
+}
+
+/**
+ * An intent detected from the utterance.
+ */
+export interface IntentModel {
+    /**
+     * Name of the intent, as defined in LUIS.
+     */
+    intent?: string;
+    /**
+     * Associated prediction score for the intent (float).
+     */
+    score?: number;
+}
+
+/**
+ * An entity extracted from the utterance.
+ */
+export interface EntityModel {
+    /**
+     * Name of the entity, as defined in LUIS.
+     */
+    entity: string;
+    /**
+     * Type of the entity, as defined in LUIS.
+     */
+    type: string;
+    /**
+     * The position of the first character of the matched entity within the utterance.
+     */
+    startIndex: number;
+    /**
+     * The position of the last character of the matched entity within the utterance.
+     */
+    endIndex: number;
+    /**
+     * Describes unknown properties. The value of an unknown property can be of "any" type.
+     */
+    [property: string]: any;
+}
+
+/**
+ * LUIS Composite Entity.
+ */
+export interface CompositeEntityModel {
+    /**
+     * Type/name of parent entity.
+     */
+    parentType: string;
+    /**
+     * Value for composite entity extracted by LUIS.
+     */
+    value: string;
+    /**
+     * Child entities.
+     */
+    children: CompositeChildModel[];
+}
+
+/**
+ * Child entity in a LUIS Composite Entity.
+ */
+export interface CompositeChildModel {
+    /**
+     * Type of child entity.
+     */
+    type: string;
+    /**
+     * Value extracted by LUIS.
+     */
+    value: string;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface PredictionResolveOptionalParams extends msRest.RequestOptionsBase {
+    /**
+     * The timezone offset for the location of the request.
+     */
+    timezoneOffset?: number;
+    /**
+     * If true, return all intents instead of just the top scoring intent.
+     */
+    verbose?: boolean;
+    /**
+     * Use the staging endpoint slot.
+     */
+    staging?: boolean;
+    /**
+     * Enable spell checking.
+     */
+    spellCheck?: boolean;
+    /**
+     * The subscription key to use when enabling bing spell check
+     */
+    bingSpellCheckSubscriptionKey?: string;
+    /**
+     * Log query (default is true)
+     */
+    log?: boolean;
+}
+
+/**
+ * Contains response data for the resolve operation.
+ */
+export type PredictionResolveResponse = LuisResult & {
+    /**
+     * The underlying HTTP response.
+     */
+    _response: msRest.HttpResponse & {
+        /**
+         * The response body as text (string format)
+         */
+        bodyAsText: string;
+
+        /**
+         * The response body as parsed JSON or XML
+         */
+        parsedBody: LuisResult;
+    };
+};

--- a/libraries/botbuilder-ai/src/luisV2-models/luisRuntimeClientV2.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisRuntimeClientV2.ts
@@ -1,0 +1,40 @@
+/**
+ * @module botbuilder-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as msRest from '@azure/ms-rest-js';
+import * as Models from './luisResult';
+import * as Mappers from './luisMappers';
+import { LuisPrediction } from './luisPrediction';
+import { LUISRuntimeClientContext } from '@azure/cognitiveservices-luis-runtime';
+
+/**
+ *
+ */
+class LUISRuntimeClientV2 extends LUISRuntimeClientContext {
+    // Operation groups
+    prediction: LuisPrediction;
+
+    /**
+     * Initializes a new instance of the LUISRuntimeClientV2 class.
+     *
+     * @remarks This is a clone of the LUISRuntimeClient in version 2 of the runtime.
+     * @param credentials Subscription credentials which uniquely identify client subscription.
+     * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
+     * https://westus.api.cognitive.microsoft.com).
+     * @param [options] The parameter options
+     */
+    constructor(credentials: msRest.ServiceClientCredentials, endpoint: string, options?: msRest.ServiceClientOptions) {
+        super(credentials, endpoint, options);
+        this.prediction = new LuisPrediction(this);
+        super.baseUri = '{Endpoint}/luis/v2.0';
+    }
+}
+
+// Operation Specifications
+
+export { LUISRuntimeClientV2, Models as LUISRuntimeModels, Mappers as LUISRuntimeMappers };

--- a/libraries/botbuilder-ai/src/luisV2-models/luisRuntimeClientV2.ts
+++ b/libraries/botbuilder-ai/src/luisV2-models/luisRuntimeClientV2.ts
@@ -13,7 +13,9 @@ import { LuisPrediction } from './luisPrediction';
 import { LUISRuntimeClientContext } from '@azure/cognitiveservices-luis-runtime';
 
 /**
+ * Represents the LUIS client for V2 of the runtime.
  *
+ * @remarks This is a clone of the LUISRuntimeClient in version 2 of the runtime.
  */
 class LUISRuntimeClientV2 extends LUISRuntimeClientContext {
     // Operation groups
@@ -22,7 +24,6 @@ class LUISRuntimeClientV2 extends LUISRuntimeClientContext {
     /**
      * Initializes a new instance of the LUISRuntimeClientV2 class.
      *
-     * @remarks This is a clone of the LUISRuntimeClient in version 2 of the runtime.
      * @param credentials Subscription credentials which uniquely identify client subscription.
      * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
      * https://westus.api.cognitive.microsoft.com).

--- a/libraries/botbuilder-ai/tests/luisSdk.test.js
+++ b/libraries/botbuilder-ai/tests/luisSdk.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const fs = require('fs-extra');
 const nock = require('nock');
-const { LUISRuntimeClient } = require('@azure/cognitiveservices-luis-runtime');
+const { LUISRuntimeClientV2 } = require('../lib/luisV2-models/luisRuntimeClientV2');
 const msRest = require('@azure/ms-rest-js');
 
 const applicationId = '00000000-0000-0000-0000-000000000000';
@@ -78,7 +78,7 @@ async function TestJson(file, includeAllIntents = true, includeInstance = true) 
 
     const newPath = expectedPath + '.new';
 
-    const client = new LUISRuntimeClient(creds, baseUrl);
+    const client = new LUISRuntimeClientV2(creds, baseUrl);
     const result = await client.prediction.resolve(applicationId, expected.query, {
         includeAllIntents: includeAllIntents,
         includeInstance: includeInstance,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "json-schema": "0.4.0",
     "jsonwebtoken": "9.0.0",
     "@xmldom/xmldom": "0.8.6",
-    "**/botbuilder-ai/@azure/cognitiveservices-luis-runtime/@azure/ms-rest-js": "^2.7.0",
     "**/botbuilder-azure/@azure/core-auth/@azure/core-tracing": "1.0.0-preview.9",
     "**/request/tough-cookie": "^4.1.3",
     "**/request-promise/tough-cookie": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,13 @@
   dependencies:
     tslib "^1.9.3"
 
-"@azure/cognitiveservices-luis-runtime@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-2.0.0.tgz#97686f2897ee2e3c2f8d6ba1aed6b98757a10b98"
-  integrity sha512-NZuqxiwpn8iYM76/QDIBDGq1jJ+YHiwS0S/yprAMeaaQgu1S5VtVhWDbTrZl+AfaqCn6iDpRewI7EKRv1GJx0g==
+"@azure/cognitiveservices-luis-runtime@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-4.0.1.tgz#7c49b0a98af2b3d1c76e2fee64b1270769de1b25"
+  integrity sha512-W5oDt1LvJQmtxCIDq1aFh8R4W+5ZKSTC+9So9DIGVZmy29SMxBNyTf8OTliHDv0L+P6Y2XBySoGCliPYfTyrhQ==
   dependencies:
-    "@azure/ms-rest-js" "^1.6.0"
-    tslib "^1.9.3"
+    "@azure/ms-rest-js" "^2.0.3"
+    tslib "^1.10.0"
 
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.0"
@@ -209,7 +209,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@azure/ms-rest-js@^1.6.0", "@azure/ms-rest-js@^2.7.0":
+"@azure/ms-rest-js@^2.0.3", "@azure/ms-rest-js@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz#8639065577ffdf4946951e1d246334ebfd72d537"
   integrity sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==


### PR DESCRIPTION
Fixes # 4509
#minor

## Description
This PR upgrades `@azure/cognitiveservices-luis-runtime` to v.4.0.0 in `botbuilder-ai` to avoid the use of the _tough-cookie_ package due to its [vulnerability issue](https://github.com/advisories/GHSA-72xf-g2v4-qvf3).
As version 4.0.0 introduced several breaking changes, we added the `luisV2-models` folder with the interfaces and classes that are required for the v2 runtime to work.

## Specific Changes
  - Upgrades `@azure/cognitiveservices-luis-runtime` package from version 2.0.0 to version 4.0.0
  - Created the folder `luisV2-models` containing the following interfaces and classes missing in the new version of the package:
     - LuisResult
     - LuisMappers
     - LuisParameters
     - LuisPrediction
     - LUISRuntimeClientV2
  - Updated `luisSdk.test.js` unit tests to work with the new `LUISRuntimeClientV2`.

## Testing
This image shows the unit tests passing after the upgrade.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/e416ecc4-be7d-4ca4-83ea-9ef91229c747)
