### PR TITLE
fix: [#4470] Migrate off @azure/ms-rest-js bf-connector

### DIFF
--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -1081,7 +1081,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.sendMeetingNotification(context, notification, meetingId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.body);
+                assert.deepEqual(errorResponse, e.details);
                 isErrorThrown = true;
             }
 
@@ -1214,7 +1214,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.sendMessageToListOfUsers(context, activity, tenantId, members);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1307,7 +1307,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.sendMessageToAllUsersInTenant(context, activity, tenantId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1395,7 +1395,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.sendMessageToAllUsersInTeam(context, activity, tenantId, teamId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1502,7 +1502,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.sendMessageToListOfChannels(context, activity, tenantId, members);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1579,7 +1579,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.getOperationState(context, operationId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1648,7 +1648,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.getFailedEntries(context, operationId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 
@@ -1697,7 +1697,7 @@ describe('TeamsInfo', function () {
             try {
                 await TeamsInfo.cancelOperation(context, operationId);
             } catch (e) {
-                assert.deepEqual(errorResponse, e.errors[0].body);
+                assert.deepEqual(errorResponse, e.errors[0].details);
                 isErrorThrown = true;
             }
 

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -27,6 +27,7 @@
     }
   },
   "dependencies": {
+    "@azure/core-http": "^3.0.2",
     "@azure/identity": "^2.0.4",
     "@azure/msal-node": "^1.2.0",
     "axios": "^0.25.0",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@azure/identity": "^2.0.4",
-    "@azure/ms-rest-js": "^2.7.0",
     "@azure/msal-node": "^1.2.0",
     "axios": "^0.25.0",
     "base64url": "^3.0.0",

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -6,8 +6,10 @@
  * Licensed under the MIT License.
  */
 
-import * as msrest from '@azure/ms-rest-js';
 import { ConfidentialClientApplication } from '@azure/msal-node';
+import { ServiceClientCredentials, WebResource } from "@azure/core-http";
+import {TokenCredentials} from "./tokenCredentials"
+import * as adal from 'adal-node';
 import { AuthenticationConstants } from './authenticationConstants';
 import { AuthenticatorResult } from './authenticatorResult';
 
@@ -15,7 +17,7 @@ import { AuthenticatorResult } from './authenticatorResult';
  * General AppCredentials auth implementation and cache.
  * Subclasses can implement refreshToken to acquire the token.
  */
-export abstract class AppCredentials implements msrest.ServiceClientCredentials {
+export abstract class AppCredentials implements ServiceClientCredentials {
     private static readonly cache: Map<string, AuthenticatorResult> = new Map<string, AuthenticatorResult>();
 
     appId: string;
@@ -148,9 +150,9 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param webResource The WebResource HTTP request.
      * @returns A Promise representing the asynchronous operation.
      */
-    async signRequest(webResource: msrest.WebResource): Promise<msrest.WebResource> {
+    async signRequest(webResource: WebResource): Promise<WebResource> {
         if (this.shouldSetToken()) {
-            return new msrest.TokenCredentials(await this.getToken()).signRequest(webResource);
+            return new TokenCredentials(await this.getToken()).signRequest(webResource);
         }
 
         return webResource;

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -7,9 +7,8 @@
  */
 
 import { ConfidentialClientApplication } from '@azure/msal-node';
-import { ServiceClientCredentials, WebResource } from "@azure/core-http";
-import {TokenCredentials} from "./tokenCredentials"
-import * as adal from 'adal-node';
+import { ServiceClientCredentials, WebResource } from '@azure/core-http';
+import { TokenCredentials } from './tokenCredentials';
 import { AuthenticationConstants } from './authenticationConstants';
 import { AuthenticatorResult } from './authenticatorResult';
 

--- a/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
@@ -8,7 +8,7 @@ import { BotFrameworkClient } from '../skills';
 import { ConversationIdHttpHeaderName } from '../conversationConstants';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { USER_AGENT } from './connectorFactoryImpl';
-import { WebResource } from '@azure/ms-rest-js';
+import { WebResource } from '@azure/core-http';
 import { ok } from 'assert';
 
 const botFrameworkClientFetchImpl: typeof fetch = async (input, init) => {

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ServiceClientCredentials } from '@azure/ms-rest-js';
+import type { ServiceClientCredentials } from '@azure/core-http';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { ok } from 'assert';
 import { CertificateAppCredentials } from './certificateAppCredentials';

--- a/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
+++ b/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getDefaultUserAgentValue, RequestPolicyFactory, userAgentPolicy } from '@azure/ms-rest-js';
+import { getDefaultUserAgentValue, RequestPolicyFactory, userAgentPolicy } from '@azure/core-http';
 import { ConnectorClient } from '../connectorApi/connectorClient';
 import { ConnectorClientOptions } from '../connectorApi/models';
 import { ConnectorFactory } from './connectorFactory';
@@ -9,9 +9,8 @@ import type { ServiceClientCredentialsFactory } from './serviceClientCredentials
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageInfo: Record<'name' | 'version', string> = require('../../package.json');
-export const USER_AGENT = `Microsoft-BotFramework/3.1 ${packageInfo.name}/${
-    packageInfo.version
-} ${getDefaultUserAgentValue()} `;
+export const USER_AGENT = `Microsoft-BotFramework/3.1 ${packageInfo.name}/${packageInfo.version
+    } ${getDefaultUserAgentValue()} `;
 
 /**
  * @internal

--- a/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
+++ b/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
@@ -9,8 +9,9 @@ import type { ServiceClientCredentialsFactory } from './serviceClientCredentials
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageInfo: Record<'name' | 'version', string> = require('../../package.json');
-export const USER_AGENT = `Microsoft-BotFramework/3.1 ${packageInfo.name}/${packageInfo.version
-    } ${getDefaultUserAgentValue()} `;
+export const USER_AGENT = `Microsoft-BotFramework/3.1 ${packageInfo.name}/${
+    packageInfo.version
+} ${getDefaultUserAgentValue()} `;
 
 /**
  * @internal

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -39,3 +39,4 @@ export * from './userTokenClient';
 
 export { MsalAppCredentials } from './msalAppCredentials';
 export { MsalServiceClientCredentialsFactory } from './msalServiceClientCredentialsFactory';
+export { TokenCredentials } from './tokenCredentials';

--- a/libraries/botframework-connector/src/auth/managedIdentityServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/managedIdentityServiceClientCredentialsFactory.ts
@@ -7,7 +7,7 @@
  */
 
 import type { IJwtTokenProviderFactory } from './jwtTokenProviderFactory';
-import type { ServiceClientCredentials } from '@azure/ms-rest-js';
+import type { ServiceClientCredentials } from '@azure/core-http';
 import { ManagedIdentityAppCredentials } from './managedIdentityAppCredentials';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { ok } from 'assert';

--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -6,7 +6,7 @@
 
 import { ConfidentialClientApplication } from '@azure/msal-node';
 import { MsalAppCredentials } from './msalAppCredentials';
-import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentials } from '@azure/core-http';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { AuthenticationConstants } from './authenticationConstants';
 import { GovernmentConstants } from './governmentConstants';

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -4,7 +4,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { ServiceClientCredentials } from '@azure/ms-rest-js';
+import type { ServiceClientCredentials } from '@azure/core-http';
 import { AuthenticationConstants } from './authenticationConstants';
 import { GovernmentConstants } from './governmentConstants';
 import { MicrosoftAppCredentials } from './microsoftAppCredentials';

--- a/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentials } from '@azure/core-http';
 
 // Export underlying type for convenience
 export { ServiceClientCredentials };

--- a/libraries/botframework-connector/src/auth/tokenCredentials.ts
+++ b/libraries/botframework-connector/src/auth/tokenCredentials.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { HttpHeaders, Constants, WebResourceLike, ServiceClientCredentials } from "@azure/core-http";
+
+const HeaderConstants = Constants.HeaderConstants;
+const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
+
+/**
+ * A credentials object that uses a token string and a authorzation scheme to authenticate.
+ */
+export class TokenCredentials implements ServiceClientCredentials {
+  token: string;
+  authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME;
+
+  /**
+   * Creates a new TokenCredentials object.
+   *
+   * @constructor
+   * @param {string} token The token.
+   * @param {string} [authorizationScheme] The authorization scheme.
+   */
+  constructor(token: string, authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME) {
+    if (!token) {
+      throw new Error("token cannot be null or undefined.");
+    }
+    this.token = token;
+    this.authorizationScheme = authorizationScheme;
+  }
+
+  /**
+   * Signs a request with the Authentication header.
+   *
+   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+   * @return {Promise<WebResourceLike>} The signed request object.
+   */
+  signRequest(webResource: WebResourceLike) {
+    if (!webResource.headers) webResource.headers = new HttpHeaders();
+    webResource.headers.set(
+      HeaderConstants.AUTHORIZATION,
+      `${this.authorizationScheme} ${this.token}`
+    );
+    return Promise.resolve(webResource);
+  }
+}

--- a/libraries/botframework-connector/src/auth/tokenCredentials.ts
+++ b/libraries/botframework-connector/src/auth/tokenCredentials.ts
@@ -1,45 +1,42 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpHeaders, Constants, WebResourceLike, ServiceClientCredentials } from "@azure/core-http";
+import { HttpHeaders, Constants, WebResourceLike, ServiceClientCredentials } from '@azure/core-http';
 
 const HeaderConstants = Constants.HeaderConstants;
-const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
+const DEFAULT_AUTHORIZATION_SCHEME = 'Bearer';
 
 /**
  * A credentials object that uses a token string and a authorzation scheme to authenticate.
  */
 export class TokenCredentials implements ServiceClientCredentials {
-  token: string;
-  authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME;
+    token: string;
+    authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME;
 
-  /**
-   * Creates a new TokenCredentials object.
-   *
-   * @constructor
-   * @param {string} token The token.
-   * @param {string} [authorizationScheme] The authorization scheme.
-   */
-  constructor(token: string, authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME) {
-    if (!token) {
-      throw new Error("token cannot be null or undefined.");
+    /**
+     * Creates a new TokenCredentials object.
+     *
+     * @class
+     * @param {string} token The token.
+     * @param {string} [authorizationScheme] The authorization scheme.
+     */
+    constructor(token: string, authorizationScheme: string = DEFAULT_AUTHORIZATION_SCHEME) {
+        if (!token) {
+            throw new Error('token cannot be null or undefined.');
+        }
+        this.token = token;
+        this.authorizationScheme = authorizationScheme;
     }
-    this.token = token;
-    this.authorizationScheme = authorizationScheme;
-  }
 
-  /**
-   * Signs a request with the Authentication header.
-   *
-   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
-   * @return {Promise<WebResourceLike>} The signed request object.
-   */
-  signRequest(webResource: WebResourceLike) {
-    if (!webResource.headers) webResource.headers = new HttpHeaders();
-    webResource.headers.set(
-      HeaderConstants.AUTHORIZATION,
-      `${this.authorizationScheme} ${this.token}`
-    );
-    return Promise.resolve(webResource);
-  }
+    /**
+     * Signs a request with the Authentication header.
+     *
+     * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+     * @returns {Promise<WebResourceLike>} The signed request object.
+     */
+    signRequest(webResource: WebResourceLike) {
+        if (!webResource.headers) webResource.headers = new HttpHeaders();
+        webResource.headers.set(HeaderConstants.AUTHORIZATION, `${this.authorizationScheme} ${this.token}`);
+        return Promise.resolve(webResource);
+    }
 }

--- a/libraries/botframework-connector/src/auth/userTokenClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/userTokenClientImpl.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as z from 'zod';
-import type { ServiceClientCredentials } from '@azure/ms-rest-js';
+import type { ServiceClientCredentials } from '@azure/core-http';
 import { Activity, SignInUrlResponse, TokenExchangeRequest, TokenResponse, TokenStatus } from 'botframework-schema';
 import { ConnectorClientOptions } from '../connectorApi/models';
 import { TokenApiClient } from '../tokenApi/tokenApiClient';

--- a/libraries/botframework-connector/src/connectorApi/connectorClient.ts
+++ b/libraries/botframework-connector/src/connectorApi/connectorClient.ts
@@ -5,7 +5,7 @@
 
 import * as Mappers from './models/mappers';
 import * as Models from './models';
-import * as msRest from '@azure/ms-rest-js';
+import { ServiceClientCredentials } from "@azure/core-http"
 import * as operations from './operations';
 import { ConnectorClientContext } from './connectorClientContext';
 
@@ -20,7 +20,7 @@ class ConnectorClient extends ConnectorClientContext {
      * @param credentials Subscription credentials which uniquely identify client subscription.
      * @param [options] The parameter options
      */
-    constructor(credentials: msRest.ServiceClientCredentials, options?: Models.ConnectorClientOptions) {
+    constructor(credentials: ServiceClientCredentials, options?: Models.ConnectorClientOptions) {
         super(credentials, options);
         this.attachments = new operations.Attachments(this);
         this.conversations = new operations.Conversations(this);

--- a/libraries/botframework-connector/src/connectorApi/connectorClientContext.ts
+++ b/libraries/botframework-connector/src/connectorApi/connectorClientContext.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceClient, ServiceClientCredentials, getDefaultUserAgentValue } from "@azure/core-http";
 import * as Models from "./models";
 
 const packageName = "botframework-connector";
 const packageVersion = "4.0.0";
 
-export class ConnectorClientContext extends msRest.ServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ConnectorClientContext extends ServiceClient {
+  credentials: ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the ConnectorClientContext class.
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.ConnectorClientOptions) {
+  constructor(credentials: ServiceClientCredentials, options?: Models.ConnectorClientOptions) {
     if (credentials === null || credentials === undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -27,7 +27,7 @@ export class ConnectorClientContext extends msRest.ServiceClient {
       options = {} as Models.ConnectorClientOptions;
     }
     // TODO  This is to workaround fact that AddUserAgent() was removed.  
-    const defaultUserAgent = msRest.getDefaultUserAgentValue();
+    const defaultUserAgent = getDefaultUserAgentValue();
     options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent} ${options.userAgent || ''}`;
 
     super(credentials, options);

--- a/libraries/botframework-connector/src/connectorApi/models/index.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/index.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import { ServiceClientOptions } from "@azure/ms-rest-js";
+
+import { ServiceClientOptions, RequestOptionsBase, HttpResponse } from "@azure/core-http";
 import { AttachmentInfo, ChannelAccount, ConversationResourceResponse, ConversationsResult, PagedMembersResult, ResourceResponse } from "botframework-schema";
 export * from "botframework-schema";
 
@@ -22,7 +22,7 @@ export interface ConnectorClientOptions extends ServiceClientOptions {
 /**
  * Optional Parameters.
  */
-export interface ConversationsGetConversationsOptionalParams extends msRest.RequestOptionsBase {
+export interface ConversationsGetConversationsOptionalParams extends RequestOptionsBase {
   /**
    * skip or continuation token
    */
@@ -32,7 +32,7 @@ export interface ConversationsGetConversationsOptionalParams extends msRest.Requ
 /**
  * Optional Parameters.
  */
-export interface ConversationsGetConversationPagedMembersOptionalParams extends msRest.RequestOptionsBase {
+export interface ConversationsGetConversationPagedMembersOptionalParams extends RequestOptionsBase {
   /**
    * Suggested page size
    */
@@ -50,7 +50,7 @@ export type AttachmentsGetAttachmentInfoResponse = AttachmentInfo & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -86,7 +86,7 @@ export type AttachmentsGetAttachmentResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse;
+  _response: HttpResponse;
 };
 
 /**
@@ -96,7 +96,7 @@ export type ConversationsGetConversationsResponse = ConversationsResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -116,7 +116,7 @@ export type ConversationsCreateConversationResponse = ConversationResourceRespon
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -136,7 +136,7 @@ export type ConversationsSendToConversationResponse = ResourceResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -156,7 +156,7 @@ export type ConversationsSendConversationHistoryResponse = ResourceResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -176,7 +176,7 @@ export type ConversationsUpdateActivityResponse = ResourceResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -196,7 +196,7 @@ export type ConversationsReplyToActivityResponse = ResourceResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -216,7 +216,7 @@ export type ConversationsGetConversationMembersResponse = Array<ChannelAccount> 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -233,21 +233,21 @@ export type ConversationsGetConversationMembersResponse = Array<ChannelAccount> 
  * Contains response data for the getConversationMember operation.
  */
 export type ConversationsGetConversationMemberResponse = ChannelAccount & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: HttpResponse & {
     /**
-     * The underlying HTTP response.
+     * The response body as text (string format)
      */
-    _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
+    bodyAsText: string;
 
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ChannelAccount;
-    };
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ChannelAccount;
   };
+};
 
 /**
  * Contains response data for the getConversationPagedMembers operation.
@@ -256,7 +256,7 @@ export type ConversationsGetConversationPagedMembersResponse = PagedMembersResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -276,7 +276,7 @@ export type ConversationsGetActivityMembersResponse = Array<ChannelAccount> & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */
@@ -296,7 +296,7 @@ export type ConversationsUploadAttachmentResponse = ResourceResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: HttpResponse & {
     /**
      * The response body as text (string format)
      */

--- a/libraries/botframework-connector/src/connectorApi/models/mappers.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/mappers.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { CompositeMapper } from "@azure/core-http"
 
-
-export const AttachmentView: msRest.CompositeMapper = {
+export const AttachmentView: CompositeMapper = {
   serializedName: "AttachmentView",
   type: {
     name: "Composite",
@@ -28,7 +27,7 @@ export const AttachmentView: msRest.CompositeMapper = {
   }
 };
 
-export const AttachmentInfo: msRest.CompositeMapper = {
+export const AttachmentInfo: CompositeMapper = {
   serializedName: "AttachmentInfo",
   type: {
     name: "Composite",
@@ -62,7 +61,7 @@ export const AttachmentInfo: msRest.CompositeMapper = {
   }
 };
 
-export const InnerHttpError: msRest.CompositeMapper = {
+export const InnerHttpError: CompositeMapper = {
   serializedName: "InnerHttpError",
   type: {
     name: "Composite",
@@ -84,7 +83,7 @@ export const InnerHttpError: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorModel: msRest.CompositeMapper = {
+export const ErrorModel: CompositeMapper = {
   serializedName: "Error",
   type: {
     name: "Composite",
@@ -113,7 +112,7 @@ export const ErrorModel: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorResponse: msRest.CompositeMapper = {
+export const ErrorResponse: CompositeMapper = {
   serializedName: "ErrorResponse",
   type: {
     name: "Composite",
@@ -130,7 +129,7 @@ export const ErrorResponse: msRest.CompositeMapper = {
   }
 };
 
-export const ChannelAccount: msRest.CompositeMapper = {
+export const ChannelAccount: CompositeMapper = {
   serializedName: "ChannelAccount",
   type: {
     name: "Composite",
@@ -164,7 +163,7 @@ export const ChannelAccount: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationAccount: msRest.CompositeMapper = {
+export const ConversationAccount: CompositeMapper = {
   serializedName: "ConversationAccount",
   type: {
     name: "Composite",
@@ -222,7 +221,7 @@ export const ConversationAccount: msRest.CompositeMapper = {
   }
 };
 
-export const MessageReaction: msRest.CompositeMapper = {
+export const MessageReaction: CompositeMapper = {
   serializedName: "MessageReaction",
   type: {
     name: "Composite",
@@ -238,7 +237,7 @@ export const MessageReaction: msRest.CompositeMapper = {
   }
 };
 
-export const CardAction: msRest.CompositeMapper = {
+export const CardAction: CompositeMapper = {
   serializedName: "CardAction",
   type: {
     name: "Composite",
@@ -296,7 +295,7 @@ export const CardAction: msRest.CompositeMapper = {
   }
 };
 
-export const SuggestedActions: msRest.CompositeMapper = {
+export const SuggestedActions: CompositeMapper = {
   serializedName: "SuggestedActions",
   type: {
     name: "Composite",
@@ -329,7 +328,7 @@ export const SuggestedActions: msRest.CompositeMapper = {
   }
 };
 
-export const Attachment: msRest.CompositeMapper = {
+export const Attachment: CompositeMapper = {
   serializedName: "Attachment",
   type: {
     name: "Composite",
@@ -369,7 +368,7 @@ export const Attachment: msRest.CompositeMapper = {
   }
 };
 
-export const Entity: msRest.CompositeMapper = {
+export const Entity: CompositeMapper = {
   serializedName: "Entity",
   type: {
     name: "Composite",
@@ -398,7 +397,7 @@ export const Entity: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationReference: msRest.CompositeMapper = {
+export const ConversationReference: CompositeMapper = {
   serializedName: "ConversationReference",
   type: {
     name: "Composite",
@@ -447,7 +446,7 @@ export const ConversationReference: msRest.CompositeMapper = {
   }
 };
 
-export const TextHighlight: msRest.CompositeMapper = {
+export const TextHighlight: CompositeMapper = {
   serializedName: "TextHighlight",
   type: {
     name: "Composite",
@@ -469,7 +468,7 @@ export const TextHighlight: msRest.CompositeMapper = {
   }
 };
 
-export const SemanticAction: msRest.CompositeMapper = {
+export const SemanticAction: CompositeMapper = {
   serializedName: "SemanticAction",
   type: {
     name: "Composite",
@@ -503,7 +502,7 @@ export const SemanticAction: msRest.CompositeMapper = {
   }
 };
 
-export const Activity: msRest.CompositeMapper = {
+export const Activity: CompositeMapper = {
   serializedName: "Activity",
   type: {
     name: "Composite",
@@ -823,7 +822,7 @@ export const Activity: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationParameters: msRest.CompositeMapper = {
+export const ConversationParameters: CompositeMapper = {
   serializedName: "ConversationParameters",
   type: {
     name: "Composite",
@@ -883,7 +882,7 @@ export const ConversationParameters: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationResourceResponse: msRest.CompositeMapper = {
+export const ConversationResourceResponse: CompositeMapper = {
   serializedName: "ConversationResourceResponse",
   type: {
     name: "Composite",
@@ -911,7 +910,7 @@ export const ConversationResourceResponse: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationMembers: msRest.CompositeMapper = {
+export const ConversationMembers: CompositeMapper = {
   serializedName: "ConversationMembers",
   type: {
     name: "Composite",
@@ -939,7 +938,7 @@ export const ConversationMembers: msRest.CompositeMapper = {
   }
 };
 
-export const ConversationsResult: msRest.CompositeMapper = {
+export const ConversationsResult: CompositeMapper = {
   serializedName: "ConversationsResult",
   type: {
     name: "Composite",
@@ -967,7 +966,7 @@ export const ConversationsResult: msRest.CompositeMapper = {
   }
 };
 
-export const ExpectedReplies: msRest.CompositeMapper = {
+export const ExpectedReplies: CompositeMapper = {
   serializedName: "ExpectedReplies",
   type: {
     name: "Composite",
@@ -989,7 +988,7 @@ export const ExpectedReplies: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceResponse: msRest.CompositeMapper = {
+export const ResourceResponse: CompositeMapper = {
   serializedName: "ResourceResponse",
   type: {
     name: "Composite",
@@ -1005,7 +1004,7 @@ export const ResourceResponse: msRest.CompositeMapper = {
   }
 };
 
-export const Transcript: msRest.CompositeMapper = {
+export const Transcript: CompositeMapper = {
   serializedName: "Transcript",
   type: {
     name: "Composite",
@@ -1027,7 +1026,7 @@ export const Transcript: msRest.CompositeMapper = {
   }
 };
 
-export const PagedMembersResult: msRest.CompositeMapper = {
+export const PagedMembersResult: CompositeMapper = {
   serializedName: "PagedMembersResult",
   type: {
     name: "Composite",
@@ -1055,7 +1054,7 @@ export const PagedMembersResult: msRest.CompositeMapper = {
   }
 };
 
-export const AttachmentData: msRest.CompositeMapper = {
+export const AttachmentData: CompositeMapper = {
   serializedName: "AttachmentData",
   type: {
     name: "Composite",
@@ -1089,7 +1088,7 @@ export const AttachmentData: msRest.CompositeMapper = {
   }
 };
 
-export const CardImage: msRest.CompositeMapper = {
+export const CardImage: CompositeMapper = {
   serializedName: "CardImage",
   type: {
     name: "Composite",
@@ -1118,7 +1117,7 @@ export const CardImage: msRest.CompositeMapper = {
   }
 };
 
-export const HeroCard: msRest.CompositeMapper = {
+export const HeroCard: CompositeMapper = {
   serializedName: "HeroCard",
   type: {
     name: "Composite",
@@ -1177,7 +1176,7 @@ export const HeroCard: msRest.CompositeMapper = {
   }
 };
 
-export const ThumbnailUrl: msRest.CompositeMapper = {
+export const ThumbnailUrl: CompositeMapper = {
   serializedName: "ThumbnailUrl",
   type: {
     name: "Composite",
@@ -1199,7 +1198,7 @@ export const ThumbnailUrl: msRest.CompositeMapper = {
   }
 };
 
-export const MediaUrl: msRest.CompositeMapper = {
+export const MediaUrl: CompositeMapper = {
   serializedName: "MediaUrl",
   type: {
     name: "Composite",
@@ -1221,7 +1220,7 @@ export const MediaUrl: msRest.CompositeMapper = {
   }
 };
 
-export const AnimationCard: msRest.CompositeMapper = {
+export const AnimationCard: CompositeMapper = {
   serializedName: "AnimationCard",
   type: {
     name: "Composite",
@@ -1316,7 +1315,7 @@ export const AnimationCard: msRest.CompositeMapper = {
   }
 };
 
-export const AudioCard: msRest.CompositeMapper = {
+export const AudioCard: CompositeMapper = {
   serializedName: "AudioCard",
   type: {
     name: "Composite",
@@ -1411,7 +1410,7 @@ export const AudioCard: msRest.CompositeMapper = {
   }
 };
 
-export const BasicCard: msRest.CompositeMapper = {
+export const BasicCard: CompositeMapper = {
   serializedName: "BasicCard",
   type: {
     name: "Composite",
@@ -1470,7 +1469,7 @@ export const BasicCard: msRest.CompositeMapper = {
   }
 };
 
-export const MediaCard: msRest.CompositeMapper = {
+export const MediaCard: CompositeMapper = {
   serializedName: "MediaCard",
   type: {
     name: "Composite",
@@ -1565,7 +1564,7 @@ export const MediaCard: msRest.CompositeMapper = {
   }
 };
 
-export const Fact: msRest.CompositeMapper = {
+export const Fact: CompositeMapper = {
   serializedName: "Fact",
   type: {
     name: "Composite",
@@ -1587,7 +1586,7 @@ export const Fact: msRest.CompositeMapper = {
   }
 };
 
-export const ReceiptItem: msRest.CompositeMapper = {
+export const ReceiptItem: CompositeMapper = {
   serializedName: "ReceiptItem",
   type: {
     name: "Composite",
@@ -1641,7 +1640,7 @@ export const ReceiptItem: msRest.CompositeMapper = {
   }
 };
 
-export const ReceiptCard: msRest.CompositeMapper = {
+export const ReceiptCard: CompositeMapper = {
   serializedName: "ReceiptCard",
   type: {
     name: "Composite",
@@ -1718,7 +1717,7 @@ export const ReceiptCard: msRest.CompositeMapper = {
   }
 };
 
-export const SigninCard: msRest.CompositeMapper = {
+export const SigninCard: CompositeMapper = {
   serializedName: "SigninCard",
   type: {
     name: "Composite",
@@ -1746,7 +1745,7 @@ export const SigninCard: msRest.CompositeMapper = {
   }
 };
 
-export const OAuthCard: msRest.CompositeMapper = {
+export const OAuthCard: CompositeMapper = {
   serializedName: "OAuthCard",
   type: {
     name: "Composite",
@@ -1780,7 +1779,7 @@ export const OAuthCard: msRest.CompositeMapper = {
   }
 };
 
-export const ThumbnailCard: msRest.CompositeMapper = {
+export const ThumbnailCard: CompositeMapper = {
   serializedName: "ThumbnailCard",
   type: {
     name: "Composite",
@@ -1839,7 +1838,7 @@ export const ThumbnailCard: msRest.CompositeMapper = {
   }
 };
 
-export const VideoCard: msRest.CompositeMapper = {
+export const VideoCard: CompositeMapper = {
   serializedName: "VideoCard",
   type: {
     name: "Composite",
@@ -1934,7 +1933,7 @@ export const VideoCard: msRest.CompositeMapper = {
   }
 };
 
-export const GeoCoordinates: msRest.CompositeMapper = {
+export const GeoCoordinates: CompositeMapper = {
   serializedName: "GeoCoordinates",
   type: {
     name: "Composite",
@@ -1974,7 +1973,7 @@ export const GeoCoordinates: msRest.CompositeMapper = {
   }
 };
 
-export const Mention: msRest.CompositeMapper = {
+export const Mention: CompositeMapper = {
   serializedName: "Mention",
   type: {
     name: "Composite",
@@ -2003,7 +2002,7 @@ export const Mention: msRest.CompositeMapper = {
   }
 };
 
-export const Place: msRest.CompositeMapper = {
+export const Place: CompositeMapper = {
   serializedName: "Place",
   type: {
     name: "Composite",
@@ -2043,7 +2042,7 @@ export const Place: msRest.CompositeMapper = {
   }
 };
 
-export const Thing: msRest.CompositeMapper = {
+export const Thing: CompositeMapper = {
   serializedName: "Thing",
   type: {
     name: "Composite",
@@ -2065,7 +2064,7 @@ export const Thing: msRest.CompositeMapper = {
   }
 };
 
-export const MediaEventValue: msRest.CompositeMapper = {
+export const MediaEventValue: CompositeMapper = {
   serializedName: "MediaEventValue",
   type: {
     name: "Composite",
@@ -2081,7 +2080,7 @@ export const MediaEventValue: msRest.CompositeMapper = {
   }
 };
 
-export const TokenRequest: msRest.CompositeMapper = {
+export const TokenRequest: CompositeMapper = {
   serializedName: "TokenRequest",
   type: {
     name: "Composite",
@@ -2108,7 +2107,7 @@ export const TokenRequest: msRest.CompositeMapper = {
   }
 };
 
-export const TokenResponse: msRest.CompositeMapper = {
+export const TokenResponse: CompositeMapper = {
   serializedName: "TokenResponse",
   type: {
     name: "Composite",
@@ -2142,7 +2141,7 @@ export const TokenResponse: msRest.CompositeMapper = {
   }
 };
 
-export const MicrosoftPayMethodData: msRest.CompositeMapper = {
+export const MicrosoftPayMethodData: CompositeMapper = {
   serializedName: "MicrosoftPayMethodData",
   type: {
     name: "Composite",
@@ -2183,7 +2182,7 @@ export const MicrosoftPayMethodData: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentAddress: msRest.CompositeMapper = {
+export const PaymentAddress: CompositeMapper = {
   serializedName: "PaymentAddress",
   type: {
     name: "Composite",
@@ -2267,7 +2266,7 @@ export const PaymentAddress: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentCurrencyAmount: msRest.CompositeMapper = {
+export const PaymentCurrencyAmount: CompositeMapper = {
   serializedName: "PaymentCurrencyAmount",
   type: {
     name: "Composite",
@@ -2298,7 +2297,7 @@ export const PaymentCurrencyAmount: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentItem: msRest.CompositeMapper = {
+export const PaymentItem: CompositeMapper = {
   serializedName: "PaymentItem",
   type: {
     name: "Composite",
@@ -2330,7 +2329,7 @@ export const PaymentItem: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentShippingOption: msRest.CompositeMapper = {
+export const PaymentShippingOption: CompositeMapper = {
   serializedName: "PaymentShippingOption",
   type: {
     name: "Composite",
@@ -2368,7 +2367,7 @@ export const PaymentShippingOption: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentDetailsModifier: msRest.CompositeMapper = {
+export const PaymentDetailsModifier: CompositeMapper = {
   serializedName: "PaymentDetailsModifier",
   type: {
     name: "Composite",
@@ -2417,7 +2416,7 @@ export const PaymentDetailsModifier: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentDetails: msRest.CompositeMapper = {
+export const PaymentDetails: CompositeMapper = {
   serializedName: "PaymentDetails",
   type: {
     name: "Composite",
@@ -2479,7 +2478,7 @@ export const PaymentDetails: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentMethodData: msRest.CompositeMapper = {
+export const PaymentMethodData: CompositeMapper = {
   serializedName: "PaymentMethodData",
   type: {
     name: "Composite",
@@ -2509,7 +2508,7 @@ export const PaymentMethodData: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentOptions: msRest.CompositeMapper = {
+export const PaymentOptions: CompositeMapper = {
   serializedName: "PaymentOptions",
   type: {
     name: "Composite",
@@ -2552,7 +2551,7 @@ export const PaymentOptions: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentRequest: msRest.CompositeMapper = {
+export const PaymentRequest: CompositeMapper = {
   serializedName: "PaymentRequest",
   type: {
     name: "Composite",
@@ -2603,7 +2602,7 @@ export const PaymentRequest: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentResponse: msRest.CompositeMapper = {
+export const PaymentResponse: CompositeMapper = {
   serializedName: "PaymentResponse",
   type: {
     name: "Composite",
@@ -2653,7 +2652,7 @@ export const PaymentResponse: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentRequestComplete: msRest.CompositeMapper = {
+export const PaymentRequestComplete: CompositeMapper = {
   serializedName: "PaymentRequestComplete",
   type: {
     name: "Composite",
@@ -2686,7 +2685,7 @@ export const PaymentRequestComplete: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentRequestCompleteResult: msRest.CompositeMapper = {
+export const PaymentRequestCompleteResult: CompositeMapper = {
   serializedName: "PaymentRequestCompleteResult",
   type: {
     name: "Composite",
@@ -2705,7 +2704,7 @@ export const PaymentRequestCompleteResult: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentRequestUpdate: msRest.CompositeMapper = {
+export const PaymentRequestUpdate: CompositeMapper = {
   serializedName: "PaymentRequestUpdate",
   type: {
     name: "Composite",
@@ -2744,7 +2743,7 @@ export const PaymentRequestUpdate: msRest.CompositeMapper = {
 /**
  * @deprecated Bot Framework no longer supports payments
  */
-export const PaymentRequestUpdateResult: msRest.CompositeMapper = {
+export const PaymentRequestUpdateResult: CompositeMapper = {
   serializedName: "PaymentRequestUpdateResult",
   type: {
     name: "Composite",

--- a/libraries/botframework-connector/src/connectorApi/models/parameters.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/parameters.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { OperationURLParameter, OperationQueryParameter } from "@azure/core-http"
 
-export const activityId: msRest.OperationURLParameter = {
+export const activityId: OperationURLParameter = {
   parameterPath: "activityId",
   mapper: {
     required: true,
@@ -15,7 +15,7 @@ export const activityId: msRest.OperationURLParameter = {
     }
   }
 };
-export const attachmentId: msRest.OperationURLParameter = {
+export const attachmentId: OperationURLParameter = {
   parameterPath: "attachmentId",
   mapper: {
     required: true,
@@ -25,7 +25,7 @@ export const attachmentId: msRest.OperationURLParameter = {
     }
   }
 };
-export const continuationToken: msRest.OperationQueryParameter = {
+export const continuationToken: OperationQueryParameter = {
   parameterPath: [
     "options",
     "continuationToken"
@@ -37,7 +37,7 @@ export const continuationToken: msRest.OperationQueryParameter = {
     }
   }
 };
-export const conversationId: msRest.OperationURLParameter = {
+export const conversationId: OperationURLParameter = {
   parameterPath: "conversationId",
   mapper: {
     required: true,
@@ -47,7 +47,7 @@ export const conversationId: msRest.OperationURLParameter = {
     }
   }
 };
-export const memberId: msRest.OperationURLParameter = {
+export const memberId: OperationURLParameter = {
   parameterPath: "memberId",
   mapper: {
     required: true,
@@ -57,7 +57,7 @@ export const memberId: msRest.OperationURLParameter = {
     }
   }
 };
-export const pageSize: msRest.OperationQueryParameter = {
+export const pageSize: OperationQueryParameter = {
   parameterPath: [
     "options",
     "pageSize"
@@ -69,7 +69,7 @@ export const pageSize: msRest.OperationQueryParameter = {
     }
   }
 };
-export const viewId: msRest.OperationURLParameter = {
+export const viewId: OperationURLParameter = {
   parameterPath: "viewId",
   mapper: {
     required: true,

--- a/libraries/botframework-connector/src/connectorApi/operations/attachments.ts
+++ b/libraries/botframework-connector/src/connectorApi/operations/attachments.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { RequestOptionsBase, ServiceCallback, OperationSpec, Serializer } from "@azure/core-http";
 import { ConnectorClientContext } from "../connectorClientContext";
 import * as Models from "../models";
 import * as Mappers from "../models/attachmentsMappers";
@@ -28,19 +28,19 @@ export class Attachments {
    * @param [options] The optional parameters
    * @returns Promise<Models.AttachmentsGetAttachmentInfoResponse>
    */
-  getAttachmentInfo(attachmentId: string, options?: msRest.RequestOptionsBase): Promise<Models.AttachmentsGetAttachmentInfoResponse>;
+  getAttachmentInfo(attachmentId: string, options?: RequestOptionsBase): Promise<Models.AttachmentsGetAttachmentInfoResponse>;
   /**
    * @param attachmentId attachment id
    * @param callback The callback
    */
-  getAttachmentInfo(attachmentId: string, callback: msRest.ServiceCallback<Models.AttachmentInfo>): void;
+  getAttachmentInfo(attachmentId: string, callback: ServiceCallback<Models.AttachmentInfo>): void;
   /**
    * @param attachmentId attachment id
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAttachmentInfo(attachmentId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AttachmentInfo>): void;
-  getAttachmentInfo(attachmentId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AttachmentInfo>, callback?: msRest.ServiceCallback<Models.AttachmentInfo>): Promise<Models.AttachmentsGetAttachmentInfoResponse> {
+  getAttachmentInfo(attachmentId: string, options: RequestOptionsBase, callback: ServiceCallback<Models.AttachmentInfo>): void;
+  getAttachmentInfo(attachmentId: string, options?: RequestOptionsBase | ServiceCallback<Models.AttachmentInfo>, callback?: ServiceCallback<Models.AttachmentInfo>): Promise<Models.AttachmentsGetAttachmentInfoResponse> {
     return this.client.sendOperationRequest(
       {
         attachmentId,
@@ -58,21 +58,21 @@ export class Attachments {
    * @param [options] The optional parameters
    * @returns Promise<Models.AttachmentsGetAttachmentResponse>
    */
-  getAttachment(attachmentId: string, viewId: string, options?: msRest.RequestOptionsBase): Promise<Models.AttachmentsGetAttachmentResponse>;
+  getAttachment(attachmentId: string, viewId: string, options?: RequestOptionsBase): Promise<Models.AttachmentsGetAttachmentResponse>;
   /**
    * @param attachmentId attachment id
    * @param viewId View id from attachmentInfo
    * @param callback The callback
    */
-  getAttachment(attachmentId: string, viewId: string, callback: msRest.ServiceCallback<void>): void;
+  getAttachment(attachmentId: string, viewId: string, callback: ServiceCallback<void>): void;
   /**
    * @param attachmentId attachment id
    * @param viewId View id from attachmentInfo
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAttachment(attachmentId: string, viewId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  getAttachment(attachmentId: string, viewId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.AttachmentsGetAttachmentResponse> {
+  getAttachment(attachmentId: string, viewId: string, options: RequestOptionsBase, callback: ServiceCallback<void>): void;
+  getAttachment(attachmentId: string, viewId: string, options?: RequestOptionsBase | ServiceCallback<void>, callback?: ServiceCallback<void>): Promise<Models.AttachmentsGetAttachmentResponse> {
     return this.client.sendOperationRequest(
       {
         attachmentId,
@@ -85,8 +85,8 @@ export class Attachments {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getAttachmentInfoOperationSpec: msRest.OperationSpec = {
+const serializer = new Serializer(Mappers);
+const getAttachmentInfoOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/attachments/{attachmentId}",
   urlParameters: [
@@ -103,7 +103,7 @@ const getAttachmentInfoOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAttachmentOperationSpec: msRest.OperationSpec = {
+const getAttachmentOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/attachments/{attachmentId}/views/{viewId}",
   urlParameters: [

--- a/libraries/botframework-connector/src/connectorApi/operations/conversations.ts
+++ b/libraries/botframework-connector/src/connectorApi/operations/conversations.ts
@@ -6,7 +6,7 @@
 import * as Mappers from "../models/conversationsMappers";
 import * as Models from "../models";
 import * as Parameters from "../models/parameters";
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceCallback, RequestOptionsBase, RestResponse, Serializer, OperationSpec } from "@azure/core-http"
 import { ConnectorClientContext } from "../connectorClientContext";
 import { ConversationIdHttpHeaderName } from "../../conversationConstants";
 
@@ -42,13 +42,13 @@ export class Conversations {
   /**
    * @param callback The callback
    */
-  getConversations(callback: msRest.ServiceCallback<Models.ConversationsResult>): void;
+  getConversations(callback: ServiceCallback<Models.ConversationsResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  getConversations(options: Models.ConversationsGetConversationsOptionalParams, callback: msRest.ServiceCallback<Models.ConversationsResult>): void;
-  getConversations(options?: Models.ConversationsGetConversationsOptionalParams | msRest.ServiceCallback<Models.ConversationsResult>, callback?: msRest.ServiceCallback<Models.ConversationsResult>): Promise<Models.ConversationsGetConversationsResponse> {
+  getConversations(options: Models.ConversationsGetConversationsOptionalParams, callback: ServiceCallback<Models.ConversationsResult>): void;
+  getConversations(options?: Models.ConversationsGetConversationsOptionalParams | ServiceCallback<Models.ConversationsResult>, callback?: ServiceCallback<Models.ConversationsResult>): Promise<Models.ConversationsGetConversationsResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -84,19 +84,19 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsCreateConversationResponse>
    */
-  createConversation(parameters: Models.ConversationParameters, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsCreateConversationResponse>;
+  createConversation(parameters: Models.ConversationParameters, options?: RequestOptionsBase): Promise<Models.ConversationsCreateConversationResponse>;
   /**
    * @param parameters Parameters to create the conversation from
    * @param callback The callback
    */
-  createConversation(parameters: Models.ConversationParameters, callback: msRest.ServiceCallback<Models.ConversationResourceResponse>): void;
+  createConversation(parameters: Models.ConversationParameters, callback: ServiceCallback<Models.ConversationResourceResponse>): void;
   /**
    * @param parameters Parameters to create the conversation from
    * @param options The optional parameters
    * @param callback The callback
    */
-  createConversation(parameters: Models.ConversationParameters, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ConversationResourceResponse>): void;
-  createConversation(parameters: Models.ConversationParameters, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ConversationResourceResponse>, callback?: msRest.ServiceCallback<Models.ConversationResourceResponse>): Promise<Models.ConversationsCreateConversationResponse> {
+  createConversation(parameters: Models.ConversationParameters, options: RequestOptionsBase, callback: ServiceCallback<Models.ConversationResourceResponse>): void;
+  createConversation(parameters: Models.ConversationParameters, options?: RequestOptionsBase | ServiceCallback<Models.ConversationResourceResponse>, callback?: ServiceCallback<Models.ConversationResourceResponse>): Promise<Models.ConversationsCreateConversationResponse> {
     return this.client.sendOperationRequest(
       {
         parameters,
@@ -125,21 +125,21 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsSendToConversationResponse>
    */
-  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsSendToConversationResponse>;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase): Promise<Models.ConversationsSendToConversationResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activity Activity to send
    * @param callback The callback
    */
-  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, callback: ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activity Activity to send
    * @param options The optional parameters
    * @param callback The callback
    */
-  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendToConversationResponse> {
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options: RequestOptionsBase, callback: ServiceCallback<Models.ResourceResponse>): void;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase | ServiceCallback<Models.ResourceResponse>, callback?: ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendToConversationResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -162,21 +162,21 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsSendConversationHistoryResponse>
    */
-  sendConversationHistory(conversationId: string, history: Models.Transcript, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsSendConversationHistoryResponse>;
+  sendConversationHistory(conversationId: string, history: Models.Transcript, options?: RequestOptionsBase): Promise<Models.ConversationsSendConversationHistoryResponse>;
   /**
    * @param conversationId Conversation ID
    * @param history Historic activities
    * @param callback The callback
    */
-  sendConversationHistory(conversationId: string, history: Models.Transcript, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  sendConversationHistory(conversationId: string, history: Models.Transcript, callback: ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param history Historic activities
    * @param options The optional parameters
    * @param callback The callback
    */
-  sendConversationHistory(conversationId: string, history: Models.Transcript, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  sendConversationHistory(conversationId: string, history: Models.Transcript, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendConversationHistoryResponse> {
+  sendConversationHistory(conversationId: string, history: Models.Transcript, options: RequestOptionsBase, callback: ServiceCallback<Models.ResourceResponse>): void;
+  sendConversationHistory(conversationId: string, history: Models.Transcript, options?: RequestOptionsBase | ServiceCallback<Models.ResourceResponse>, callback?: ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendConversationHistoryResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -201,14 +201,14 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsUpdateActivityResponse>
    */
-  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsUpdateActivityResponse>;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase): Promise<Models.ConversationsUpdateActivityResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to update
    * @param activity replacement Activity
    * @param callback The callback
    */
-  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to update
@@ -216,8 +216,8 @@ export class Conversations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUpdateActivityResponse> {
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: RequestOptionsBase, callback: ServiceCallback<Models.ResourceResponse>): void;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase | ServiceCallback<Models.ResourceResponse>, callback?: ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUpdateActivityResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -249,14 +249,14 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsReplyToActivityResponse>
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsReplyToActivityResponse>;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase): Promise<Models.ConversationsReplyToActivityResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId the reply is to (OPTIONAL)
    * @param activity Activity to send
    * @param callback The callback
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId the reply is to (OPTIONAL)
@@ -264,8 +264,8 @@ export class Conversations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsReplyToActivityResponse> {
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: RequestOptionsBase, callback: ServiceCallback<Models.ResourceResponse>): void;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: RequestOptionsBase | ServiceCallback<Models.ResourceResponse>, callback?: ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsReplyToActivityResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -286,23 +286,23 @@ export class Conversations {
    * @param conversationId Conversation ID
    * @param activityId activityId to delete
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<RestResponse>
    */
-  deleteActivity(conversationId: string, activityId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteActivity(conversationId: string, activityId: string, options?: RequestOptionsBase): Promise<RestResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to delete
    * @param callback The callback
    */
-  deleteActivity(conversationId: string, activityId: string, callback: msRest.ServiceCallback<void>): void;
+  deleteActivity(conversationId: string, activityId: string, callback: ServiceCallback<void>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to delete
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteActivity(conversationId: string, activityId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteActivity(conversationId: string, activityId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteActivity(conversationId: string, activityId: string, options: RequestOptionsBase, callback: ServiceCallback<void>): void;
+  deleteActivity(conversationId: string, activityId: string, options?: RequestOptionsBase | ServiceCallback<void>, callback?: ServiceCallback<void>): Promise<RestResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -323,19 +323,19 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsGetConversationMembersResponse>
    */
-  getConversationMembers(conversationId: string, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsGetConversationMembersResponse>;
+  getConversationMembers(conversationId: string, options?: RequestOptionsBase): Promise<Models.ConversationsGetConversationMembersResponse>;
   /**
    * @param conversationId Conversation ID
    * @param callback The callback
    */
-  getConversationMembers(conversationId: string, callback: msRest.ServiceCallback<Models.ChannelAccount[]>): void;
+  getConversationMembers(conversationId: string, callback: ServiceCallback<Models.ChannelAccount[]>): void;
   /**
    * @param conversationId Conversation ID
    * @param options The optional parameters
    * @param callback The callback
    */
-  getConversationMembers(conversationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ChannelAccount[]>): void;
-  getConversationMembers(conversationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ChannelAccount[]>, callback?: msRest.ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetConversationMembersResponse> {
+  getConversationMembers(conversationId: string, options: RequestOptionsBase, callback: ServiceCallback<Models.ChannelAccount[]>): void;
+  getConversationMembers(conversationId: string, options?: RequestOptionsBase | ServiceCallback<Models.ChannelAccount[]>, callback?: ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetConversationMembersResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -351,7 +351,7 @@ export class Conversations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getConversationMember(conversationId: string, memberId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ChannelAccount[]>, callback?: msRest.ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetConversationMemberResponse> {
+  getConversationMember(conversationId: string, memberId: string, options?: RequestOptionsBase | ServiceCallback<Models.ChannelAccount[]>, callback?: ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetConversationMemberResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -388,14 +388,14 @@ export class Conversations {
    * @param conversationId Conversation ID
    * @param callback The callback
    */
-  getConversationPagedMembers(conversationId: string, callback: msRest.ServiceCallback<Models.PagedMembersResult>): void;
+  getConversationPagedMembers(conversationId: string, callback: ServiceCallback<Models.PagedMembersResult>): void;
   /**
    * @param conversationId Conversation ID
    * @param options The optional parameters
    * @param callback The callback
    */
-  getConversationPagedMembers(conversationId: string, options: Models.ConversationsGetConversationPagedMembersOptionalParams, callback: msRest.ServiceCallback<Models.PagedMembersResult>): void;
-  getConversationPagedMembers(conversationId: string, options?: Models.ConversationsGetConversationPagedMembersOptionalParams | msRest.ServiceCallback<Models.PagedMembersResult>, callback?: msRest.ServiceCallback<Models.PagedMembersResult>): Promise<Models.ConversationsGetConversationPagedMembersResponse> {
+  getConversationPagedMembers(conversationId: string, options: Models.ConversationsGetConversationPagedMembersOptionalParams, callback: ServiceCallback<Models.PagedMembersResult>): void;
+  getConversationPagedMembers(conversationId: string, options?: Models.ConversationsGetConversationPagedMembersOptionalParams | ServiceCallback<Models.PagedMembersResult>, callback?: ServiceCallback<Models.PagedMembersResult>): Promise<Models.ConversationsGetConversationPagedMembersResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -415,23 +415,23 @@ export class Conversations {
    * @param conversationId Conversation ID
    * @param memberId ID of the member to delete from this conversation
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<RestResponse>
    */
-  deleteConversationMember(conversationId: string, memberId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteConversationMember(conversationId: string, memberId: string, options?: RequestOptionsBase): Promise<RestResponse>;
   /**
    * @param conversationId Conversation ID
    * @param memberId ID of the member to delete from this conversation
    * @param callback The callback
    */
-  deleteConversationMember(conversationId: string, memberId: string, callback: msRest.ServiceCallback<void>): void;
+  deleteConversationMember(conversationId: string, memberId: string, callback: ServiceCallback<void>): void;
   /**
    * @param conversationId Conversation ID
    * @param memberId ID of the member to delete from this conversation
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteConversationMember(conversationId: string, memberId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteConversationMember(conversationId: string, memberId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteConversationMember(conversationId: string, memberId: string, options: RequestOptionsBase, callback: ServiceCallback<void>): void;
+  deleteConversationMember(conversationId: string, memberId: string, options?: RequestOptionsBase | ServiceCallback<void>, callback?: ServiceCallback<void>): Promise<RestResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -453,21 +453,21 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsGetActivityMembersResponse>
    */
-  getActivityMembers(conversationId: string, activityId: string, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsGetActivityMembersResponse>;
+  getActivityMembers(conversationId: string, activityId: string, options?: RequestOptionsBase): Promise<Models.ConversationsGetActivityMembersResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId Activity ID
    * @param callback The callback
    */
-  getActivityMembers(conversationId: string, activityId: string, callback: msRest.ServiceCallback<Models.ChannelAccount[]>): void;
+  getActivityMembers(conversationId: string, activityId: string, callback: ServiceCallback<Models.ChannelAccount[]>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId Activity ID
    * @param options The optional parameters
    * @param callback The callback
    */
-  getActivityMembers(conversationId: string, activityId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ChannelAccount[]>): void;
-  getActivityMembers(conversationId: string, activityId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ChannelAccount[]>, callback?: msRest.ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetActivityMembersResponse> {
+  getActivityMembers(conversationId: string, activityId: string, options: RequestOptionsBase, callback: ServiceCallback<Models.ChannelAccount[]>): void;
+  getActivityMembers(conversationId: string, activityId: string, options?: RequestOptionsBase | ServiceCallback<Models.ChannelAccount[]>, callback?: ServiceCallback<Models.ChannelAccount[]>): Promise<Models.ConversationsGetActivityMembersResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -492,21 +492,21 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsUploadAttachmentResponse>
    */
-  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsUploadAttachmentResponse>;
+  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options?: RequestOptionsBase): Promise<Models.ConversationsUploadAttachmentResponse>;
   /**
    * @param conversationId Conversation ID
    * @param attachmentUpload Attachment data
    * @param callback The callback
    */
-  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, callback: ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param attachmentUpload Attachment data
    * @param options The optional parameters
    * @param callback The callback
    */
-  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUploadAttachmentResponse> {
+  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options: RequestOptionsBase, callback: ServiceCallback<Models.ResourceResponse>): void;
+  uploadAttachment(conversationId: string, attachmentUpload: Models.AttachmentData, options?: RequestOptionsBase | ServiceCallback<Models.ResourceResponse>, callback?: ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUploadAttachmentResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -519,8 +519,8 @@ export class Conversations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getConversationsOperationSpec: msRest.OperationSpec = {
+const serializer = new Serializer(Mappers);
+const getConversationsOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/conversations",
   queryParameters: [
@@ -537,7 +537,7 @@ const getConversationsOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createConversationOperationSpec: msRest.OperationSpec = {
+const createConversationOperationSpec: OperationSpec = {
   httpMethod: "POST",
   path: "v3/conversations",
   requestBody: {
@@ -564,7 +564,7 @@ const createConversationOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const sendToConversationOperationSpec: msRest.OperationSpec = {
+const sendToConversationOperationSpec: OperationSpec = {
   httpMethod: "POST",
   path: "v3/conversations/{conversationId}/activities",
   urlParameters: [
@@ -594,7 +594,7 @@ const sendToConversationOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const sendConversationHistoryOperationSpec: msRest.OperationSpec = {
+const sendConversationHistoryOperationSpec: OperationSpec = {
   httpMethod: "POST",
   path: "v3/conversations/{conversationId}/activities/history",
   urlParameters: [
@@ -624,7 +624,7 @@ const sendConversationHistoryOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateActivityOperationSpec: msRest.OperationSpec = {
+const updateActivityOperationSpec: OperationSpec = {
   httpMethod: "PUT",
   path: "v3/conversations/{conversationId}/activities/{activityId}",
   urlParameters: [
@@ -655,7 +655,7 @@ const updateActivityOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const replyToActivityOperationSpec: msRest.OperationSpec = {
+const replyToActivityOperationSpec: OperationSpec = {
   httpMethod: "POST",
   path: "v3/conversations/{conversationId}/activities/{activityId}",
   urlParameters: [
@@ -695,7 +695,7 @@ const replyToActivityOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteActivityOperationSpec: msRest.OperationSpec = {
+const deleteActivityOperationSpec: OperationSpec = {
   httpMethod: "DELETE",
   path: "v3/conversations/{conversationId}/activities/{activityId}",
   urlParameters: [
@@ -712,7 +712,7 @@ const deleteActivityOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getConversationMembersOperationSpec: msRest.OperationSpec = {
+const getConversationMembersOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/conversations/{conversationId}/members",
   urlParameters: [
@@ -723,13 +723,13 @@ const getConversationMembersOperationSpec: msRest.OperationSpec = {
       bodyMapper: {
         serializedName: "parsedResponse",
         type: {
-            name: "Sequence",
-            element: {
-                type: {
-                    name: "Composite",
-                    className: "ChannelAccount"
-                }
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ChannelAccount"
             }
+          }
         }
       }
     },
@@ -740,25 +740,25 @@ const getConversationMembersOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getConversationMemberOperationSpec: msRest.OperationSpec = {
-    httpMethod: "GET",
-    path: "v3/conversations/{conversationId}/members/{memberId}",
-    urlParameters: [
-      Parameters.conversationId,
-      Parameters.memberId
-    ],
-    responses: {
-      200: {
-        bodyMapper: Mappers.ChannelAccount,
-      },
-      default: {
-        bodyMapper: Mappers.ErrorResponse
-      }
+const getConversationMemberOperationSpec: OperationSpec = {
+  httpMethod: "GET",
+  path: "v3/conversations/{conversationId}/members/{memberId}",
+  urlParameters: [
+    Parameters.conversationId,
+    Parameters.memberId
+  ],
+  responses: {
+    200: {
+      bodyMapper: Mappers.ChannelAccount,
     },
-    serializer
-  };
+    default: {
+      bodyMapper: Mappers.ErrorResponse
+    }
+  },
+  serializer
+};
 
-const getConversationPagedMembersOperationSpec: msRest.OperationSpec = {
+const getConversationPagedMembersOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/conversations/{conversationId}/pagedmembers",
   urlParameters: [
@@ -777,7 +777,7 @@ const getConversationPagedMembersOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteConversationMemberOperationSpec: msRest.OperationSpec = {
+const deleteConversationMemberOperationSpec: OperationSpec = {
   httpMethod: "DELETE",
   path: "v3/conversations/{conversationId}/members/{memberId}",
   urlParameters: [
@@ -794,7 +794,7 @@ const deleteConversationMemberOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getActivityMembersOperationSpec: msRest.OperationSpec = {
+const getActivityMembersOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "v3/conversations/{conversationId}/activities/{activityId}/members",
   urlParameters: [
@@ -823,7 +823,7 @@ const getActivityMembersOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const uploadAttachmentOperationSpec: msRest.OperationSpec = {
+const uploadAttachmentOperationSpec: OperationSpec = {
   httpMethod: "POST",
   path: "v3/conversations/{conversationId}/attachments",
   urlParameters: [

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/ms-rest-js';
+import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/core-http';
 import {
     ConversationList,
     TeamDetails,

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from '@azure/ms-rest-js';
+import { CompositeMapper } from "@azure/core-http"
 
-export const ChannelInfo: msRest.CompositeMapper = {
+export const ChannelInfo: CompositeMapper = {
     serializedName: 'ChannelInfo',
     type: {
         name: 'Composite',
@@ -33,7 +33,7 @@ export const ChannelInfo: msRest.CompositeMapper = {
     },
 };
 
-export const ConversationList: msRest.CompositeMapper = {
+export const ConversationList: CompositeMapper = {
     serializedName: 'ConversationList',
     type: {
         name: 'Composite',
@@ -55,7 +55,7 @@ export const ConversationList: msRest.CompositeMapper = {
     },
 };
 
-export const TeamDetails: msRest.CompositeMapper = {
+export const TeamDetails: CompositeMapper = {
     serializedName: 'TeamDetails',
     type: {
         name: 'Composite',
@@ -89,7 +89,7 @@ export const TeamDetails: msRest.CompositeMapper = {
     },
 };
 
-export const TeamInfo: msRest.CompositeMapper = {
+export const TeamInfo: CompositeMapper = {
     serializedName: 'TeamInfo',
     type: {
         name: 'Composite',
@@ -117,7 +117,7 @@ export const TeamInfo: msRest.CompositeMapper = {
     },
 };
 
-export const NotificationInfo: msRest.CompositeMapper = {
+export const NotificationInfo: CompositeMapper = {
     serializedName: 'NotificationInfo',
     type: {
         name: 'Composite',
@@ -145,7 +145,7 @@ export const NotificationInfo: msRest.CompositeMapper = {
     },
 };
 
-export const TenantInfo: msRest.CompositeMapper = {
+export const TenantInfo: CompositeMapper = {
     serializedName: 'TenantInfo',
     type: {
         name: 'Composite',
@@ -161,7 +161,7 @@ export const TenantInfo: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsChannelData: msRest.CompositeMapper = {
+export const TeamsChannelData: CompositeMapper = {
     serializedName: 'TeamsChannelData',
     type: {
         name: 'Composite',
@@ -212,7 +212,7 @@ export const TeamsChannelData: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsChannelDataSettings: msRest.CompositeMapper = {
+export const TeamsChannelDataSettings: CompositeMapper = {
     serializedName: 'TeamsChannelDataSettings',
     type: {
         name: 'Composite',
@@ -229,7 +229,7 @@ export const TeamsChannelDataSettings: msRest.CompositeMapper = {
     },
 };
 
-export const ChannelAccount: msRest.CompositeMapper = {
+export const ChannelAccount: CompositeMapper = {
     serializedName: 'ChannelAccount',
     type: {
         name: 'Composite',
@@ -251,7 +251,7 @@ export const ChannelAccount: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsChannelAccount: msRest.CompositeMapper = {
+export const TeamsChannelAccount: CompositeMapper = {
     serializedName: 'TeamsChannelAccount',
     type: {
         name: 'Composite',
@@ -298,7 +298,7 @@ export const TeamsChannelAccount: msRest.CompositeMapper = {
     },
 };
 
-export const Meeting: msRest.CompositeMapper = {
+export const Meeting: CompositeMapper = {
     serializedName: 'meeting',
     type: {
         name: 'Composite',
@@ -320,7 +320,7 @@ export const Meeting: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMeetingParticipant: msRest.CompositeMapper = {
+export const TeamsMeetingParticipant: CompositeMapper = {
     serializedName: 'TeamsMeetingParticipant',
     type: {
         name: 'Composite',
@@ -351,7 +351,7 @@ export const TeamsMeetingParticipant: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMeetingInfo: msRest.CompositeMapper = {
+export const TeamsMeetingInfo: CompositeMapper = {
     serializedName: 'TeamsMeetingInfo',
     type: {
         name: 'Composite',
@@ -382,7 +382,7 @@ export const TeamsMeetingInfo: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMeetingDetails: msRest.CompositeMapper = {
+export const TeamsMeetingDetails: CompositeMapper = {
     serializedName: 'TeamsMeetingDetails',
     type: {
         name: 'Composite',
@@ -434,7 +434,7 @@ export const TeamsMeetingDetails: msRest.CompositeMapper = {
     },
 };
 
-export const MeetingNotification: msRest.CompositeMapper = {
+export const MeetingNotification: CompositeMapper = {
     serializedName: 'MeetingNotification',
     type: {
         name: 'Composite',
@@ -485,7 +485,7 @@ export const MeetingNotificationChannelData = {
     },
 };
 
-export const OnBehalfOf: msRest.CompositeMapper = {
+export const OnBehalfOf: CompositeMapper = {
     serializedName: 'OnBehalfOf',
     type: {
         name: 'Composite',
@@ -519,7 +519,7 @@ export const OnBehalfOf: msRest.CompositeMapper = {
     },
 };
 
-export const MeetingNotificationRecipientFailureInfo: msRest.CompositeMapper = {
+export const MeetingNotificationRecipientFailureInfo: CompositeMapper = {
     serializedName: 'MeetingNotificationRecipientFailureInfo',
     type: {
         name: 'Composite',
@@ -547,7 +547,7 @@ export const MeetingNotificationRecipientFailureInfo: msRest.CompositeMapper = {
     },
 };
 
-export const MeetingNotificationResponse: msRest.CompositeMapper = {
+export const MeetingNotificationResponse: CompositeMapper = {
     serializedName: 'MeetingNotificationResponse',
     type: {
         name: 'Composite',
@@ -569,7 +569,7 @@ export const MeetingNotificationResponse: msRest.CompositeMapper = {
     },
 };
 
-export const CardAction: msRest.CompositeMapper = {
+export const CardAction: CompositeMapper = {
     serializedName: 'CardAction',
     type: {
         name: 'Composite',
@@ -603,7 +603,7 @@ export const CardAction: msRest.CompositeMapper = {
     },
 };
 
-export const CardImage: msRest.CompositeMapper = {
+export const CardImage: CompositeMapper = {
     serializedName: 'CardImage',
     type: {
         name: 'Composite',
@@ -632,7 +632,7 @@ export const CardImage: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardFact: msRest.CompositeMapper = {
+export const O365ConnectorCardFact: CompositeMapper = {
     serializedName: 'O365ConnectorCardFact',
     type: {
         name: 'Composite',
@@ -654,7 +654,7 @@ export const O365ConnectorCardFact: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardImage: msRest.CompositeMapper = {
+export const O365ConnectorCardImage: CompositeMapper = {
     serializedName: 'O365ConnectorCardImage',
     type: {
         name: 'Composite',
@@ -676,7 +676,7 @@ export const O365ConnectorCardImage: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardActionBase: msRest.CompositeMapper = {
+export const O365ConnectorCardActionBase: CompositeMapper = {
     serializedName: 'O365ConnectorCardActionBase',
     type: {
         name: 'Composite',
@@ -704,7 +704,7 @@ export const O365ConnectorCardActionBase: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardSection: msRest.CompositeMapper = {
+export const O365ConnectorCardSection: CompositeMapper = {
     serializedName: 'O365ConnectorCardSection',
     type: {
         name: 'Composite',
@@ -798,7 +798,7 @@ export const O365ConnectorCardSection: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCard: msRest.CompositeMapper = {
+export const O365ConnectorCard: CompositeMapper = {
     serializedName: 'O365ConnectorCard',
     type: {
         name: 'Composite',
@@ -856,7 +856,7 @@ export const O365ConnectorCard: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardViewAction: msRest.CompositeMapper = {
+export const O365ConnectorCardViewAction: CompositeMapper = {
     serializedName: 'O365ConnectorCardViewAction',
     type: {
         name: 'Composite',
@@ -878,7 +878,7 @@ export const O365ConnectorCardViewAction: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardOpenUriTarget: msRest.CompositeMapper = {
+export const O365ConnectorCardOpenUriTarget: CompositeMapper = {
     serializedName: 'O365ConnectorCardOpenUriTarget',
     type: {
         name: 'Composite',
@@ -900,7 +900,7 @@ export const O365ConnectorCardOpenUriTarget: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardOpenUri: msRest.CompositeMapper = {
+export const O365ConnectorCardOpenUri: CompositeMapper = {
     serializedName: 'O365ConnectorCardOpenUri',
     type: {
         name: 'Composite',
@@ -923,7 +923,7 @@ export const O365ConnectorCardOpenUri: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardHttpPOST: msRest.CompositeMapper = {
+export const O365ConnectorCardHttpPOST: CompositeMapper = {
     serializedName: 'O365ConnectorCardHttpPOST',
     type: {
         name: 'Composite',
@@ -940,7 +940,7 @@ export const O365ConnectorCardHttpPOST: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardInputBase: msRest.CompositeMapper = {
+export const O365ConnectorCardInputBase: CompositeMapper = {
     serializedName: 'O365ConnectorCardInputBase',
     type: {
         name: 'Composite',
@@ -980,7 +980,7 @@ export const O365ConnectorCardInputBase: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardActionCard: msRest.CompositeMapper = {
+export const O365ConnectorCardActionCard: CompositeMapper = {
     serializedName: 'O365ConnectorCardActionCard',
     type: {
         name: 'Composite',
@@ -1015,7 +1015,7 @@ export const O365ConnectorCardActionCard: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardTextInput: msRest.CompositeMapper = {
+export const O365ConnectorCardTextInput: CompositeMapper = {
     serializedName: 'O365ConnectorCardTextInput',
     type: {
         name: 'Composite',
@@ -1038,7 +1038,7 @@ export const O365ConnectorCardTextInput: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardDateInput: msRest.CompositeMapper = {
+export const O365ConnectorCardDateInput: CompositeMapper = {
     serializedName: 'O365ConnectorCardDateInput',
     type: {
         name: 'Composite',
@@ -1055,7 +1055,7 @@ export const O365ConnectorCardDateInput: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardMultichoiceInputChoice: msRest.CompositeMapper = {
+export const O365ConnectorCardMultichoiceInputChoice: CompositeMapper = {
     serializedName: 'O365ConnectorCardMultichoiceInputChoice',
     type: {
         name: 'Composite',
@@ -1077,7 +1077,7 @@ export const O365ConnectorCardMultichoiceInputChoice: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardMultichoiceInput: msRest.CompositeMapper = {
+export const O365ConnectorCardMultichoiceInput: CompositeMapper = {
     serializedName: 'O365ConnectorCardMultichoiceInput',
     type: {
         name: 'Composite',
@@ -1112,7 +1112,7 @@ export const O365ConnectorCardMultichoiceInput: msRest.CompositeMapper = {
     },
 };
 
-export const O365ConnectorCardActionQuery: msRest.CompositeMapper = {
+export const O365ConnectorCardActionQuery: CompositeMapper = {
     serializedName: 'O365ConnectorCardActionQuery',
     type: {
         name: 'Composite',
@@ -1134,7 +1134,7 @@ export const O365ConnectorCardActionQuery: msRest.CompositeMapper = {
     },
 };
 
-export const SigninStateVerificationQuery: msRest.CompositeMapper = {
+export const SigninStateVerificationQuery: CompositeMapper = {
     serializedName: 'SigninStateVerificationQuery',
     type: {
         name: 'Composite',
@@ -1150,7 +1150,7 @@ export const SigninStateVerificationQuery: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionQueryOptions: msRest.CompositeMapper = {
+export const MessagingExtensionQueryOptions: CompositeMapper = {
     serializedName: 'MessagingExtensionQueryOptions',
     type: {
         name: 'Composite',
@@ -1172,7 +1172,7 @@ export const MessagingExtensionQueryOptions: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionParameter: msRest.CompositeMapper = {
+export const MessagingExtensionParameter: CompositeMapper = {
     serializedName: 'MessagingExtensionParameter',
     type: {
         name: 'Composite',
@@ -1194,7 +1194,7 @@ export const MessagingExtensionParameter: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionQuery: msRest.CompositeMapper = {
+export const MessagingExtensionQuery: CompositeMapper = {
     serializedName: 'MessagingExtensionQuery',
     type: {
         name: 'Composite',
@@ -1235,7 +1235,7 @@ export const MessagingExtensionQuery: msRest.CompositeMapper = {
     },
 };
 
-export const Activity: msRest.CompositeMapper = {
+export const Activity: CompositeMapper = {
     serializedName: 'Activity',
     type: {
         name: 'Composite',
@@ -1257,7 +1257,7 @@ export const Activity: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadUser: msRest.CompositeMapper = {
+export const MessageActionsPayloadUser: CompositeMapper = {
     serializedName: 'MessageActionsPayloadUser',
     type: {
         name: 'Composite',
@@ -1285,7 +1285,7 @@ export const MessageActionsPayloadUser: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadApp: msRest.CompositeMapper = {
+export const MessageActionsPayloadApp: CompositeMapper = {
     serializedName: 'MessageActionsPayloadApp',
     type: {
         name: 'Composite',
@@ -1313,7 +1313,7 @@ export const MessageActionsPayloadApp: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadConversation: msRest.CompositeMapper = {
+export const MessageActionsPayloadConversation: CompositeMapper = {
     serializedName: 'MessageActionsPayloadConversation',
     type: {
         name: 'Composite',
@@ -1341,7 +1341,7 @@ export const MessageActionsPayloadConversation: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadFrom: msRest.CompositeMapper = {
+export const MessageActionsPayloadFrom: CompositeMapper = {
     serializedName: 'MessageActionsPayloadFrom',
     type: {
         name: 'Composite',
@@ -1372,7 +1372,7 @@ export const MessageActionsPayloadFrom: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadBody: msRest.CompositeMapper = {
+export const MessageActionsPayloadBody: CompositeMapper = {
     serializedName: 'MessageActionsPayload_body',
     type: {
         name: 'Composite',
@@ -1400,7 +1400,7 @@ export const MessageActionsPayloadBody: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadAttachment: msRest.CompositeMapper = {
+export const MessageActionsPayloadAttachment: CompositeMapper = {
     serializedName: 'MessageActionsPayloadAttachment',
     type: {
         name: 'Composite',
@@ -1446,7 +1446,7 @@ export const MessageActionsPayloadAttachment: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadMention: msRest.CompositeMapper = {
+export const MessageActionsPayloadMention: CompositeMapper = {
     serializedName: 'MessageActionsPayloadMention',
     type: {
         name: 'Composite',
@@ -1475,7 +1475,7 @@ export const MessageActionsPayloadMention: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayloadReaction: msRest.CompositeMapper = {
+export const MessageActionsPayloadReaction: CompositeMapper = {
     serializedName: 'MessageActionsPayloadReaction',
     type: {
         name: 'Composite',
@@ -1504,7 +1504,7 @@ export const MessageActionsPayloadReaction: msRest.CompositeMapper = {
     },
 };
 
-export const MessageActionsPayload: msRest.CompositeMapper = {
+export const MessageActionsPayload: CompositeMapper = {
     serializedName: 'MessageActionsPayload',
     type: {
         name: 'Composite',
@@ -1636,7 +1636,7 @@ export const MessageActionsPayload: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleRequest: msRest.CompositeMapper = {
+export const TaskModuleRequest: CompositeMapper = {
     serializedName: 'TaskModuleRequest',
     type: {
         name: 'Composite',
@@ -1659,7 +1659,7 @@ export const TaskModuleRequest: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionAction: msRest.CompositeMapper = {
+export const MessagingExtensionAction: CompositeMapper = {
     serializedName: 'MessagingExtensionAction',
     type: {
         name: 'Composite',
@@ -1707,7 +1707,7 @@ export const MessagingExtensionAction: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleResponseBase: msRest.CompositeMapper = {
+export const TaskModuleResponseBase: CompositeMapper = {
     serializedName: 'TaskModuleResponseBase',
     type: {
         name: 'Composite',
@@ -1723,7 +1723,7 @@ export const TaskModuleResponseBase: msRest.CompositeMapper = {
     },
 };
 
-export const Attachment: msRest.CompositeMapper = {
+export const Attachment: CompositeMapper = {
     serializedName: 'Attachment',
     type: {
         name: 'Composite',
@@ -1763,7 +1763,7 @@ export const Attachment: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionAttachment: msRest.CompositeMapper = {
+export const MessagingExtensionAttachment: CompositeMapper = {
     serializedName: 'MessagingExtensionAttachment',
     type: {
         name: 'Composite',
@@ -1781,7 +1781,7 @@ export const MessagingExtensionAttachment: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionSuggestedAction: msRest.CompositeMapper = {
+export const MessagingExtensionSuggestedAction: CompositeMapper = {
     serializedName: 'MessagingExtensionSuggestedAction',
     type: {
         name: 'Composite',
@@ -1803,7 +1803,7 @@ export const MessagingExtensionSuggestedAction: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionResult: msRest.CompositeMapper = {
+export const MessagingExtensionResult: CompositeMapper = {
     serializedName: 'MessagingExtensionResult',
     type: {
         name: 'Composite',
@@ -1857,7 +1857,7 @@ export const MessagingExtensionResult: msRest.CompositeMapper = {
     },
 };
 
-export const CacheInfo: msRest.CompositeMapper = {
+export const CacheInfo: CompositeMapper = {
     serializedName: 'cacheInfo',
     type: {
         name: 'Composite',
@@ -1879,7 +1879,7 @@ export const CacheInfo: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionActionResponse: msRest.CompositeMapper = {
+export const MessagingExtensionActionResponse: CompositeMapper = {
     serializedName: 'MessagingExtensionActionResponse',
     type: {
         name: 'Composite',
@@ -1910,7 +1910,7 @@ export const MessagingExtensionActionResponse: msRest.CompositeMapper = {
     },
 };
 
-export const MessagingExtensionResponse: msRest.CompositeMapper = {
+export const MessagingExtensionResponse: CompositeMapper = {
     serializedName: 'MessagingExtensionResponse',
     type: {
         name: 'Composite',
@@ -1934,7 +1934,7 @@ export const MessagingExtensionResponse: msRest.CompositeMapper = {
     },
 };
 
-export const FileConsentCard: msRest.CompositeMapper = {
+export const FileConsentCard: CompositeMapper = {
     serializedName: 'FileConsentCard',
     type: {
         name: 'Composite',
@@ -1968,7 +1968,7 @@ export const FileConsentCard: msRest.CompositeMapper = {
     },
 };
 
-export const FileDownloadInfo: msRest.CompositeMapper = {
+export const FileDownloadInfo: CompositeMapper = {
     serializedName: 'FileDownloadInfo',
     type: {
         name: 'Composite',
@@ -2002,7 +2002,7 @@ export const FileDownloadInfo: msRest.CompositeMapper = {
     },
 };
 
-export const FileInfoCard: msRest.CompositeMapper = {
+export const FileInfoCard: CompositeMapper = {
     serializedName: 'FileInfoCard',
     type: {
         name: 'Composite',
@@ -2030,7 +2030,7 @@ export const FileInfoCard: msRest.CompositeMapper = {
     },
 };
 
-export const FileUploadInfo: msRest.CompositeMapper = {
+export const FileUploadInfo: CompositeMapper = {
     serializedName: 'FileUploadInfo',
     type: {
         name: 'Composite',
@@ -2070,7 +2070,7 @@ export const FileUploadInfo: msRest.CompositeMapper = {
     },
 };
 
-export const FileConsentCardResponse: msRest.CompositeMapper = {
+export const FileConsentCardResponse: CompositeMapper = {
     serializedName: 'FileConsentCardResponse',
     type: {
         name: 'Composite',
@@ -2099,7 +2099,7 @@ export const FileConsentCardResponse: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleTaskInfo: msRest.CompositeMapper = {
+export const TaskModuleTaskInfo: CompositeMapper = {
     serializedName: 'TaskModuleTaskInfo',
     type: {
         name: 'Composite',
@@ -2152,7 +2152,7 @@ export const TaskModuleTaskInfo: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleContinueResponse: msRest.CompositeMapper = {
+export const TaskModuleContinueResponse: CompositeMapper = {
     serializedName: 'TaskModuleContinueResponse',
     type: {
         name: 'Composite',
@@ -2170,7 +2170,7 @@ export const TaskModuleContinueResponse: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleMessageResponse: msRest.CompositeMapper = {
+export const TaskModuleMessageResponse: CompositeMapper = {
     serializedName: 'TaskModuleMessageResponse',
     type: {
         name: 'Composite',
@@ -2187,7 +2187,7 @@ export const TaskModuleMessageResponse: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleResponse: msRest.CompositeMapper = {
+export const TaskModuleResponse: CompositeMapper = {
     serializedName: 'TaskModuleResponse',
     type: {
         name: 'Composite',
@@ -2211,7 +2211,7 @@ export const TaskModuleResponse: msRest.CompositeMapper = {
     },
 };
 
-export const TaskModuleRequestContext: msRest.CompositeMapper = {
+export const TaskModuleRequestContext: CompositeMapper = {
     serializedName: 'TaskModuleRequest_context',
     type: {
         name: 'Composite',
@@ -2227,7 +2227,7 @@ export const TaskModuleRequestContext: msRest.CompositeMapper = {
     },
 };
 
-export const AppBasedLinkQuery: msRest.CompositeMapper = {
+export const AppBasedLinkQuery: CompositeMapper = {
     serializedName: 'AppBasedLinkQuery',
     type: {
         name: 'Composite',
@@ -2249,7 +2249,7 @@ export const AppBasedLinkQuery: msRest.CompositeMapper = {
     },
 };
 
-export const BatchOperationRequest: msRest.CompositeMapper = {
+export const BatchOperationRequest: CompositeMapper = {
     serializedName: 'BatchOperationRequest',
     type: {
         name: 'Composite',
@@ -2312,7 +2312,7 @@ export const BatchOperationRequest: msRest.CompositeMapper = {
     },
 };
 
-export const BatchOperationResponse: msRest.CompositeMapper = {
+export const BatchOperationResponse: CompositeMapper = {
     serializedName: 'BatchOperationResponse',
     type: {
         name: 'Composite',
@@ -2328,7 +2328,7 @@ export const BatchOperationResponse: msRest.CompositeMapper = {
     },
 };
 
-export const GetTeamsOperationStateResponse: msRest.CompositeMapper = {
+export const GetTeamsOperationStateResponse: CompositeMapper = {
     serializedName: 'GetTeamsOperationStateResponse',
     type: {
         name: 'Composite',
@@ -2367,7 +2367,7 @@ export const GetTeamsOperationStateResponse: msRest.CompositeMapper = {
     },
 };
 
-export const GetTeamsFailedEntriesResponse: msRest.CompositeMapper = {
+export const GetTeamsFailedEntriesResponse: CompositeMapper = {
     serializedName: 'BatchFailedEntriesResponse',
     type: {
         name: 'Composite',
@@ -2409,7 +2409,7 @@ export const GetTeamsFailedEntriesResponse: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMember: msRest.CompositeMapper = {
+export const TeamsMember: CompositeMapper = {
     serializedName: 'TeamsMember',
     type: {
         name: 'Composite',

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { CompositeMapper } from "@azure/core-http"
+import { CompositeMapper } from '@azure/core-http';
 
 export const ChannelInfo: CompositeMapper = {
     serializedName: 'ChannelInfo',

--- a/libraries/botframework-connector/src/teams/models/parameters.ts
+++ b/libraries/botframework-connector/src/teams/models/parameters.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from '@azure/ms-rest-js';
+import { OperationURLParameter, OperationQueryParameter } from "@azure/core-http"
 
-export const teamId: msRest.OperationURLParameter = {
+export const teamId: OperationURLParameter = {
     parameterPath: 'teamId',
     mapper: {
         required: true,
@@ -16,7 +16,7 @@ export const teamId: msRest.OperationURLParameter = {
     },
 };
 
-export const meetingId: msRest.OperationURLParameter = {
+export const meetingId: OperationURLParameter = {
     parameterPath: 'meetingId',
     mapper: {
         required: true,
@@ -27,7 +27,7 @@ export const meetingId: msRest.OperationURLParameter = {
     },
 };
 
-export const participantId: msRest.OperationURLParameter = {
+export const participantId: OperationURLParameter = {
     parameterPath: 'participantId',
     mapper: {
         required: true,
@@ -38,7 +38,7 @@ export const participantId: msRest.OperationURLParameter = {
     },
 };
 
-export const tenantId: msRest.OperationQueryParameter = {
+export const tenantId: OperationQueryParameter = {
     parameterPath: ['options', 'tenantId'],
     mapper: {
         serializedName: 'tenantId',
@@ -48,7 +48,7 @@ export const tenantId: msRest.OperationQueryParameter = {
     },
 };
 
-export const operationId: msRest.OperationURLParameter = {
+export const operationId: OperationURLParameter = {
     parameterPath: 'operationId',
     mapper: {
         serializedName: 'operationId',

--- a/libraries/botframework-connector/src/teams/models/parameters.ts
+++ b/libraries/botframework-connector/src/teams/models/parameters.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OperationURLParameter, OperationQueryParameter } from "@azure/core-http"
+import { OperationURLParameter, OperationQueryParameter } from '@azure/core-http';
 
 export const teamId: OperationURLParameter = {
     parameterPath: 'teamId',

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from '@azure/ms-rest-js';
+import { ServiceCallback, RequestOptionsBase, Serializer, OperationSpec } from "@azure/core-http"
 import * as Models from '../models';
 import * as Mappers from '../models/teamsMappers';
 import * as Parameters from '../models/parameters';
@@ -47,7 +47,7 @@ export class Teams {
      */
     fetchChannelList(
         teamId: string,
-        options?: msRest.RequestOptionsBase
+        options?: RequestOptionsBase
     ): Promise<Models.TeamsFetchChannelListResponse>;
     /**
      * Fetches channel list for a given team.
@@ -55,7 +55,7 @@ export class Teams {
      * @param teamId Team Id.
      * @param callback The callback.
      */
-    fetchChannelList(teamId: string, callback: msRest.ServiceCallback<ConversationList>): void;
+    fetchChannelList(teamId: string, callback: ServiceCallback<ConversationList>): void;
     /**
      * Fetches channel list for a given team.
      *
@@ -65,8 +65,8 @@ export class Teams {
      */
     fetchChannelList(
         teamId: string,
-        options: msRest.RequestOptionsBase,
-        callback: msRest.ServiceCallback<ConversationList>
+        options: RequestOptionsBase,
+        callback: ServiceCallback<ConversationList>
     ): void;
     /**
      * Fetches channel list for a given team.
@@ -78,8 +78,8 @@ export class Teams {
      */
     fetchChannelList(
         teamId: string,
-        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<ConversationList>,
-        callback?: msRest.ServiceCallback<ConversationList>
+        options?: RequestOptionsBase | ServiceCallback<ConversationList>,
+        callback?: ServiceCallback<ConversationList>
     ): Promise<Models.TeamsFetchChannelListResponse> {
         return this.client.sendOperationRequest(
             {
@@ -100,7 +100,7 @@ export class Teams {
      */
     fetchTeamDetails(
         teamId: string,
-        options?: msRest.RequestOptionsBase
+        options?: RequestOptionsBase
     ): Promise<Models.TeamsFetchTeamDetailsResponse>;
     /**
      * Fetches details related to a team.
@@ -108,7 +108,7 @@ export class Teams {
      * @param teamId Team Id.
      * @param callback The callback.
      */
-    fetchTeamDetails(teamId: string, callback: msRest.ServiceCallback<TeamDetails>): void;
+    fetchTeamDetails(teamId: string, callback: ServiceCallback<TeamDetails>): void;
     /**
      * Fetches details related to a team.
      *
@@ -118,8 +118,8 @@ export class Teams {
      */
     fetchTeamDetails(
         teamId: string,
-        options: msRest.RequestOptionsBase,
-        callback: msRest.ServiceCallback<TeamDetails>
+        options: RequestOptionsBase,
+        callback: ServiceCallback<TeamDetails>
     ): void;
     /**
      * Fetches details related to a team.
@@ -131,8 +131,8 @@ export class Teams {
      */
     fetchTeamDetails(
         teamId: string,
-        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
-        callback?: msRest.ServiceCallback<TeamDetails>
+        options?: RequestOptionsBase | ServiceCallback<TeamDetails>,
+        callback?: ServiceCallback<TeamDetails>
     ): Promise<Models.TeamsFetchTeamDetailsResponse> {
         return this.client.sendOperationRequest(
             {
@@ -166,7 +166,7 @@ export class Teams {
     fetchMeetingParticipant(
         meetingId: string,
         participantId: string,
-        callback: msRest.ServiceCallback<TeamsMeetingParticipant>
+        callback: ServiceCallback<TeamsMeetingParticipant>
     ): void;
     /**
      * @param meetingId Meeting Id
@@ -178,7 +178,7 @@ export class Teams {
         meetingId: string,
         participantId: string,
         options: Models.TeamsFetchMeetingParticipantOptionalParams,
-        callback: msRest.ServiceCallback<TeamsMeetingParticipant>
+        callback: ServiceCallback<TeamsMeetingParticipant>
     ): void;
     /**
      * @param meetingId Meeting Id.
@@ -190,8 +190,8 @@ export class Teams {
     fetchMeetingParticipant(
         meetingId: string,
         participantId: string,
-        options?: Models.TeamsFetchMeetingParticipantOptionalParams | msRest.ServiceCallback<TeamsMeetingParticipant>,
-        callback?: msRest.ServiceCallback<TeamsMeetingParticipant>
+        options?: Models.TeamsFetchMeetingParticipantOptionalParams | ServiceCallback<TeamsMeetingParticipant>,
+        callback?: ServiceCallback<TeamsMeetingParticipant>
     ): Promise<Models.TeamsFetchMeetingParticipantResponse> {
         return this.client.sendOperationRequest(
             {
@@ -214,7 +214,7 @@ export class Teams {
      */
     fetchMeetingInfo(
         meetingId: string,
-        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>
+        options?: RequestOptionsBase | ServiceCallback<TeamDetails>
     ): Promise<Models.TeamsMeetingInfoResponse>;
     /**
      * @param meetingId Meeting Id, encoded as a BASE64 string.
@@ -222,7 +222,7 @@ export class Teams {
      */
     fetchMeetingInfo(
         meetingId: string,
-        callback: msRest.ServiceCallback<TeamsMeetingInfo>
+        callback: ServiceCallback<TeamsMeetingInfo>
     ): void;
     /**
      * @param meetingId Meeting Id, encoded as a BASE64 string.
@@ -231,8 +231,8 @@ export class Teams {
      */
     fetchMeetingInfo(
         meetingId: string,
-        options: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
-        callback: msRest.ServiceCallback<TeamsMeetingInfo>
+        options: RequestOptionsBase | ServiceCallback<TeamDetails>,
+        callback: ServiceCallback<TeamsMeetingInfo>
     ): void;
     /**
      * @param meetingId Meeting Id.
@@ -242,8 +242,8 @@ export class Teams {
      */
     fetchMeetingInfo(
         meetingId: string,
-        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
-        callback?: msRest.ServiceCallback<TeamsMeetingInfo>
+        options?: RequestOptionsBase | ServiceCallback<TeamDetails>,
+        callback?: ServiceCallback<TeamsMeetingInfo>
     ): Promise<Models.TeamsMeetingInfoResponse> {
         return this.client.sendOperationRequest(
             {
@@ -265,7 +265,7 @@ export class Teams {
     sendMeetingNotification(
         meetingId: string,
         notification: MeetingNotification,
-        options?: msRest.RequestOptionsBase,
+        options?: RequestOptionsBase,
     ): Promise<Models.TeamsMeetingNotificationResponse>
     /**
      * @param meetingId Meeting Id.
@@ -275,7 +275,7 @@ export class Teams {
     sendMeetingNotification(
         meetingId: string,
         notification: MeetingNotification,
-        callback: msRest.ServiceCallback<MeetingNotificationResponse>
+        callback: ServiceCallback<MeetingNotificationResponse>
     ): void;
     /**
      * @param meetingId Meeting Id.
@@ -286,8 +286,8 @@ export class Teams {
     sendMeetingNotification(
         meetingId: string,
         notification: MeetingNotification,
-        options: msRest.RequestOptionsBase,
-        callback: msRest.ServiceCallback<MeetingNotificationResponse>
+        options: RequestOptionsBase,
+        callback: ServiceCallback<MeetingNotificationResponse>
     ): void;
     /**
      * @param meetingId Meeting Id.
@@ -299,8 +299,8 @@ export class Teams {
     sendMeetingNotification(
         meetingId: string,
         notification: MeetingNotification,
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<MeetingNotificationResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<MeetingNotificationResponse>
     ): Promise<Models.TeamsMeetingNotificationResponse> {
         return this.client.sendOperationRequest(
             {
@@ -328,8 +328,8 @@ export class Teams {
         activity: Activity,
         tenantId: string,
         members: TeamsMember[],
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchOperationResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchOperationResponse>
     ): Promise<Models.TeamsBatchOperationResponse> {
         const content = {
             activity,
@@ -358,8 +358,8 @@ export class Teams {
     sendMessageToAllUsersInTenant(
         activity: Activity,
         tenantId: string,
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchOperationResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchOperationResponse>
     ): Promise<Models.TeamsBatchOperationResponse> {
         const content = {
             activity,
@@ -389,8 +389,8 @@ export class Teams {
         activity: Activity,
         tenantId: string,
         teamId: string,
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchOperationResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchOperationResponse>
     ): Promise<Models.TeamsBatchOperationResponse> {
         const content = {
             activity,
@@ -421,8 +421,8 @@ export class Teams {
         activity: Activity,
         tenantId: string,
         members: TeamsMember[],
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchOperationResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchOperationResponse>
     ): Promise<Models.TeamsBatchOperationResponse> {
         const content = {
             activity,
@@ -449,8 +449,8 @@ export class Teams {
      */
     getOperationState(
         operationId: string,
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchOperationStateResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchOperationStateResponse>
     ): Promise<Models.BatchBatchOperationStateResponse> {
         return retryAction(() => this.client.sendOperationRequest(
             {
@@ -472,8 +472,8 @@ export class Teams {
      */
     getOperationFailedEntries(
         operationId: string,
-        options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<BatchFailedEntriesResponse>
+        options?: RequestOptionsBase,
+        callback?: ServiceCallback<BatchFailedEntriesResponse>
     ): Promise<Models.BatchBatchFailedEntriesResponse> {
         return retryAction(() => this.client.sendOperationRequest(
             {
@@ -494,7 +494,7 @@ export class Teams {
      */
     cancelOperation(
         operationId: string,
-        options?: msRest.RequestOptionsBase,
+        options?: RequestOptionsBase,
     ): Promise<Models.CancelOperationResponse> {
         return retryAction(() => this.client.sendOperationRequest(
             {
@@ -507,8 +507,8 @@ export class Teams {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const fetchChannelListOperationSpec: msRest.OperationSpec = {
+const serializer = new Serializer(Mappers);
+const fetchChannelListOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v3/teams/{teamId}/conversations',
     urlParameters: [Parameters.teamId],
@@ -521,7 +521,7 @@ const fetchChannelListOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const fetchTeamDetailsOperationSpec: msRest.OperationSpec = {
+const fetchTeamDetailsOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v3/teams/{teamId}',
     urlParameters: [Parameters.teamId],
@@ -534,7 +534,7 @@ const fetchTeamDetailsOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const fetchMeetingParticipantOperationSpec: msRest.OperationSpec = {
+const fetchMeetingParticipantOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v1/meetings/{meetingId}/participants/{participantId}',
     urlParameters: [Parameters.meetingId, Parameters.participantId],
@@ -548,7 +548,7 @@ const fetchMeetingParticipantOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const fetchMeetingInfoOperationSpec: msRest.OperationSpec = {
+const fetchMeetingInfoOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v1/meetings/{meetingId}',
     urlParameters: [Parameters.meetingId],
@@ -561,7 +561,7 @@ const fetchMeetingInfoOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const sendMeetingNotificationOperationSpec: msRest.OperationSpec = {
+const sendMeetingNotificationOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'v1/meetings/{meetingId}/notification',
     urlParameters: [Parameters.meetingId],
@@ -586,7 +586,7 @@ const sendMeetingNotificationOperationSpec: msRest.OperationSpec = {
     serializer
 }
 
-const sendMessageToListOfUsersOperationSpec: msRest.OperationSpec = {
+const sendMessageToListOfUsersOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'v3/batch/conversation/users',
     requestBody: {
@@ -607,7 +607,7 @@ const sendMessageToListOfUsersOperationSpec: msRest.OperationSpec = {
     serializer
 }
 
-const sendMessageToAllUsersInTenantOperationSpec: msRest.OperationSpec = {
+const sendMessageToAllUsersInTenantOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'v3/batch/conversation/tenant',
     requestBody: {
@@ -628,7 +628,7 @@ const sendMessageToAllUsersInTenantOperationSpec: msRest.OperationSpec = {
     serializer
 }
 
-const sendMessageToAllUsersInTeamOperationSpec: msRest.OperationSpec = {
+const sendMessageToAllUsersInTeamOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'v3/batch/conversation/team',
     requestBody: {
@@ -649,7 +649,7 @@ const sendMessageToAllUsersInTeamOperationSpec: msRest.OperationSpec = {
     serializer
 }
 
-const sendMessageToListOfChannelsOperationSpec: msRest.OperationSpec = {
+const sendMessageToListOfChannelsOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'v3/batch/conversation/channels',
     requestBody: {
@@ -670,7 +670,7 @@ const sendMessageToListOfChannelsOperationSpec: msRest.OperationSpec = {
     serializer
 }
 
-const getOperationStateSpec: msRest.OperationSpec = {
+const getOperationStateSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v3/batch/conversation/{operationId}',
     urlParameters: [Parameters.operationId],
@@ -685,7 +685,7 @@ const getOperationStateSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const getPagedFailedEntriesSpec: msRest.OperationSpec = {
+const getPagedFailedEntriesSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'v3/batch/conversation/failedentries/{operationId}',
     urlParameters: [Parameters.operationId],
@@ -700,7 +700,7 @@ const getPagedFailedEntriesSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const cancelOperationSpec: msRest.OperationSpec = {
+const cancelOperationSpec: OperationSpec = {
     httpMethod: 'DELETE',
     path: 'v3/batch/conversation/{operationId}',
     urlParameters: [Parameters.operationId],

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License.
  */
 
-import { ServiceCallback, RequestOptionsBase, Serializer, OperationSpec } from "@azure/core-http"
+import { ServiceCallback, RequestOptionsBase, Serializer, OperationSpec } from '@azure/core-http'
 import * as Models from '../models';
 import * as Mappers from '../models/teamsMappers';
 import * as Parameters from '../models/parameters';

--- a/libraries/botframework-connector/src/teams/teamsConnectorClient.ts
+++ b/libraries/botframework-connector/src/teams/teamsConnectorClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentials } from '@azure/core-http';
 import * as Models from './models';
 import * as Mappers from './models/mappers';
 import * as operations from './operations';

--- a/libraries/botframework-connector/src/teams/teamsConnectorClientContext.ts
+++ b/libraries/botframework-connector/src/teams/teamsConnectorClientContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ServiceClientCredentials, ServiceClient } from '@azure/ms-rest-js';
+import { ServiceClientCredentials, ServiceClient } from '@azure/core-http';
 import { TeamsConnectorClientOptions } from './models';
 
 /**

--- a/libraries/botframework-connector/src/tokenApi/models/index.ts
+++ b/libraries/botframework-connector/src/tokenApi/models/index.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ServiceClientOptions } from "@azure/ms-rest-js";
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceClientOptions, RequestOptionsBase, HttpResponse } from "@azure/core-http";
 import { SignInUrlResponse, TokenResponse, TokenStatus } from "botframework-schema";
 
 /**
@@ -82,7 +81,7 @@ export interface TokenApiClientOptions extends ServiceClientOptions {
  *
  * @extends RequestOptionsBase
  */
-export interface BotSignInGetSignInUrlOptionalParams extends msRest.RequestOptionsBase {
+export interface BotSignInGetSignInUrlOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [codeChallenge]
    */
@@ -104,7 +103,7 @@ export interface BotSignInGetSignInUrlOptionalParams extends msRest.RequestOptio
  *
  * @extends RequestOptionsBase
  */
-export interface BotSignInGetSignInResourceOptionalParams extends msRest.RequestOptionsBase {
+export interface BotSignInGetSignInResourceOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [codeChallenge]
    */
@@ -126,7 +125,7 @@ export interface BotSignInGetSignInResourceOptionalParams extends msRest.Request
  *
  * @extends RequestOptionsBase
  */
-export interface UserTokenGetTokenOptionalParams extends msRest.RequestOptionsBase {
+export interface UserTokenGetTokenOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [channelId]
    */
@@ -144,7 +143,7 @@ export interface UserTokenGetTokenOptionalParams extends msRest.RequestOptionsBa
  *
  * @extends RequestOptionsBase
  */
-export interface UserTokenGetAadTokensOptionalParams extends msRest.RequestOptionsBase {
+export interface UserTokenGetAadTokensOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [channelId]
    */
@@ -158,7 +157,7 @@ export interface UserTokenGetAadTokensOptionalParams extends msRest.RequestOptio
  *
  * @extends RequestOptionsBase
  */
-export interface UserTokenSignOutOptionalParams extends msRest.RequestOptionsBase {
+export interface UserTokenSignOutOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [connectionName]
    */
@@ -176,7 +175,7 @@ export interface UserTokenSignOutOptionalParams extends msRest.RequestOptionsBas
  *
  * @extends RequestOptionsBase
  */
-export interface UserTokenGetTokenStatusOptionalParams extends msRest.RequestOptionsBase {
+export interface UserTokenGetTokenStatusOptionalParams extends RequestOptionsBase {
   /**
    * @member {string} [channelId]
    */
@@ -198,16 +197,16 @@ export type BotSignInGetSignInUrlResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: string;
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: string;
+  };
 };
 
 /**
@@ -217,16 +216,16 @@ export type BotSignInGetSignInResourceResponse = SignInUrlResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: SignInUrlResponse;
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: SignInUrlResponse;
+  };
 };
 
 /**
@@ -236,16 +235,16 @@ export type UserTokenGetTokenResponse = TokenResponse & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: TokenResponse;
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: TokenResponse;
+  };
 };
 
 /**
@@ -260,16 +259,16 @@ export type UserTokenGetAadTokensResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: { [propertyName: string]: TokenResponse };
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: { [propertyName: string]: TokenResponse };
+  };
 };
 
 /**
@@ -283,16 +282,16 @@ export type UserTokenSignOutResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: any;
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: any;
+  };
 };
 
 /**
@@ -302,16 +301,16 @@ export type UserTokenGetTokenStatusResponse = Array<TokenStatus> & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: TokenStatus[];
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: TokenStatus[];
+  };
 };
 
 /**
@@ -325,14 +324,14 @@ export type UserTokenExchangeAsyncResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: any;
-    };
+  _response: HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: any;
+  };
 };

--- a/libraries/botframework-connector/src/tokenApi/models/mappers.ts
+++ b/libraries/botframework-connector/src/tokenApi/models/mappers.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { CompositeMapper } from "@azure/core-http";
 
-
-export const TokenExchangeResource: msRest.CompositeMapper = {
+export const TokenExchangeResource: CompositeMapper = {
   serializedName: "TokenExchangeResource",
   type: {
     name: "Composite",
@@ -34,7 +33,7 @@ export const TokenExchangeResource: msRest.CompositeMapper = {
   }
 };
 
-export const SignInUrlResponse: msRest.CompositeMapper = {
+export const SignInUrlResponse: CompositeMapper = {
   serializedName: "SignInUrlResponse",
   type: {
     name: "Composite",
@@ -57,7 +56,7 @@ export const SignInUrlResponse: msRest.CompositeMapper = {
   }
 };
 
-export const TokenResponse: msRest.CompositeMapper = {
+export const TokenResponse: CompositeMapper = {
   serializedName: "TokenResponse",
   type: {
     name: "Composite",
@@ -91,7 +90,7 @@ export const TokenResponse: msRest.CompositeMapper = {
   }
 };
 
-export const InnerHttpError: msRest.CompositeMapper = {
+export const InnerHttpError: CompositeMapper = {
   serializedName: "InnerHttpError",
   type: {
     name: "Composite",
@@ -113,7 +112,7 @@ export const InnerHttpError: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorModel: msRest.CompositeMapper = {
+export const ErrorModel: CompositeMapper = {
   serializedName: "Error",
   type: {
     name: "Composite",
@@ -142,7 +141,7 @@ export const ErrorModel: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorResponse: msRest.CompositeMapper = {
+export const ErrorResponse: CompositeMapper = {
   serializedName: "ErrorResponse",
   type: {
     name: "Composite",
@@ -159,7 +158,7 @@ export const ErrorResponse: msRest.CompositeMapper = {
   }
 };
 
-export const AadResourceUrls: msRest.CompositeMapper = {
+export const AadResourceUrls: CompositeMapper = {
   serializedName: "AadResourceUrls",
   type: {
     name: "Composite",
@@ -180,7 +179,7 @@ export const AadResourceUrls: msRest.CompositeMapper = {
   }
 };
 
-export const TokenStatus: msRest.CompositeMapper = {
+export const TokenStatus: CompositeMapper = {
   serializedName: "TokenStatus",
   type: {
     name: "Composite",
@@ -214,7 +213,7 @@ export const TokenStatus: msRest.CompositeMapper = {
   }
 };
 
-export const TokenExchangeRequest: msRest.CompositeMapper = {
+export const TokenExchangeRequest: CompositeMapper = {
   serializedName: "TokenExchangeRequest",
   type: {
     name: "Composite",

--- a/libraries/botframework-connector/src/tokenApi/models/parameters.ts
+++ b/libraries/botframework-connector/src/tokenApi/models/parameters.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { OperationQueryParameter } from "@azure/core-http"
 
-export const channelId0: msRest.OperationQueryParameter = {
+export const channelId0: OperationQueryParameter = {
   parameterPath: [
     "options",
     "channelId"
@@ -17,7 +17,7 @@ export const channelId0: msRest.OperationQueryParameter = {
     }
   }
 };
-export const channelId1: msRest.OperationQueryParameter = {
+export const channelId1: OperationQueryParameter = {
   parameterPath: "channelId",
   mapper: {
     required: true,
@@ -27,7 +27,7 @@ export const channelId1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const code: msRest.OperationQueryParameter = {
+export const code: OperationQueryParameter = {
   parameterPath: [
     "options",
     "code"
@@ -39,7 +39,7 @@ export const code: msRest.OperationQueryParameter = {
     }
   }
 };
-export const codeChallenge: msRest.OperationQueryParameter = {
+export const codeChallenge: OperationQueryParameter = {
   parameterPath: [
     "options",
     "codeChallenge"
@@ -51,7 +51,7 @@ export const codeChallenge: msRest.OperationQueryParameter = {
     }
   }
 };
-export const connectionName0: msRest.OperationQueryParameter = {
+export const connectionName0: OperationQueryParameter = {
   parameterPath: "connectionName",
   mapper: {
     required: true,
@@ -61,7 +61,7 @@ export const connectionName0: msRest.OperationQueryParameter = {
     }
   }
 };
-export const connectionName1: msRest.OperationQueryParameter = {
+export const connectionName1: OperationQueryParameter = {
   parameterPath: [
     "options",
     "connectionName"
@@ -73,7 +73,7 @@ export const connectionName1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const emulatorUrl: msRest.OperationQueryParameter = {
+export const emulatorUrl: OperationQueryParameter = {
   parameterPath: [
     "options",
     "emulatorUrl"
@@ -85,7 +85,7 @@ export const emulatorUrl: msRest.OperationQueryParameter = {
     }
   }
 };
-export const finalRedirect: msRest.OperationQueryParameter = {
+export const finalRedirect: OperationQueryParameter = {
   parameterPath: [
     "options",
     "finalRedirect"
@@ -97,7 +97,7 @@ export const finalRedirect: msRest.OperationQueryParameter = {
     }
   }
 };
-export const include: msRest.OperationQueryParameter = {
+export const include: OperationQueryParameter = {
   parameterPath: [
     "options",
     "include"
@@ -109,7 +109,7 @@ export const include: msRest.OperationQueryParameter = {
     }
   }
 };
-export const state: msRest.OperationQueryParameter = {
+export const state: OperationQueryParameter = {
   parameterPath: "state",
   mapper: {
     required: true,
@@ -119,7 +119,7 @@ export const state: msRest.OperationQueryParameter = {
     }
   }
 };
-export const userId: msRest.OperationQueryParameter = {
+export const userId: OperationQueryParameter = {
   parameterPath: "userId",
   mapper: {
     required: true,

--- a/libraries/botframework-connector/src/tokenApi/operations/botSignIn.ts
+++ b/libraries/botframework-connector/src/tokenApi/operations/botSignIn.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceCallback, Serializer, OperationSpec } from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/botSignInMappers";
 import * as Parameters from "../models/parameters";
@@ -32,14 +32,14 @@ export class BotSignIn {
    * @param state
    * @param callback The callback
    */
-  getSignInUrl(state: string, callback: msRest.ServiceCallback<string>): void;
+  getSignInUrl(state: string, callback: ServiceCallback<string>): void;
   /**
    * @param state
    * @param options The optional parameters
    * @param callback The callback
    */
-  getSignInUrl(state: string, options: Models.BotSignInGetSignInUrlOptionalParams, callback: msRest.ServiceCallback<string>): void;
-  getSignInUrl(state: string, options?: Models.BotSignInGetSignInUrlOptionalParams | msRest.ServiceCallback<string>, callback?: msRest.ServiceCallback<string>): Promise<Models.BotSignInGetSignInUrlResponse> {
+  getSignInUrl(state: string, options: Models.BotSignInGetSignInUrlOptionalParams, callback: ServiceCallback<string>): void;
+  getSignInUrl(state: string, options?: Models.BotSignInGetSignInUrlOptionalParams | ServiceCallback<string>, callback?: ServiceCallback<string>): Promise<Models.BotSignInGetSignInUrlResponse> {
     return this.client.sendOperationRequest(
       {
         state,
@@ -59,14 +59,14 @@ export class BotSignIn {
    * @param state
    * @param callback The callback
    */
-  getSignInResource(state: string, callback: msRest.ServiceCallback<SignInUrlResponse>): void;
+  getSignInResource(state: string, callback: ServiceCallback<SignInUrlResponse>): void;
   /**
    * @param state
    * @param options The optional parameters
    * @param callback The callback
    */
-  getSignInResource(state: string, options: Models.BotSignInGetSignInResourceOptionalParams, callback: msRest.ServiceCallback<SignInUrlResponse>): void;
-  getSignInResource(state: string, options?: Models.BotSignInGetSignInResourceOptionalParams | msRest.ServiceCallback<SignInUrlResponse>, callback?: msRest.ServiceCallback<SignInUrlResponse>): Promise<Models.BotSignInGetSignInResourceResponse> {
+  getSignInResource(state: string, options: Models.BotSignInGetSignInResourceOptionalParams, callback: ServiceCallback<SignInUrlResponse>): void;
+  getSignInResource(state: string, options?: Models.BotSignInGetSignInResourceOptionalParams | ServiceCallback<SignInUrlResponse>, callback?: ServiceCallback<SignInUrlResponse>): Promise<Models.BotSignInGetSignInResourceResponse> {
     return this.client.sendOperationRequest(
       {
         state,
@@ -78,8 +78,8 @@ export class BotSignIn {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getSignInUrlOperationSpec: msRest.OperationSpec = {
+const serializer = new Serializer(Mappers);
+const getSignInUrlOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "api/botsignin/GetSignInUrl",
   queryParameters: [
@@ -102,7 +102,7 @@ const getSignInUrlOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getSignInResourceOperationSpec: msRest.OperationSpec = {
+const getSignInResourceOperationSpec: OperationSpec = {
   httpMethod: "GET",
   path: "api/botsignin/GetSignInResource",
   queryParameters: [

--- a/libraries/botframework-connector/src/tokenApi/operations/userToken.ts
+++ b/libraries/botframework-connector/src/tokenApi/operations/userToken.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from '@azure/ms-rest-js';
+import { ServiceCallback, RequestOptionsBase, Serializer, OperationSpec } from "@azure/core-http";
 import * as Models from '../models';
 import * as Mappers from '../models/userTokenMappers';
 import * as Parameters from '../models/parameters';
@@ -39,7 +39,7 @@ export class UserToken {
      * @param connectionName
      * @param callback The callback
      */
-    getToken(userId: string, connectionName: string, callback: msRest.ServiceCallback<TokenResponse>): void;
+    getToken(userId: string, connectionName: string, callback: ServiceCallback<TokenResponse>): void;
     /**
      * @param userId
      * @param connectionName
@@ -50,13 +50,13 @@ export class UserToken {
         userId: string,
         connectionName: string,
         options: Models.UserTokenGetTokenOptionalParams,
-        callback: msRest.ServiceCallback<TokenResponse>
+        callback: ServiceCallback<TokenResponse>
     ): void;
     getToken(
         userId: string,
         connectionName: string,
-        options?: Models.UserTokenGetTokenOptionalParams | msRest.ServiceCallback<TokenResponse>,
-        callback?: msRest.ServiceCallback<TokenResponse>
+        options?: Models.UserTokenGetTokenOptionalParams | ServiceCallback<TokenResponse>,
+        callback?: ServiceCallback<TokenResponse>
     ): Promise<Models.UserTokenGetTokenResponse> {
         return this.client.sendOperationRequest(
             {
@@ -92,7 +92,7 @@ export class UserToken {
         userId: string,
         connectionName: string,
         aadResourceUrls: Models.AadResourceUrls,
-        callback: msRest.ServiceCallback<{ [propertyName: string]: TokenResponse }>
+        callback: ServiceCallback<{ [propertyName: string]: TokenResponse }>
     ): void;
     /**
      * @param userId
@@ -106,7 +106,7 @@ export class UserToken {
         connectionName: string,
         aadResourceUrls: Models.AadResourceUrls,
         options: Models.UserTokenGetAadTokensOptionalParams,
-        callback: msRest.ServiceCallback<{ [propertyName: string]: TokenResponse }>
+        callback: ServiceCallback<{ [propertyName: string]: TokenResponse }>
     ): void;
     getAadTokens(
         userId: string,
@@ -114,8 +114,8 @@ export class UserToken {
         aadResourceUrls: Models.AadResourceUrls,
         options?:
             | Models.UserTokenGetAadTokensOptionalParams
-            | msRest.ServiceCallback<{ [propertyName: string]: TokenResponse }>,
-        callback?: msRest.ServiceCallback<{ [propertyName: string]: TokenResponse }>
+            | ServiceCallback<{ [propertyName: string]: TokenResponse }>,
+        callback?: ServiceCallback<{ [propertyName: string]: TokenResponse }>
     ): Promise<Models.UserTokenGetAadTokensResponse> {
         return this.client.sendOperationRequest(
             {
@@ -139,7 +139,7 @@ export class UserToken {
      * @param userId
      * @param callback The callback
      */
-    signOut(userId: string, callback: msRest.ServiceCallback<any>): void;
+    signOut(userId: string, callback: ServiceCallback<any>): void;
     /**
      * @param userId
      * @param options The optional parameters
@@ -148,12 +148,12 @@ export class UserToken {
     signOut(
         userId: string,
         options: Models.UserTokenSignOutOptionalParams,
-        callback: msRest.ServiceCallback<any>
+        callback: ServiceCallback<any>
     ): void;
     signOut(
         userId: string,
-        options?: Models.UserTokenSignOutOptionalParams | msRest.ServiceCallback<any>,
-        callback?: msRest.ServiceCallback<any>
+        options?: Models.UserTokenSignOutOptionalParams | ServiceCallback<any>,
+        callback?: ServiceCallback<any>
     ): Promise<Models.UserTokenSignOutResponse> {
         return this.client.sendOperationRequest(
             {
@@ -178,7 +178,7 @@ export class UserToken {
      * @param userId
      * @param callback The callback
      */
-    getTokenStatus(userId: string, callback: msRest.ServiceCallback<TokenStatus[]>): void;
+    getTokenStatus(userId: string, callback: ServiceCallback<TokenStatus[]>): void;
     /**
      * @param userId
      * @param options The optional parameters
@@ -187,12 +187,12 @@ export class UserToken {
     getTokenStatus(
         userId: string,
         options: Models.UserTokenGetTokenStatusOptionalParams,
-        callback: msRest.ServiceCallback<TokenStatus[]>
+        callback: ServiceCallback<TokenStatus[]>
     ): void;
     getTokenStatus(
         userId: string,
-        options?: Models.UserTokenGetTokenStatusOptionalParams | msRest.ServiceCallback<TokenStatus[]>,
-        callback?: msRest.ServiceCallback<TokenStatus[]>
+        options?: Models.UserTokenGetTokenStatusOptionalParams | ServiceCallback<TokenStatus[]>,
+        callback?: ServiceCallback<TokenStatus[]>
     ): Promise<Models.UserTokenGetTokenStatusResponse> {
         return this.client.sendOperationRequest(
             {
@@ -217,7 +217,7 @@ export class UserToken {
         connectionName: string,
         channelId: string,
         exchangeRequest: TokenExchangeRequest,
-        options?: msRest.RequestOptionsBase
+        options?: RequestOptionsBase
     ): Promise<Models.UserTokenExchangeAsyncResponse>;
     /**
      * @param userId
@@ -231,7 +231,7 @@ export class UserToken {
         connectionName: string,
         channelId: string,
         exchangeRequest: TokenExchangeRequest,
-        callback: msRest.ServiceCallback<any>
+        callback: ServiceCallback<any>
     ): void;
     /**
      * @param userId
@@ -246,16 +246,16 @@ export class UserToken {
         connectionName: string,
         channelId: string,
         exchangeRequest: TokenExchangeRequest,
-        options: msRest.RequestOptionsBase,
-        callback: msRest.ServiceCallback<any>
+        options: RequestOptionsBase,
+        callback: ServiceCallback<any>
     ): void;
     exchangeAsync(
         userId: string,
         connectionName: string,
         channelId: string,
         exchangeRequest: TokenExchangeRequest,
-        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<any>,
-        callback?: msRest.ServiceCallback<any>
+        options?: RequestOptionsBase | ServiceCallback<any>,
+        callback?: ServiceCallback<any>
     ): Promise<Models.UserTokenExchangeAsyncResponse> {
         return this.client.sendOperationRequest(
             {
@@ -272,8 +272,8 @@ export class UserToken {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getTokenOperationSpec: msRest.OperationSpec = {
+const serializer = new Serializer(Mappers);
+const getTokenOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'api/usertoken/GetToken',
     queryParameters: [Parameters.userId, Parameters.connectionName0, Parameters.channelId0, Parameters.code],
@@ -291,7 +291,7 @@ const getTokenOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const getAadTokensOperationSpec: msRest.OperationSpec = {
+const getAadTokensOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'api/usertoken/GetAadTokens',
     queryParameters: [Parameters.userId, Parameters.connectionName0, Parameters.channelId0],
@@ -324,7 +324,7 @@ const getAadTokensOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const signOutOperationSpec: msRest.OperationSpec = {
+const signOutOperationSpec: OperationSpec = {
     httpMethod: 'DELETE',
     path: 'api/usertoken/SignOut',
     queryParameters: [Parameters.userId, Parameters.connectionName1, Parameters.channelId0],
@@ -345,7 +345,7 @@ const signOutOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const getTokenStatusOperationSpec: msRest.OperationSpec = {
+const getTokenStatusOperationSpec: OperationSpec = {
     httpMethod: 'GET',
     path: 'api/usertoken/GetTokenStatus',
     queryParameters: [Parameters.userId, Parameters.channelId0, Parameters.include],
@@ -371,7 +371,7 @@ const getTokenStatusOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const exchangeAsyncOperationSpec: msRest.OperationSpec = {
+const exchangeAsyncOperationSpec: OperationSpec = {
     httpMethod: 'POST',
     path: 'api/usertoken/exchange',
     queryParameters: [Parameters.userId, Parameters.connectionName0, Parameters.channelId1],

--- a/libraries/botframework-connector/src/tokenApi/tokenApiClient.ts
+++ b/libraries/botframework-connector/src/tokenApi/tokenApiClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceClientCredentials } from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -19,7 +19,7 @@ class TokenApiClient extends TokenApiClientContext {
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.TokenApiClientOptions) {
+  constructor(credentials: ServiceClientCredentials, options?: Models.TokenApiClientOptions) {
     super(credentials, options);
     this.botSignIn = new operations.BotSignIn(this);
     this.userToken = new operations.UserToken(this);

--- a/libraries/botframework-connector/src/tokenApi/tokenApiClientContext.ts
+++ b/libraries/botframework-connector/src/tokenApi/tokenApiClientContext.ts
@@ -3,18 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import { ServiceClient, ServiceClientCredentials, getDefaultUserAgentValue } from "@azure/core-http";
 import * as Models from "./models";
 
 const packageName = "botframework-Token";
 const packageVersion = "4.0.0";
 
-export class TokenApiClientContext extends msRest.ServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class TokenApiClientContext extends ServiceClient {
+  credentials: ServiceClientCredentials;
 
   // Protects against JSON.stringify leaking secrets
   private toJSON(): unknown {
-      return { name: this.constructor.name };
+    return { name: this.constructor.name };
   }
 
   /**
@@ -22,7 +22,7 @@ export class TokenApiClientContext extends msRest.ServiceClient {
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.TokenApiClientOptions) {
+  constructor(credentials: ServiceClientCredentials, options?: Models.TokenApiClientOptions) {
     if (credentials === null || credentials === undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -30,7 +30,7 @@ export class TokenApiClientContext extends msRest.ServiceClient {
     if (!options) {
       options = {};
     }
-    const defaultUserAgent = msRest.getDefaultUserAgentValue();
+    const defaultUserAgent = getDefaultUserAgentValue();
     options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent} ${options.userAgent || ''}`;
 
     super(credentials, options);

--- a/libraries/botframework-connector/tests/appCredentials.test.js
+++ b/libraries/botframework-connector/tests/appCredentials.test.js
@@ -5,7 +5,7 @@
 
 const { AuthenticationConstants, CertificateAppCredentials, MicrosoftAppCredentials } = require('../');
 const { ok: assert, strictEqual } = require('assert');
-const { WebResource } = require('@azure/ms-rest-js');
+const { WebResource } = require('@azure/core-http');
 
 const APP_ID = '2cd87869-38a0-4182-9251-d056e8f0ac24';
 const APP_PASSWORD = 'password';

--- a/libraries/botframework-connector/tests/botFrameworkAuthenticationFactory.test.js
+++ b/libraries/botframework-connector/tests/botFrameworkAuthenticationFactory.test.js
@@ -11,7 +11,7 @@ const {
     PasswordServiceClientCredentialFactory,
     SkillValidation,
 } = require('..');
-const { HttpHeaders } = require('@azure/ms-rest-js');
+const { HttpHeaders } = require('@azure/core-http');
 
 describe('BotFrameworkAuthenticationFactory', function () {
     it('should create anonymous BotFrameworkAuthentication', function () {

--- a/libraries/botframework-connector/tests/ms-rest-mappers-test.js
+++ b/libraries/botframework-connector/tests/ms-rest-mappers-test.js
@@ -1,13 +1,13 @@
-const msRest = require('@azure/ms-rest-js');
+const { Serializer } = require('@azure/core-http');
 const Mappers = require('../lib/connectorApi/models/mappers');
-const Serializer = new msRest.Serializer({ Activity: Mappers.Activity, Entity: Mappers.Entity });
+const serializer = new Serializer({ Activity: Mappers.Activity, Entity: Mappers.Entity });
 const assert = require('assert');
 
 describe('serialize', function () {
     const entity = [{ type: 'mention', keyone: 'valueOne', keytwo: { keythree: 'valueThree' } }];
     const activity = { type: 'message', entities: entity };
     it('should retain custom Entity properties', function () {
-        const serializedObject = Serializer.serialize(Mappers.Activity, activity);
+        const serializedObject = serializer.serialize(Mappers.Activity, activity);
         assert.deepStrictEqual(serializedObject.entities, entity);
     });
 });

--- a/libraries/tests.uischema
+++ b/libraries/tests.uischema
@@ -8,7 +8,8 @@
         "triggers",
         "generator",
         "selector",
-        "schema"
+        "schema",
+        "dialogs"
       ],
       "label": "Adaptive dialog",
       "order": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",
-    "@azure/ms-rest-js": "^2.7.0",
     "@microsoft/api-extractor": "^7.15.1",
     "@standardlabs/downlevel-dts": "^0.7.5",
     "@standardlabs/is-private": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "**/botbuilder-azure/@azure/core-auth/@azure/core-tracing": "1.0.0-preview.9",
     "**/request/tough-cookie": "^4.1.3",
     "**/request-promise/tough-cookie": "^4.1.3",
-    "**/request-promise-native/tough-cookie": "^4.1.3"
+    "**/request-promise-native/tough-cookie": "^4.1.3",
+    "@azure/core-util": "1.5.0"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,31 +9,23 @@
   dependencies:
     tslib "^1.9.3"
 
-"@azure/cognitiveservices-luis-runtime@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-4.0.1.tgz#7c49b0a98af2b3d1c76e2fee64b1270769de1b25"
-  integrity sha512-W5oDt1LvJQmtxCIDq1aFh8R4W+5ZKSTC+9So9DIGVZmy29SMxBNyTf8OTliHDv0L+P6Y2XBySoGCliPYfTyrhQ==
-  dependencies:
-    "@azure/ms-rest-js" "^2.0.3"
-    tslib "^1.10.0"
-
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz#dcccebb88406e5c76e0e1d52e8cc4c43a68b3ee7"
   integrity sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
 
-"@azure/core-auth@^1.1.4", "@azure/core-auth@^1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
-  integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    tslib "^2.2.0"
-
 "@azure/core-auth@^1.2.0", "@azure/core-auth@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.4.0.tgz#6fa9661c1705857820dbc216df5ba5665ac36a9e"
   integrity sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-auth@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
+  integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.2.0"
@@ -221,20 +213,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
-
-"@azure/ms-rest-js@^2.0.3", "@azure/ms-rest-js@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz#8639065577ffdf4946951e1d246334ebfd72d537"
-  integrity sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==
-  dependencies:
-    "@azure/core-auth" "^1.1.4"
-    abort-controller "^3.0.0"
-    form-data "^2.5.0"
-    node-fetch "^2.6.7"
-    tslib "^1.10.0"
-    tunnel "0.0.6"
-    uuid "^8.3.2"
-    xml2js "^0.5.0"
 
 "@azure/msal-browser@^2.16.0":
   version "2.17.0"
@@ -2675,13 +2653,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 accepts@^1.3.7, accepts@~1.3.8:
   version "1.3.8"
@@ -5885,11 +5856,6 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^3.0.0:
   version "3.2.0"
@@ -13043,7 +13009,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -13080,7 +13046,7 @@ tty-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
-tunnel@0.0.6, tunnel@^0.0.6:
+tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,27 @@
   dependencies:
     tslib "^1.9.3"
 
+"@azure/cognitiveservices-luis-runtime@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-4.0.1.tgz#7c49b0a98af2b3d1c76e2fee64b1270769de1b25"
+  integrity sha512-W5oDt1LvJQmtxCIDq1aFh8R4W+5ZKSTC+9So9DIGVZmy29SMxBNyTf8OTliHDv0L+P6Y2XBySoGCliPYfTyrhQ==
+  dependencies:
+    "@azure/ms-rest-js" "^2.0.3"
+    tslib "^1.10.0"
+
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz#dcccebb88406e5c76e0e1d52e8cc4c43a68b3ee7"
   integrity sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
+
+"@azure/core-auth@^1.1.4":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.5.0.tgz#a41848c5c31cb3b7c84c409885267d55a2c92e44"
+  integrity sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-util" "^1.1.0"
+    tslib "^2.2.0"
 
 "@azure/core-auth@^1.2.0", "@azure/core-auth@^1.4.0":
   version "1.4.0"
@@ -127,22 +144,7 @@
     "@opentelemetry/api" "^0.10.2"
     tslib "^2.0.0"
 
-"@azure/core-util@^1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.0.0-beta.1.tgz#2efd2c74b4b0a38180369f50fe274a3c4cd36e98"
-  integrity sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==
-  dependencies:
-    tslib "^2.0.0"
-
-"@azure/core-util@^1.1.1":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.3.2.tgz#3f8cfda1e87fac0ce84f8c1a42fcd6d2a986632d"
-  integrity sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    tslib "^2.2.0"
-
-"@azure/core-util@^1.2.0":
+"@azure/core-util@1.5.0", "@azure/core-util@^1.0.0-beta.1", "@azure/core-util@^1.1.0", "@azure/core-util@^1.1.1", "@azure/core-util@^1.2.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.5.0.tgz#ffe49c3e867044da67daeb8122143fa065e1eb0e"
   integrity sha512-GZBpVFDtQ/15hW1OgBcRdT4Bl7AEpcEZqLfbAvOtm1CQUncKWiYapFHVD588hmlV27NbOOtSm3cnLF3lvoHi4g==
@@ -213,6 +215,20 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
+
+"@azure/ms-rest-js@^2.0.3", "@azure/ms-rest-js@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz#8639065577ffdf4946951e1d246334ebfd72d537"
+  integrity sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==
+  dependencies:
+    "@azure/core-auth" "^1.1.4"
+    abort-controller "^3.0.0"
+    form-data "^2.5.0"
+    node-fetch "^2.6.7"
+    tslib "^1.10.0"
+    tunnel "0.0.6"
+    uuid "^8.3.2"
+    xml2js "^0.5.0"
 
 "@azure/msal-browser@^2.16.0":
   version "2.17.0"
@@ -2653,6 +2669,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@^1.3.7, accepts@~1.3.8:
   version "1.3.8"
@@ -5856,6 +5879,11 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^3.0.0:
   version "3.2.0"
@@ -13009,7 +13037,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -13046,7 +13074,7 @@ tty-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
-tunnel@^0.0.6:
+tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==


### PR DESCRIPTION
#minor

## Description
This PR replaces the uses of **_@azure/ms-rest-js_** in the following botbuilder-js libraries.

- [ ] botbuilder
- [ ] botbuilder-ai
- [x] botframework-connector
- [ ] tool

## Specific Changes
  - Replaced the **_@azure/ms-rest-js_** imports with **_@azure/core-http_**.
  - Added **_@azure/core-http_** to libraries package.json.
  - Added **_@azure/core-util_** version 1.5.0 to resolutions.
  - Updated unit tests to work with core-http **_RestError_** class.

## Testing
The following image shows some samples working after the update.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/44ada9a4-ee05-4bef-859b-f7d1122a06ac)
![image](https://github.com/southworks/botbuilder-js/assets/122501764/62c877d0-5cdb-4067-bf2b-ca3798a3f08f)
