### PR TITLE
port: [#6685][#4529] Update JwtTokenExtractor

### DIFF
--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -101,11 +101,11 @@ describe('CloudAdapter', function () {
         });
 
         it('throws exception on expired token', async function () {
-            const consoleSpy = sinon.spy(console, 'error');
+            const consoleStub = sinon.stub(console, 'error');
 
             // Expired token with removed AppID
             const authorization =
-                'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjJaUXBKM1VwYmpBWVhZR2FYRUpsOGxWMFRPSSIsImtpZCI6IjJaUXBKM1VwYmpBWVhZR2FYRUpsOGxWMFRPSSJ9.eyJhdWQiOiJodHRwczovL2FwaS5ib3RmcmFtZXdvcmsuY29tIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiLyIsImlhdCI6MTY3MDM1MDQxNSwibmJmIjoxNjcwMzUwNDE1LCJleHAiOjE2NzA0MzcxMTUsImFpbyI6IkUyWmdZTkJONEpWZmxlOTJUc2wxYjhtOHBjOWpBQT09IiwiYXBwaWQiOiI5ZGRmM2QwZS02ZDRlLTQ2MWEtYjM4Yi0zMTYzZWQ3Yjg1NmIiLCJhcHBpZGFjciI6IjEiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwicmgiOiIwLkFXNEFJSlRVMXB2ejkwMmgzTldhazFoeDIwSXpMWTBwejFsSmxYY09EcS05RnJ4dUFBQS4iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJIWDlncld2bU1rMlhESTRkS3BHSEFBIiwidmVyIjoiMS4wIn0.PBLuja5sCcDfFjweoy-VucvbfHEyEcs1GyqXjekzBqgvK-mSc1UrEfqr5834qY6dLNsXVIMJzMFuH6WyPbnAfIfRcabdiVSOAl8N8e9Tex6vHfPi4h4P2F96VkXU80EtZX4QMjsJMDJ5eXbJlIDEAxXoJbAdHqgy-lHcVBx8XK7toJ_W7vSsFhis3C4CPCHI1cf1WuHVwfFXBiNwsOzj9cnRUKpea6UELV89q4C0L6aeSNdWYXehZmgq-wlo2wIaGgQ7rOXx4MlIrc83LBzMMc6TWvBJecK6O8pJWLe6BTwOltBI8Tmo2hWnY1OnsbOhbSSlfwLaZqKI7QpA50_2GQ';
+                'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyIsImtpZCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyJ9.eyJhdWQiOiJodHRwczovL2FwaS5ib3RmcmFtZXdvcmsuY29tIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiLyIsImlhdCI6MTY5Mjg3MDMwMiwibmJmIjoxNjkyODcwMzAyLCJleHAiOjE2OTI5NTcwMDIsImFpbyI6IkUyRmdZUGhhdFZ6czVydGFFYTlWbDN2ZnIyQ2JBZ0E9IiwiYXBwaWQiOiIxNWYwMTZmZS00ODhjLTQwZTktOWNiZS00Yjk0OGY5OGUyMmMiLCJhcHBpZGFjciI6IjEiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwicmgiOiIwLkFXNEFJSlRVMXB2ejkwMmgzTldhazFoeDIwSXpMWTBwejFsSmxYY09EcS05RnJ4dUFBQS4iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJkenVwa1dWd2FVT2x1RldkbnlvLUFBIiwidmVyIjoiMS4wIn0.sbQH997Q2GDKiiYd6l5MIz_XNfXypJd6zLY9xjtvEgXMBB0x0Vu3fv9W0nM57_ZipQiZDTZuSQA5BE30KBBwU-ZVqQ7MgiTkmE9eF6Ngie_5HwSr9xMK3EiDghHiOP9pIj3oEwGOSyjR5L9n-7tLSdUbKVyV14nS8OQtoPd1LZfoZI3e7tVu3vx8Lx3KzudanXX8Vz7RKaYndj3RyRi4wEN5hV9ab40d7fQsUzygFd5n_PXC2rs0OhjZJzjCOTC0VLQEn1KwiTkSH1E-OSzkrMltn1sbhD2tv_H-4rqQd51vAEJ7esC76qQjz_pfDRLs6T2jvJyhd5MZrN_MT0TqlA';
 
             const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
 
@@ -150,7 +150,8 @@ describe('CloudAdapter', function () {
             await adapter.process(req, res, logic);
 
             assert.equal(StatusCodes.UNAUTHORIZED, res.statusCode);
-            expect(consoleSpy.calledWithMatch({ message: 'jwt expired' })).to.be.true;
+            expect(consoleStub.calledWithMatch({ message: 'The token has expired' })).to.be.true;
+            consoleStub.restore();
         });
     });
 

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -101,7 +101,7 @@ describe('CloudAdapter', function () {
         });
 
         it('throws exception on expired token', async function () {
-            const consoleStub = sinon.stub(console, 'error');
+            const consoleStub = sandbox.stub(console, 'error');
 
             // Expired token with removed AppID
             const authorization =
@@ -151,7 +151,6 @@ describe('CloudAdapter', function () {
 
             assert.equal(StatusCodes.UNAUTHORIZED, res.statusCode);
             expect(consoleStub.calledWithMatch({ message: 'The token has expired' })).to.be.true;
-            consoleStub.restore();
         });
     });
 


### PR DESCRIPTION
#minor

## Description
This PR updates the _throws exception on expired token_ test to avoid the throwing of an exception.
Because the implementation of token handling between [_botbuilder-dotnet_](https://github.com/microsoft/botbuilder-dotnet/blob/501ddca1e6af1bb74bdd370afd26ddebf26d2b95/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs#L229) and [_botbuilder-js_](https://github.com/microsoft/botbuilder-js/blob/81e2d98d4bfe503ad10f9445b80c5b3c4b87f5e6/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts#L132) is different, we made no changes since botbuilder-js uses a cache check as a security method for the token key. It also does not use two entities to handle the token, it only uses the decoded token.

## Specific Changes
  - Updated authorization token in  _throws exception on expired token_ test.
  - Replaced the use of sinon.spy by sinon.stub in  _throws exception on expired token_ test in _**cloudAdapter.test**_.

## Testing
The following image shows the unit test throws exception on expired token passing without throw an error.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/4b70738d-340b-44f8-838c-5e961ad926f3)
