### PR TITLE
fix: [#4520] Upgrade restify to fix error on Node version 18+

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.ts
@@ -14,7 +14,7 @@ import { INodeSocket } from 'botframework-streaming';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { 
+import {
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
     ConversationState,

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0",
-        "botbuilder-ai": "~4.15.0",
-        "botbuilder-dialogs": "~4.15.0",
-        "botbuilder-testing": "~4.15.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
+        "botbuilder-testing": "~4.20.0",
         "dotenv": "^8.2.0",
         "restify": "^11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -22,7 +22,7 @@
         "botbuilder-dialogs": "~4.15.0",
         "botbuilder-testing": "~4.15.0",
         "dotenv": "^8.2.0",
-        "restify": "^8.5.1"
+        "restify": "^11.1.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -44,7 +44,7 @@
       "botbuilder-testing": "~4.15.0",
       "dotenv": "^8.2.0",
       "replace": "~1.2.0",
-      "restify": "~8.5.1"
+      "restify": "~11.1.0"
 },
   "devDependencies": {
       "@types/mocha": "^7.0.2",

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -38,10 +38,10 @@
     },
     "dependencies": {
       "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-      "botbuilder": "~4.15.0",
-      "botbuilder-ai": "~4.15.0",
-      "botbuilder-dialogs": "~4.15.0",
-      "botbuilder-testing": "~4.15.0",
+      "botbuilder": "~4.20.0",
+      "botbuilder-ai": "~4.20.0",
+      "botbuilder-dialogs": "~4.20.0",
+      "botbuilder-testing": "~4.20.0",
       "dotenv": "^8.2.0",
       "replace": "~1.2.0",
       "restify": "~11.1.0"

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -21,7 +21,7 @@
         "botbuilder-ai": "~4.15.0",
         "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0",
-        "botbuilder-ai": "~4.15.0",
-        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "~8.2.0",
         "restify": "~11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -24,7 +24,7 @@
         "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
-        "restify": "~8.5.1"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.2",

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -19,9 +19,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0",
-        "botbuilder-ai": "~4.15.0",
-        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "~8.2.0",
         "restify": "~11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -21,7 +21,7 @@
         "botbuilder": "~4.15.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
-        "restify": "~8.5.1"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/generators/generator-botbuilder/generators/app/templates/echo/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/echo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "botbuilder": "~4.15.0",
-        "restify": "~10.0.0"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0",
+        "botbuilder": "~4.20.0",
         "restify": "~11.1.0"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -20,7 +20,7 @@
     "dependencies": {
         "botbuilder": "~4.15.0",
         "replace": "~1.2.0",
-        "restify": "~8.5.1"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0",
+        "botbuilder": "~4.20.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/empty/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/empty/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -150,7 +150,7 @@ describe('CloudAdapter', function () {
             await adapter.process(req, res, logic);
 
             assert.equal(StatusCodes.UNAUTHORIZED, res.statusCode);
-            expect(consoleSpy.calledWithMatch({ message: 'jwt expired' })).to.be.true;
+            expect(consoleSpy.calledWithMatch({ message: 'The token has expired' })).to.be.true;
         });
     });
 


### PR DESCRIPTION
Fixes # 4520
#minor

## Description
This PR upgrades the **_restify_** dependency to version _11.1.0_ to avoid the error on Node 18+.
It also updates the target in TS bots, as the new version of _restify_ introduced a [breaking change](https://github.com/restify/node-restify/issues/1935).
Additionally, it upgrades **_botbuilder_** packages to version _4.20.0_ and fixes an eslint issue in the core bot's index.ts.

## Specific Changes
  - Updated remaining TS and JS bots to use `restify` version _11.1.0_.
  - Upgraded `botbuilder` packages to version _4.20.0_.
  - Updated the `tsconfig.json`'s _target_ property to _es2017_.
  - Fixed a lint issue in `templates/core/index.ts`.

## Testing
These images show the generated bots working and the tests in _core-with-tests_ passing.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/6b61d3b8-249e-4052-8c0d-87aec9aeaff9)

![image](https://github.com/southworks/botbuilder-js/assets/44245136/b695d8ea-6df7-4034-9d64-21efd10d43d5)
