### PR TITLE
fix: [#4470] Migrate off @azure/ms-rest-js tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",
-    "@azure/ms-rest-js": "^2.7.0",
     "@microsoft/api-extractor": "^7.15.1",
     "@standardlabs/downlevel-dts": "^0.7.5",
     "@standardlabs/is-private": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "**/botbuilder-azure/@azure/core-auth/@azure/core-tracing": "1.0.0-preview.9",
     "**/request/tough-cookie": "^4.1.3",
     "**/request-promise/tough-cookie": "^4.1.3",
-    "**/request-promise-native/tough-cookie": "^4.1.3"
+    "**/request-promise-native/tough-cookie": "^4.1.3",
+    "@azure/core-util": "1.5.0"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/tools/framework/suite-base.js
+++ b/tools/framework/suite-base.js
@@ -21,11 +21,11 @@ var sinon = require('sinon');
 var _ = require('underscore');
 var util = require('util');
 var uuid = require('uuid');
-var msRest = require('@azure/ms-rest-js');
-var identity = require('@azure/identity');
-var { Environment } = require('@azure/ms-rest-azure-env');
+var { TokenCredentials } = require('botframework-connector');
 var MicrosoftAppCredentials = require('botframework-connector/lib/auth/microsoftAppCredentials');
 var TokenApiClient = require('botframework-connector/lib/tokenApi/tokenApiClient');
+var identity = require('@azure/identity');
+var { Environment } = require('@azure/ms-rest-azure-env');
 var FileTokenCache = require('../util/fileTokenCache');
 var MockTokenCache = require('./mock-token-cache');
 var nockHelper = require('./nock-helper');
@@ -59,7 +59,7 @@ function SuiteBase(mochaSuiteObject, testPrefix, env, libraryPath) {
     this.mockServerClient;
     this.currentTest = '';
     //Recording info
-    this.setRecordingsDirectory(path.join(__dirname, '../../', `libraries/${ libraryPath }/tests/recordings/`));
+    this.setRecordingsDirectory(path.join(__dirname, '../../', `libraries/${libraryPath}/tests/recordings/`));
     this.suiteRecordingsFile = this.getRecordingsDirectory() + 'suite.' + this.testPrefix + '.nock.js';
     //test modes
     // dotenv reads booleans as strings, so we'll use ternary statements to conver to boolean
@@ -74,7 +74,7 @@ function SuiteBase(mochaSuiteObject, testPrefix, env, libraryPath) {
     this.username = process.env['AZURE_USERNAME'] || 'username@example.com';
     this.password = process.env['AZURE_PASSWORD'] || 'dummypassword';
     this.secret = process.env['CLIENT_SECRET'] || 'dummysecret';
-    const clientApplication = new msal.PublicClientApplication({auth: {}});
+    const clientApplication = new msal.PublicClientApplication({ auth: {} });
     this.tokenCache = clientApplication.getTokenCache();
 
     this._setCredentials();
@@ -98,11 +98,11 @@ function SuiteBase(mochaSuiteObject, testPrefix, env, libraryPath) {
 
 _.extend(SuiteBase.prototype, {
 
-    _setCredentials: function() {
+    _setCredentials: function () {
         if (!this.isPlayback) {
             if (process.env['SKIP_CREDENTIAL_CHECK']) {
                 let token = process.env['AZURE_ACCESS_TOKEN'] || 'token';
-                this.credentials = new msRest.TokenCredentials('token');
+                this.credentials = new TokenCredentials('token');
             } else if ((process.env['AZURE_PASSWORD'] && process.env['CLIENT_SECRET']) ||
                 (!process.env['AZURE_PASSWORD'] && !process.env['CLIENT_SECRET'])) {
                 throw new Error('You must either set the envt. variables \'AZURE_USERNAME\' ' +
@@ -128,8 +128,8 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {@azure/identity.UsernamePasswordCredential} The user token credentials object.
    */
-    _createUserCredentials: function() {
-        if(process.env['AZURE_ENVIRONMENT'] && process.env['AZURE_ENVIRONMENT'].toUpperCase() === 'DOGFOOD') {
+    _createUserCredentials: function () {
+        if (process.env['AZURE_ENVIRONMENT'] && process.env['AZURE_ENVIRONMENT'].toUpperCase() === 'DOGFOOD') {
             var df = {
                 name: 'Dogfood',
                 portalUrl: 'https://windows.azure-test.net/',
@@ -152,8 +152,8 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {@azure/identity.ClientSecretCredential} The application token credentials object.
    */
-    _createApplicationCredentials: function() {
-        if(process.env['AZURE_ENVIRONMENT'] && process.env['AZURE_ENVIRONMENT'].toUpperCase() === 'DOGFOOD') {
+    _createApplicationCredentials: function () {
+        if (process.env['AZURE_ENVIRONMENT'] && process.env['AZURE_ENVIRONMENT'].toUpperCase() === 'DOGFOOD') {
             var df = {
                 name: 'Dogfood',
                 portalUrl: 'https://windows.azure-test.net/',
@@ -177,7 +177,7 @@ _.extend(SuiteBase.prototype, {
     /**
    * Creates a ResourceManagementClient and sets it as a property of the suite.
    */
-    _setupResourceManagementClient: function() {
+    _setupResourceManagementClient: function () {
         if (!this.resourceManagement) {
             this.resourceManagement = new ResourceManagementClient(this.credentials, this.subscriptionId);
         }
@@ -194,7 +194,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {function} callback(err, result) - It contains error and result for the create request.
    */
-    createResourcegroup: function(groupName, location, callback) {
+    createResourcegroup: function (groupName, location, callback) {
         console.log('Creating Resource Group: \'' + groupName + '\' at location: \'' + location + '\'');
         this._setupResourceManagementClient();
         return this.resourceManagement.resourceGroups.createOrUpdate(groupName, {
@@ -209,7 +209,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {function} callback(err, result) - It contains error and result for the delete request.
    */
-    deleteResourcegroup: function(groupName, callback) {
+    deleteResourcegroup: function (groupName, callback) {
         console.log('Deleting Resource Group: ' + groupName);
         if (!this.resourceManagement) {
             this._setupResourceManagementClient();
@@ -222,7 +222,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {string} The test recordings directory
    */
-    getRecordingsDirectory: function() {
+    getRecordingsDirectory: function () {
         return this.recordingsDirectory;
     },
 
@@ -231,7 +231,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {string} dir The test recordings directory
    */
-    setRecordingsDirectory: function(dir) {
+    setRecordingsDirectory: function (dir) {
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir);
         }
@@ -243,19 +243,19 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {string} The curent test recordings file
    */
-    getTestRecordingsFile: function() {
+    getTestRecordingsFile: function () {
         this.testRecordingsFile = this.getRecordingsDirectory() +
             this.normalizeTestName(this.currentTest) + '.nock.js';
         return this.testRecordingsFile;
     },
 
-    normalizeTestName: function(str) {
+    normalizeTestName: function (str) {
         return str.replace(/[{}\[\]'";\(\)#@~`!%&\^\$\+=,\/\\?<>\|\*:]/ig, '').replace(/(\s+)/ig, '_');
     },
 
-    normalizeEnvironment: function(env) {
-        this.requiredEnvironment = env.map(function(env) {
-            if (typeof(env) === 'string') {
+    normalizeEnvironment: function (env) {
+        this.requiredEnvironment = env.map(function (env) {
+            if (typeof (env) === 'string') {
                 return {
                     name: env,
                     secure: false
@@ -266,14 +266,14 @@ _.extend(SuiteBase.prototype, {
         });
     },
 
-    validateEnvironment: function() {
+    validateEnvironment: function () {
         if (this.isPlayback) {
             return;
         }
 
         var messages = [];
         var missing = [];
-        this.requiredEnvironment.forEach(function(e) {
+        this.requiredEnvironment.forEach(function (e) {
             if (!process.env[e.name] && !e.defaultValue) {
                 missing.push(e.name);
             }
@@ -289,8 +289,8 @@ _.extend(SuiteBase.prototype, {
         }
     },
 
-    setEnvironmentDefaults: function() {
-        this.requiredEnvironment.forEach(function(env) {
+    setEnvironmentDefaults: function () {
+        this.requiredEnvironment.forEach(function (env) {
             if (env.defaultValue && !process.env[env.name]) {
                 process.env[env.name] = env.defaultValue;
             }
@@ -302,7 +302,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @returns {string} The curent suite recordings file
    */
-    getSuiteRecordingsFile: function() {
+    getSuiteRecordingsFile: function () {
         return this.suiteRecordingsFile;
     },
 
@@ -312,7 +312,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {function} callback  A hook to provide the steps to execute during setup suite
    */
-    setupSuite: function(callback, isAsyncSetUp) {
+    setupSuite: function (callback, isAsyncSetUp) {
         if (this.isMocked) {
             process.env.AZURE_ENABLE_STRICT_SSL = false;
         }
@@ -344,9 +344,9 @@ _.extend(SuiteBase.prototype, {
         }
         var self = this;
         async.series([
-            function(firstCallback) {
+            function (firstCallback) {
                 if (isAsyncSetUp) {
-                    callback(function() {
+                    callback(function () {
                         firstCallback(null);
                     });
                 } else {
@@ -354,7 +354,7 @@ _.extend(SuiteBase.prototype, {
                     firstCallback(null);
                 }
             },
-            function(secondCallback) {
+            function (secondCallback) {
                 //write the suite level testids and uuids to a suite recordings file
                 if (self.isMocked && self.isRecording) {
                     self.writeRecordingHeader(self.getSuiteRecordingsFile());
@@ -367,11 +367,11 @@ _.extend(SuiteBase.prototype, {
                 secondCallback(null);
             }
         ],
-        function(err, results) {
-            if (err) {
-                throw err;
-            }
-        });
+            function (err, results) {
+                if (err) {
+                    throw err;
+                }
+            });
     },
 
     /**
@@ -380,7 +380,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {function} callback  A hook to provide the steps to execute during setup suite
    */
-    setupSuiteAsync: function(callback) {
+    setupSuiteAsync: function (callback) {
         this.setupSuite(callback, true);
     },
 
@@ -389,7 +389,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {function} callback  A hook to provide the steps to execute after the suite has completed execution
    */
-    teardownSuite: function(callback) {
+    teardownSuite: function (callback) {
         if (this.isMocked) {
             delete process.env.AZURE_ENABLE_STRICT_SSL;
         }
@@ -402,7 +402,7 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {function} callback  A hook to provide the steps to execute before the test starts execution
    */
-    setupTest: function(callback) {
+    setupTest: function (callback) {
         this.currentTest = this.mochaSuiteObject.currentTest.fullTitle();
         this.numberOfRandomTestIdGenerated = 0;
         this.currentUuid = 0;
@@ -436,7 +436,7 @@ _.extend(SuiteBase.prototype, {
             this.tokenCache = new MockTokenCache();
 
             if (nocked.scopes.length === 1) {
-                nocked.scopes[0].forEach(function(createScopeFunc) {
+                nocked.scopes[0].forEach(function (createScopeFunc) {
                     createScopeFunc(nockHelper.nock);
                 });
             } else {
@@ -454,14 +454,14 @@ _.extend(SuiteBase.prototype, {
    *
    * @param {function} callback  A hook to provide the steps to execute after the test has completed execution
    */
-    baseTeardownTest: function(callback) {
+    baseTeardownTest: function (callback) {
         if (this.isMocked) {
             if (this.isRecording) {
                 // play nock recording
                 var scope = '[';
                 var lineWritten;
                 var importFsAndPathInRecording = false;
-                nockHelper.nock.recorder.play().forEach(function(line) {
+                nockHelper.nock.recorder.play().forEach(function (line) {
                     if (line.indexOf('nock') >= 0) {
                         // apply fixups of nock generated mocks
 
@@ -534,9 +534,9 @@ _.extend(SuiteBase.prototype, {
    * @param {string} filename        (Optional) The file name to which the uuids need to be added
    *                                 If the filename is not provided then it will get the current test recording file.
    */
-    writeGeneratedUuids: function(filename) {
+    writeGeneratedUuids: function (filename) {
         if (this.uuidsGenerated.length > 0) {
-            var uuids = this.uuidsGenerated.map(function(uuid) {
+            var uuids = this.uuidsGenerated.map(function (uuid) {
                 return '\'' + uuid + '\'';
             }).join(',');
             var content = util.format('\n exports.uuidsGenerated = function() { return [%s];};', uuids);
@@ -552,9 +552,9 @@ _.extend(SuiteBase.prototype, {
    * @param {string} filename        (Optional) The file name to which the random test ids need to be added
    *                                 If the filename is not provided then it will get the current test recording file.
    */
-    writeGeneratedRandomTestIds: function(filename) {
+    writeGeneratedRandomTestIds: function (filename) {
         if (this.randomTestIdsGenerated.length > 0) {
-            var ids = this.randomTestIdsGenerated.map(function(id) {
+            var ids = this.randomTestIdsGenerated.map(function (id) {
                 return '\'' + id + '\'';
             }).join(',');
             var content = util.format('\n exports.randomTestIdsGenerated = function() { return [%s];};', ids);
@@ -570,7 +570,7 @@ _.extend(SuiteBase.prototype, {
    * @param {string} filename        (Optional) The file name to which the mock variables need to be added
    *                                 If the filename is not provided then it will get the current test recording file.
    */
-    writeMockVariables: function(filename) {
+    writeMockVariables: function (filename) {
         if (this.mockVariables && Object.keys(this.mockVariables).length > 0) {
             var mockVariablesObject = JSON.stringify(this.mockVariables);
             var content = util.format('\n exports.mockVariables = function() { return %s; };', mockVariablesObject);
@@ -586,7 +586,7 @@ _.extend(SuiteBase.prototype, {
    * @param {string} filename        (Optional) The file name to which the recording header needs to be added
    *                                 If the filename is not provided then it will get the current test recording file.
    */
-    writeRecordingHeader: function(filename) {
+    writeRecordingHeader: function (filename) {
         var template = fs.readFileSync(path.join(__dirname, 'preamble.template'), {
             encoding: 'utf8'
         });
@@ -603,7 +603,7 @@ _.extend(SuiteBase.prototype, {
    * @param {array}  currentList     The current list of identifiers.
    * @return {string} A new unique identifier.
    */
-    generateId: function(prefix, currentList) {
+    generateId: function (prefix, currentList) {
         if (!currentList) {
             currentList = [];
         }
@@ -635,7 +635,7 @@ _.extend(SuiteBase.prototype, {
    * retrieve the guid from the recording file if in 'Playback' mode.
    * @return {string} A new Guid.
    */
-    generateGuid: function() {
+    generateGuid: function () {
         var newGuid;
         //record or live
         if (!this.isPlayback) {
@@ -658,7 +658,7 @@ _.extend(SuiteBase.prototype, {
    * Saves the mock variable with the specified name to the recording file when the test is run
    * in 'Record' mode or keeps it in memory when the test is run in 'Live' mode.
    */
-    saveMockVariable: function(mockVariableName, mockVariable) {
+    saveMockVariable: function (mockVariableName, mockVariable) {
         //record or live
         if (!this.isPlayback) {
             this.mockVariables[mockVariableName] = mockVariable;
@@ -669,7 +669,7 @@ _.extend(SuiteBase.prototype, {
    * Gets the mock variable with the specified name. Returns undefined if the variable name is not present.
    * @return {object} A mock variable.
    */
-    getMockVariable: function(mockVariableName) {
+    getMockVariable: function (mockVariableName) {
         return this.mockVariables[mockVariableName];
     },
 
@@ -683,7 +683,7 @@ _.extend(SuiteBase.prototype, {
    *                              returns new function that runs when method is called.
    * @return {object}             The created stub.
    */
-    wrap: function(sinonObj, object, property, setup) {
+    wrap: function (sinonObj, object, property, setup) {
         var original = object[property];
         return sinonObj.stub(object, property, setup(original));
     },
@@ -696,7 +696,7 @@ _.extend(SuiteBase.prototype, {
    *                              (This ensures that there are no duplicates in the list)
    * @return {string}             The generated random nmumber.
    */
-    generateRandomId: function(prefix, currentList) {
+    generateRandomId: function (prefix, currentList) {
         var newNumber;
         while (true) {
             newNumber = prefix + Math.floor(Math.random() * 10000);
@@ -710,19 +710,19 @@ _.extend(SuiteBase.prototype, {
     /**
    * Stubs certain methods.
    */
-    _stubMethods: function() {
-        if (this.isPlayback) {           
+    _stubMethods: function () {
+        if (this.isPlayback) {
             if (this.createResourcegroup.restore) {
                 this.createResourcegroup.restore();
             }
-            sinon.stub(this, 'createResourcegroup').callsFake(function(groupName, location, callback) {
+            sinon.stub(this, 'createResourcegroup').callsFake(function (groupName, location, callback) {
                 return callback(null);
             });
 
             if (this.deleteResourcegroup.restore) {
                 this.deleteResourcegroup.restore();
             }
-            sinon.stub(this, 'deleteResourcegroup').callsFake(function(groupName, callback) {
+            sinon.stub(this, 'deleteResourcegroup').callsFake(function (groupName, callback) {
                 return callback(null);
             });
 
@@ -766,7 +766,7 @@ _.extend(SuiteBase.prototype, {
                 connectionName: 'mockConnection',
                 token: 'mockToken',
                 expiration: 'mockExpiration',
-                _response : {
+                _response: {
                     bodyAsText: 'mockBody',
                     parsedBody: {
                         channelId: 'mockChannel',

--- a/tools/resourceManagement/lib/resource/operations/deploymentOperations.js
+++ b/tools/resourceManagement/lib/resource/operations/deploymentOperations.js
@@ -10,9 +10,8 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 const uuid = require('uuid');
-const WebResource = msRest.WebResource;
 
 /**
  * Gets a deployments operation.
@@ -43,9 +42,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _get(resourceGroupName, deploymentName, operationId, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -58,16 +57,13 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -75,16 +71,13 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -125,13 +118,13 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -147,8 +140,8 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -164,7 +157,7 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -184,8 +177,8 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -225,9 +218,9 @@ function _get(resourceGroupName, deploymentName, operationId, options, callback)
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _list(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -241,16 +234,13 @@ function _list(resourceGroupName, deploymentName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -258,16 +248,13 @@ function _list(resourceGroupName, deploymentName, options, callback) {
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -310,13 +297,13 @@ function _list(resourceGroupName, deploymentName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -332,8 +319,8 @@ function _list(resourceGroupName, deploymentName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -349,7 +336,7 @@ function _list(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -369,8 +356,8 @@ function _list(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -405,9 +392,9 @@ function _list(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -438,13 +425,13 @@ function _listNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -460,8 +447,8 @@ function _listNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -477,7 +464,7 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -497,8 +484,8 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/operations/deployments.js
+++ b/tools/resourceManagement/lib/resource/operations/deployments.js
@@ -10,10 +10,8 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 const uuid = require('uuid');
-const WebResource = msRest.WebResource;
-
 
 /**
  * @summary Deletes a deployment from the deployment history.
@@ -52,9 +50,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteMethod(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -115,9 +113,9 @@ function _deleteMethod(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _checkExistence(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -130,16 +128,13 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -147,16 +142,13 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -193,13 +185,13 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -215,8 +207,8 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
     if (statusCode !== 204 && statusCode !== 404) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -232,7 +224,7 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -336,9 +328,9 @@ function _checkExistence(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdate(resourceGroupName, deploymentName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -377,8 +369,8 @@ function _createOrUpdate(resourceGroupName, deploymentName, parameters, options,
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
 
@@ -414,9 +406,9 @@ function _createOrUpdate(resourceGroupName, deploymentName, parameters, options,
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _get(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -429,16 +421,13 @@ function _get(resourceGroupName, deploymentName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -446,16 +435,13 @@ function _get(resourceGroupName, deploymentName, options, callback) {
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -492,13 +478,13 @@ function _get(resourceGroupName, deploymentName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -514,8 +500,8 @@ function _get(resourceGroupName, deploymentName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -531,7 +517,7 @@ function _get(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -551,8 +537,8 @@ function _get(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -592,9 +578,9 @@ function _get(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _cancel(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -607,16 +593,13 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -624,16 +607,13 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -670,13 +650,13 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -692,8 +672,8 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
     if (statusCode !== 204) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -709,7 +689,7 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -809,9 +789,9 @@ function _cancel(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _validate(resourceGroupName, deploymentName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -824,16 +804,13 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -841,16 +818,13 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -890,13 +864,13 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -913,7 +887,7 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -926,8 +900,8 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
     if (statusCode !== 200 && statusCode !== 400) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -943,7 +917,7 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -963,8 +937,8 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -980,8 +954,8 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -1019,9 +993,9 @@ function _validate(resourceGroupName, deploymentName, parameters, options, callb
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1034,16 +1008,13 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1051,16 +1022,13 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1097,13 +1065,13 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1119,8 +1087,8 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1136,7 +1104,7 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1156,8 +1124,8 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1197,9 +1165,9 @@ function _exportTemplate(resourceGroupName, deploymentName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listByResourceGroup(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1214,16 +1182,13 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1271,13 +1236,13 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1293,8 +1258,8 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1310,7 +1275,7 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1330,8 +1295,8 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1377,9 +1342,9 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1392,16 +1357,13 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1409,16 +1371,13 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1455,13 +1414,13 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1477,8 +1436,8 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
     if (statusCode !== 202 && statusCode !== 204) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1494,7 +1453,7 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1596,9 +1555,9 @@ function _beginDeleteMethod(resourceGroupName, deploymentName, options, callback
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1611,16 +1570,13 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1628,16 +1584,13 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
       throw new Error('deploymentName cannot be null or undefined and it must be of type string.');
     }
     if (deploymentName !== null && deploymentName !== undefined) {
-      if (deploymentName.length > 64)
-      {
+      if (deploymentName.length > 64) {
         throw new Error('"deploymentName" should satisfy the constraint - "MaxLength": 64');
       }
-      if (deploymentName.length < 1)
-      {
+      if (deploymentName.length < 1) {
         throw new Error('"deploymentName" should satisfy the constraint - "MinLength": 1');
       }
-      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (deploymentName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"deploymentName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1677,13 +1630,13 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1700,7 +1653,7 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -1713,8 +1666,8 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
     if (statusCode !== 200 && statusCode !== 201) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1730,7 +1683,7 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1750,8 +1703,8 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1767,8 +1720,8 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -1802,9 +1755,9 @@ function _beginCreateOrUpdate(resourceGroupName, deploymentName, parameters, opt
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listByResourceGroupNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1835,13 +1788,13 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1857,8 +1810,8 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1874,7 +1827,7 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1894,8 +1847,8 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/operations/providers.js
+++ b/tools/resourceManagement/lib/resource/operations/providers.js
@@ -10,9 +10,8 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 const uuid = require('uuid');
-const WebResource = msRest.WebResource;
 
 /**
  * Unregisters a subscription from a resource provider.
@@ -39,9 +38,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _unregister(resourceProviderNamespace, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -85,13 +84,13 @@ function _unregister(resourceProviderNamespace, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -107,8 +106,8 @@ function _unregister(resourceProviderNamespace, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -124,7 +123,7 @@ function _unregister(resourceProviderNamespace, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -144,8 +143,8 @@ function _unregister(resourceProviderNamespace, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -179,9 +178,9 @@ function _unregister(resourceProviderNamespace, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _register(resourceProviderNamespace, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -225,13 +224,13 @@ function _register(resourceProviderNamespace, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -247,8 +246,8 @@ function _register(resourceProviderNamespace, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -264,7 +263,7 @@ function _register(resourceProviderNamespace, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -284,8 +283,8 @@ function _register(resourceProviderNamespace, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -324,9 +323,9 @@ function _register(resourceProviderNamespace, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _list(options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -380,13 +379,13 @@ function _list(options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -402,8 +401,8 @@ function _list(options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -419,7 +418,7 @@ function _list(options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -439,8 +438,8 @@ function _list(options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -477,9 +476,9 @@ function _list(options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _get(resourceProviderNamespace, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -530,13 +529,13 @@ function _get(resourceProviderNamespace, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -552,8 +551,8 @@ function _get(resourceProviderNamespace, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -569,7 +568,7 @@ function _get(resourceProviderNamespace, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -589,8 +588,8 @@ function _get(resourceProviderNamespace, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -624,9 +623,9 @@ function _get(resourceProviderNamespace, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -657,13 +656,13 @@ function _listNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -679,8 +678,8 @@ function _listNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -696,7 +695,7 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -716,8 +715,8 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/operations/resourceGroups.js
+++ b/tools/resourceManagement/lib/resource/operations/resourceGroups.js
@@ -10,9 +10,8 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 const uuid = require('uuid');
-const WebResource = msRest.WebResource;
 
 /**
  * Checks whether a resource group exists.
@@ -38,9 +37,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _checkExistence(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -53,16 +52,13 @@ function _checkExistence(resourceGroupName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -98,13 +94,13 @@ function _checkExistence(resourceGroupName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -120,8 +116,8 @@ function _checkExistence(resourceGroupName, options, callback) {
     if (statusCode !== 204 && statusCode !== 404) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -137,7 +133,7 @@ function _checkExistence(resourceGroupName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -192,9 +188,9 @@ function _checkExistence(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdate(resourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -207,16 +203,13 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -255,13 +248,13 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -278,7 +271,7 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -291,8 +284,8 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
     if (statusCode !== 201 && statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -308,7 +301,7 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -328,8 +321,8 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -345,8 +338,8 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -384,9 +377,9 @@ function _createOrUpdate(resourceGroupName, parameters, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteMethod(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -446,9 +439,9 @@ function _deleteMethod(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _get(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -461,16 +454,13 @@ function _get(resourceGroupName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -506,13 +496,13 @@ function _get(resourceGroupName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -528,8 +518,8 @@ function _get(resourceGroupName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -545,7 +535,7 @@ function _get(resourceGroupName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -565,8 +555,8 @@ function _get(resourceGroupName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -615,9 +605,9 @@ function _get(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _update(resourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -630,16 +620,13 @@ function _update(resourceGroupName, parameters, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -678,13 +665,13 @@ function _update(resourceGroupName, parameters, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -701,7 +688,7 @@ function _update(resourceGroupName, parameters, options, callback) {
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -714,8 +701,8 @@ function _update(resourceGroupName, parameters, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -731,7 +718,7 @@ function _update(resourceGroupName, parameters, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -751,8 +738,8 @@ function _update(resourceGroupName, parameters, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -797,9 +784,9 @@ function _update(resourceGroupName, parameters, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _exportTemplate(resourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -812,16 +799,13 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -860,13 +844,13 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -883,7 +867,7 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -896,8 +880,8 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -913,7 +897,7 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -933,8 +917,8 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -971,9 +955,9 @@ function _exportTemplate(resourceGroupName, parameters, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _list(options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1027,13 +1011,13 @@ function _list(options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1049,8 +1033,8 @@ function _list(options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1066,7 +1050,7 @@ function _list(options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1086,8 +1070,8 @@ function _list(options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1124,9 +1108,9 @@ function _list(options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginDeleteMethod(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1139,16 +1123,13 @@ function _beginDeleteMethod(resourceGroupName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1184,13 +1165,13 @@ function _beginDeleteMethod(resourceGroupName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1206,8 +1187,8 @@ function _beginDeleteMethod(resourceGroupName, options, callback) {
     if (statusCode !== 202 && statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1223,7 +1204,7 @@ function _beginDeleteMethod(resourceGroupName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1262,9 +1243,9 @@ function _beginDeleteMethod(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1295,13 +1276,13 @@ function _listNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1317,8 +1298,8 @@ function _listNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1334,7 +1315,7 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1354,8 +1335,8 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/operations/resources.js
+++ b/tools/resourceManagement/lib/resource/operations/resources.js
@@ -11,9 +11,7 @@
 'use strict';
 
 const uuid = require('uuid');
-const msRest = require('@azure/ms-rest-js');
-
-const WebResource = msRest.WebResource;
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 
 /**
  * Get all the resources for a resource group.
@@ -47,9 +45,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listByResourceGroup(resourceGroupName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -65,16 +63,13 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -128,13 +123,13 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -150,8 +145,8 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -167,7 +162,7 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -187,8 +182,8 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -234,9 +229,9 @@ function _listByResourceGroup(resourceGroupName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _moveResources(sourceResourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -311,9 +306,9 @@ function _moveResources(sourceResourceGroupName, parameters, options, callback) 
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _validateMoveResources(sourceResourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -377,9 +372,9 @@ function _validateMoveResources(sourceResourceGroupName, parameters, options, ca
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _list(options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -440,13 +435,13 @@ function _list(options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -462,8 +457,8 @@ function _list(options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -479,7 +474,7 @@ function _list(options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -499,8 +494,8 @@ function _list(options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -545,9 +540,9 @@ function _list(options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _checkExistence(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -560,16 +555,13 @@ function _checkExistence(resourceGroupName, resourceProviderNamespace, parentRes
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -621,13 +613,13 @@ function _checkExistence(resourceGroupName, resourceProviderNamespace, parentRes
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -643,8 +635,8 @@ function _checkExistence(resourceGroupName, resourceProviderNamespace, parentRes
     if (statusCode !== 204 && statusCode !== 404) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -660,7 +652,7 @@ function _checkExistence(resourceGroupName, resourceProviderNamespace, parentRes
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -710,9 +702,9 @@ function _checkExistence(resourceGroupName, resourceProviderNamespace, parentRes
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteMethod(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -826,9 +818,9 @@ function _deleteMethod(resourceGroupName, resourceProviderNamespace, parentResou
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdate(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -867,8 +859,8 @@ function _createOrUpdate(resourceGroupName, resourceProviderNamespace, parentRes
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
 
@@ -913,9 +905,9 @@ function _createOrUpdate(resourceGroupName, resourceProviderNamespace, parentRes
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -928,16 +920,13 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -989,13 +978,13 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1011,8 +1000,8 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1028,7 +1017,7 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1048,8 +1037,8 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1085,9 +1074,9 @@ function _get(resourceGroupName, resourceProviderNamespace, parentResourcePath, 
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _checkExistenceById(resourceId, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1127,13 +1116,13 @@ function _checkExistenceById(resourceId, apiVersion, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1149,8 +1138,8 @@ function _checkExistenceById(resourceId, apiVersion, options, callback) {
     if (statusCode !== 204 && statusCode !== 404) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1166,7 +1155,7 @@ function _checkExistenceById(resourceId, apiVersion, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1208,9 +1197,9 @@ function _checkExistenceById(resourceId, apiVersion, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteById(resourceId, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1316,9 +1305,9 @@ function _deleteById(resourceId, apiVersion, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdateById(resourceId, apiVersion, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1357,8 +1346,8 @@ function _createOrUpdateById(resourceId, apiVersion, parameters, options, callba
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
 
@@ -1395,9 +1384,9 @@ function _createOrUpdateById(resourceId, apiVersion, parameters, options, callba
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _getById(resourceId, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1437,13 +1426,13 @@ function _getById(resourceId, apiVersion, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1459,8 +1448,8 @@ function _getById(resourceId, apiVersion, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1476,7 +1465,7 @@ function _getById(resourceId, apiVersion, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1496,8 +1485,8 @@ function _getById(resourceId, apiVersion, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -1542,9 +1531,9 @@ function _getById(resourceId, apiVersion, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginMoveResources(sourceResourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1557,16 +1546,13 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
       throw new Error('sourceResourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (sourceResourceGroupName !== null && sourceResourceGroupName !== undefined) {
-      if (sourceResourceGroupName.length > 90)
-      {
+      if (sourceResourceGroupName.length > 90) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (sourceResourceGroupName.length < 1)
-      {
+      if (sourceResourceGroupName.length < 1) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (sourceResourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (sourceResourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1605,13 +1591,13 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1628,7 +1614,7 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -1641,8 +1627,8 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
     if (statusCode !== 202 && statusCode !== 204) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1658,7 +1644,7 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1710,9 +1696,9 @@ function _beginMoveResources(sourceResourceGroupName, parameters, options, callb
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginValidateMoveResources(sourceResourceGroupName, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1725,16 +1711,13 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
       throw new Error('sourceResourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (sourceResourceGroupName !== null && sourceResourceGroupName !== undefined) {
-      if (sourceResourceGroupName.length > 90)
-      {
+      if (sourceResourceGroupName.length > 90) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (sourceResourceGroupName.length < 1)
-      {
+      if (sourceResourceGroupName.length < 1) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (sourceResourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (sourceResourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"sourceResourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1773,13 +1756,13 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1796,7 +1779,7 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -1809,8 +1792,8 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
     if (statusCode !== 202 && statusCode !== 204 && statusCode !== 409) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1826,7 +1809,7 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -1874,9 +1857,9 @@ function _beginValidateMoveResources(sourceResourceGroupName, parameters, option
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -1889,16 +1872,13 @@ function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parent
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -1950,13 +1930,13 @@ function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parent
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -1972,8 +1952,8 @@ function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parent
     if (statusCode !== 200 && statusCode !== 204 && statusCode !== 202) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -1989,7 +1969,7 @@ function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parent
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2080,9 +2060,9 @@ function _beginDeleteMethod(resourceGroupName, resourceProviderNamespace, parent
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -2095,16 +2075,13 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
       throw new Error('resourceGroupName cannot be null or undefined and it must be of type string.');
     }
     if (resourceGroupName !== null && resourceGroupName !== undefined) {
-      if (resourceGroupName.length > 90)
-      {
+      if (resourceGroupName.length > 90) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MaxLength": 90');
       }
-      if (resourceGroupName.length < 1)
-      {
+      if (resourceGroupName.length < 1) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "MinLength": 1');
       }
-      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null)
-      {
+      if (resourceGroupName.match(/^[-\w\._\(\)]+$/) === null) {
         throw new Error('"resourceGroupName" should satisfy the constraint - "Pattern": /^[-\w\._\(\)]+$/');
       }
     }
@@ -2159,13 +2136,13 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -2182,7 +2159,7 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -2195,8 +2172,8 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
     if (statusCode !== 201 && statusCode !== 200 && statusCode !== 202) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -2212,7 +2189,7 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2232,8 +2209,8 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -2249,8 +2226,8 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -2286,9 +2263,9 @@ function _beginCreateOrUpdate(resourceGroupName, resourceProviderNamespace, pare
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginDeleteById(resourceId, apiVersion, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -2328,13 +2305,13 @@ function _beginDeleteById(resourceId, apiVersion, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -2350,8 +2327,8 @@ function _beginDeleteById(resourceId, apiVersion, options, callback) {
     if (statusCode !== 200 && statusCode !== 204 && statusCode !== 202) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -2367,7 +2344,7 @@ function _beginDeleteById(resourceId, apiVersion, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2450,9 +2427,9 @@ function _beginDeleteById(resourceId, apiVersion, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -2495,13 +2472,13 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -2518,7 +2495,7 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
     }
   } catch (error) {
     let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(parameters, null, 2)}.`);
+      `payload - ${JSON.stringify(parameters, null, 2)}.`);
     return callback(serializationError);
   }
   httpRequest.body = requestContent;
@@ -2531,8 +2508,8 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
     if (statusCode !== 201 && statusCode !== 200 && statusCode !== 202) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -2548,7 +2525,7 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2568,8 +2545,8 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -2585,8 +2562,8 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -2620,9 +2597,9 @@ function _beginCreateOrUpdateById(resourceId, apiVersion, parameters, options, c
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listByResourceGroupNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -2653,13 +2630,13 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -2675,8 +2652,8 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -2692,7 +2669,7 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2712,8 +2689,8 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -2747,9 +2724,9 @@ function _listByResourceGroupNext(nextPageLink, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -2780,13 +2757,13 @@ function _listNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -2802,8 +2779,8 @@ function _listNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -2819,7 +2796,7 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -2839,8 +2816,8 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/operations/tags.js
+++ b/tools/resourceManagement/lib/resource/operations/tags.js
@@ -10,9 +10,8 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { stripRequest, stripResponse, WebResource } = require("@azure/core-http");
 const uuid = require('uuid');
-const WebResource = msRest.WebResource;
 
 /**
  * Deletes a tag value.
@@ -39,9 +38,9 @@ const WebResource = msRest.WebResource;
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteValue(tagName, tagValue, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -89,13 +88,13 @@ function _deleteValue(tagName, tagValue, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -111,8 +110,8 @@ function _deleteValue(tagName, tagValue, options, callback) {
     if (statusCode !== 200 && statusCode !== 204) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -128,7 +127,7 @@ function _deleteValue(tagName, tagValue, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -167,9 +166,9 @@ function _deleteValue(tagName, tagValue, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdateValue(tagName, tagValue, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -217,13 +216,13 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -239,8 +238,8 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
     if (statusCode !== 200 && statusCode !== 201) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -256,7 +255,7 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -276,8 +275,8 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -293,8 +292,8 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -331,9 +330,9 @@ function _createOrUpdateValue(tagName, tagValue, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _createOrUpdate(tagName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -377,13 +376,13 @@ function _createOrUpdate(tagName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -399,8 +398,8 @@ function _createOrUpdate(tagName, options, callback) {
     if (statusCode !== 200 && statusCode !== 201) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -416,7 +415,7 @@ function _createOrUpdate(tagName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -436,8 +435,8 @@ function _createOrUpdate(tagName, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -453,8 +452,8 @@ function _createOrUpdate(tagName, options, callback) {
         }
       } catch (error) {
         let deserializationError1 = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError1.request = msRest.stripRequest(httpRequest);
-        deserializationError1.response = msRest.stripResponse(response);
+        deserializationError1.request = stripRequest(httpRequest);
+        deserializationError1.response = stripResponse(response);
         return callback(deserializationError1);
       }
     }
@@ -488,9 +487,9 @@ function _createOrUpdate(tagName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _deleteMethod(tagName, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -534,13 +533,13 @@ function _deleteMethod(tagName, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -556,8 +555,8 @@ function _deleteMethod(tagName, options, callback) {
     if (statusCode !== 200 && statusCode !== 204) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -573,7 +572,7 @@ function _deleteMethod(tagName, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -609,9 +608,9 @@ function _deleteMethod(tagName, options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _list(options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -651,13 +650,13 @@ function _list(options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -673,8 +672,8 @@ function _list(options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -690,7 +689,7 @@ function _list(options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -710,8 +709,8 @@ function _list(options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }
@@ -746,9 +745,9 @@ function _list(options, callback) {
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
 function _listNext(nextPageLink, options, callback) {
-   /* jshint validthis: true */
+  /* jshint validthis: true */
   let client = this.client;
-  if(!callback && typeof options === 'function') {
+  if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
@@ -779,13 +778,13 @@ function _listNext(nextPageLink, options, callback) {
   // Set Headers
   httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
   if (this.client.generateClientRequestId) {
-      httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
+    httpRequest.headers['x-ms-client-request-id'] = uuid.v4();
   }
   if (this.client.acceptLanguage !== undefined && this.client.acceptLanguage !== null) {
     httpRequest.headers['accept-language'] = this.client.acceptLanguage;
   }
-  if(options) {
-    for(let headerName in options['customHeaders']) {
+  if (options) {
+    for (let headerName in options['customHeaders']) {
       if (options['customHeaders'].hasOwnProperty(headerName)) {
         httpRequest.headers[headerName] = options['customHeaders'][headerName];
       }
@@ -801,8 +800,8 @@ function _listNext(nextPageLink, options, callback) {
     if (statusCode !== 200) {
       let error = new Error(responseBody);
       error.statusCode = response.statusCode;
-      error.request = msRest.stripRequest(httpRequest);
-      error.response = msRest.stripResponse(response);
+      error.request = stripRequest(httpRequest);
+      error.response = stripResponse(response);
       if (responseBody === '') responseBody = null;
       let parsedErrorResponse;
       try {
@@ -818,7 +817,7 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (defaultError) {
         error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
-                         `- "${responseBody}" for the default response.`;
+          `- "${responseBody}" for the default response.`;
         return callback(error);
       }
       return callback(error);
@@ -838,8 +837,8 @@ function _listNext(nextPageLink, options, callback) {
         }
       } catch (error) {
         let deserializationError = new Error(`Error ${error} occurred in deserializing the responseBody - ${responseBody}`);
-        deserializationError.request = msRest.stripRequest(httpRequest);
-        deserializationError.response = msRest.stripResponse(response);
+        deserializationError.request = stripRequest(httpRequest);
+        deserializationError.response = stripResponse(response);
         return callback(deserializationError);
       }
     }

--- a/tools/resourceManagement/lib/resource/resourceManagementClient.js
+++ b/tools/resourceManagement/lib/resource/resourceManagementClient.js
@@ -14,10 +14,9 @@
 
 'use strict';
 
-const msRest = require('@azure/ms-rest-js');
+const { ServiceClient, Serializer } = require("@azure/core-http");
 const fs = require('fs');
 const path = require('path');
-const ServiceClient = msRest.ServiceClient;
 
 const models = require('./models');
 const operations = require('./operations');
@@ -88,7 +87,7 @@ class ResourceManagementClient extends ServiceClient {
 
   addSerializationMixin(destObject) {
     ['serialize', 'serializeObject', 'deserialize'].forEach((property) => {
-      destObject[property] = msRest.Serializer[property];
+      destObject[property] = Serializer[property];
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,31 +9,23 @@
   dependencies:
     tslib "^1.9.3"
 
-"@azure/cognitiveservices-luis-runtime@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-4.0.1.tgz#7c49b0a98af2b3d1c76e2fee64b1270769de1b25"
-  integrity sha512-W5oDt1LvJQmtxCIDq1aFh8R4W+5ZKSTC+9So9DIGVZmy29SMxBNyTf8OTliHDv0L+P6Y2XBySoGCliPYfTyrhQ==
-  dependencies:
-    "@azure/ms-rest-js" "^2.0.3"
-    tslib "^1.10.0"
-
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz#dcccebb88406e5c76e0e1d52e8cc4c43a68b3ee7"
   integrity sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
 
-"@azure/core-auth@^1.1.4", "@azure/core-auth@^1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
-  integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    tslib "^2.2.0"
-
 "@azure/core-auth@^1.2.0", "@azure/core-auth@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.4.0.tgz#6fa9661c1705857820dbc216df5ba5665ac36a9e"
   integrity sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-auth@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
+  integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.2.0"
@@ -221,20 +213,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
-
-"@azure/ms-rest-js@^2.0.3", "@azure/ms-rest-js@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz#8639065577ffdf4946951e1d246334ebfd72d537"
-  integrity sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==
-  dependencies:
-    "@azure/core-auth" "^1.1.4"
-    abort-controller "^3.0.0"
-    form-data "^2.5.0"
-    node-fetch "^2.6.7"
-    tslib "^1.10.0"
-    tunnel "0.0.6"
-    uuid "^8.3.2"
-    xml2js "^0.5.0"
 
 "@azure/msal-browser@^2.16.0":
   version "2.17.0"
@@ -2675,13 +2653,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 accepts@^1.3.7, accepts@~1.3.8:
   version "1.3.8"
@@ -5885,11 +5856,6 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^3.0.0:
   version "3.2.0"
@@ -13043,7 +13009,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -13080,7 +13046,7 @@ tty-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
-tunnel@0.0.6, tunnel@^0.0.6:
+tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,27 @@
   dependencies:
     tslib "^1.9.3"
 
+"@azure/cognitiveservices-luis-runtime@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/cognitiveservices-luis-runtime/-/cognitiveservices-luis-runtime-4.0.1.tgz#7c49b0a98af2b3d1c76e2fee64b1270769de1b25"
+  integrity sha512-W5oDt1LvJQmtxCIDq1aFh8R4W+5ZKSTC+9So9DIGVZmy29SMxBNyTf8OTliHDv0L+P6Y2XBySoGCliPYfTyrhQ==
+  dependencies:
+    "@azure/ms-rest-js" "^2.0.3"
+    tslib "^1.10.0"
+
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz#dcccebb88406e5c76e0e1d52e8cc4c43a68b3ee7"
   integrity sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
+
+"@azure/core-auth@^1.1.4":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.5.0.tgz#a41848c5c31cb3b7c84c409885267d55a2c92e44"
+  integrity sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-util" "^1.1.0"
+    tslib "^2.2.0"
 
 "@azure/core-auth@^1.2.0", "@azure/core-auth@^1.4.0":
   version "1.4.0"
@@ -127,22 +144,7 @@
     "@opentelemetry/api" "^0.10.2"
     tslib "^2.0.0"
 
-"@azure/core-util@^1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.0.0-beta.1.tgz#2efd2c74b4b0a38180369f50fe274a3c4cd36e98"
-  integrity sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==
-  dependencies:
-    tslib "^2.0.0"
-
-"@azure/core-util@^1.1.1":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.3.2.tgz#3f8cfda1e87fac0ce84f8c1a42fcd6d2a986632d"
-  integrity sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    tslib "^2.2.0"
-
-"@azure/core-util@^1.2.0":
+"@azure/core-util@1.5.0", "@azure/core-util@^1.0.0-beta.1", "@azure/core-util@^1.1.0", "@azure/core-util@^1.1.1", "@azure/core-util@^1.2.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.5.0.tgz#ffe49c3e867044da67daeb8122143fa065e1eb0e"
   integrity sha512-GZBpVFDtQ/15hW1OgBcRdT4Bl7AEpcEZqLfbAvOtm1CQUncKWiYapFHVD588hmlV27NbOOtSm3cnLF3lvoHi4g==
@@ -213,6 +215,20 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
+
+"@azure/ms-rest-js@^2.0.3", "@azure/ms-rest-js@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz#8639065577ffdf4946951e1d246334ebfd72d537"
+  integrity sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==
+  dependencies:
+    "@azure/core-auth" "^1.1.4"
+    abort-controller "^3.0.0"
+    form-data "^2.5.0"
+    node-fetch "^2.6.7"
+    tslib "^1.10.0"
+    tunnel "0.0.6"
+    uuid "^8.3.2"
+    xml2js "^0.5.0"
 
 "@azure/msal-browser@^2.16.0":
   version "2.17.0"
@@ -2653,6 +2669,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@^1.3.7, accepts@~1.3.8:
   version "1.3.8"
@@ -5856,6 +5879,11 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^3.0.0:
   version "3.2.0"
@@ -13009,7 +13037,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -13046,7 +13074,7 @@ tty-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
-tunnel@^0.0.6:
+tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==


### PR DESCRIPTION
#minor

## Description
This PR replaces the uses of **_@azure/ms-rest-js_** in the following botbuilder-js libraries.

- [ ] botbuilder
- [ ] botbuilder-ai
- [ ] botframework-connector
- [x] tools

## Specific Changes
  - Replaced the **_@azure/ms-rest-js_** imports with **_@azure/core-http_**.
  - Added **_@azure/core-http_** to libraries package.json.
  - Added **_@azure/core-util_** version 1.5.0 to resolutions.
  - Updated unit tests to work with core-http **_RestError_**.

## Testing
The following image shows some samples working after the update.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/44ada9a4-ee05-4bef-859b-f7d1122a06ac)
![image](https://github.com/southworks/botbuilder-js/assets/122501764/62c877d0-5cdb-4067-bf2b-ca3798a3f08f)
