### PR TITLE
fix: remove read-text-file package

### DIFF
--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.1",
-    "read-text-file": "^1.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -5,9 +5,9 @@
  * Licensed under the MIT License.
  */
 import * as fsx from 'fs-extra';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as process from 'process';
-import * as txtfile from 'read-text-file';
 import { v4 as uuidv4 } from 'uuid';
 import { BotConfigurationBase } from './botConfigurationBase';
 import * as encrypt from './encrypt';
@@ -106,7 +106,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @returns A Promise with the new BotConfiguration instance.
      */
     static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
-        const json: string = await txtfile.read(botpath);
+        const json: string = fs.readFileSync(botpath, "utf8")
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
 
@@ -121,7 +121,7 @@ export class BotConfiguration extends BotConfigurationBase {
      * @returns A new BotConfiguration instance.
      */
     static loadSync(botpath: string, secret?: string): BotConfiguration {
-        const json: string = txtfile.readSync(botpath);
+        const json: string = fs.readFileSync(botpath, "utf8")
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
 

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -106,7 +106,8 @@ export class BotConfiguration extends BotConfigurationBase {
      * @returns A Promise with the new BotConfiguration instance.
      */
     static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
-        const json: string = fs.readFileSync(botpath, "utf8")
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        const json: string = fs.readFileSync(botpath, 'utf8');
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
 
@@ -121,7 +122,8 @@ export class BotConfiguration extends BotConfigurationBase {
      * @returns A new BotConfiguration instance.
      */
     static loadSync(botpath: string, secret?: string): BotConfiguration {
-        const json: string = fs.readFileSync(botpath, "utf8")
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        const json: string = fs.readFileSync(botpath, 'utf8');
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
 

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -107,7 +107,7 @@ export class BotConfiguration extends BotConfigurationBase {
      */
     static async load(botpath: string, secret?: string): Promise<BotConfiguration> {
         // eslint-disable-next-line security/detect-non-literal-fs-filename
-        const json: string = fs.readFileSync(botpath, 'utf8');
+        const json: string = await fs.promises.readFile(botpath, 'utf8');
         const bot: BotConfiguration = BotConfiguration.internalLoad(json, secret);
         bot.internal.location = botpath;
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
-    "read-text-file": "^1.1.0",
     "replace-in-file": "^4.1.0",
     "rimraf": "^3.0.2",
     "shx": "^0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7380,7 +7380,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8147,11 +8147,6 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-
-jschardet@^1.4.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
-  integrity sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==
 
 jsdoctypeparser@^9.0.0:
   version "9.0.0"
@@ -10994,14 +10989,6 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
-
-read-text-file@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-text-file/-/read-text-file-1.1.0.tgz#d0c3f18768828f9107d61bb0b368ee7b90f71893"
-  integrity sha1-0MPxh2iCj5EH1huws2jue5D3GJM=
-  dependencies:
-    iconv-lite "^0.4.17"
-    jschardet "^1.4.2"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"


### PR DESCRIPTION
#minor

## Description
This PR removes _read-text-file_ to avoid the use of LGPL.

## Specific Changes
  - Replaced _txtfile.read_ function by _fs.readFileSync_ in _**BotConfiguration**_ class.
  - Removed _read-text-file_ from the packages.json files.


## Testing
The following image shows the _botframework-config_ tests, which use _**BotConfiguration**_ class, running successfully.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/9caae7f1-3674-497c-8d06-010ad3b616c9)
