### PR TITLE
[#4545] Please upgrade zod package

### DIFF
--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -40,7 +40,7 @@
     "fs-extra": "^7.0.1",
     "htmlparser2": "^6.0.1",
     "uuid": "^8.3.2",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -38,7 +38,7 @@ import {
 } from 'botframework-streaming';
 
 // Note: this is _okay_ because we pass the result through `validateAndFixActivity`. Should not be used otherwise.
-const ActivityT = z.custom<Activity>((val) => z.record(z.unknown()).check(val), { message: 'Activity' });
+const ActivityT = z.custom<Activity>((val) => z.record(z.unknown()).safeParse(val).success, { message: 'Activity' });
 
 /**
  * An adapter that implements the Bot Framework Protocol and can be hosted in different cloud environmens both public and private.
@@ -118,7 +118,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
         // Ensure we have a parsed request body already. We rely on express/restify middleware to parse
         // request body and azure functions, which does it for us before invoking our code. Warn the user
         // to update their code and return an error.
-        if (!z.record(z.unknown()).check(req.body)) {
+        if (!z.record(z.unknown()).safeParse(req.body).success) {
             return end(
                 StatusCodes.BAD_REQUEST,
                 '`req.body` not an object, make sure you are using middleware to parse incoming requests.'

--- a/libraries/botbuilder/src/setSpeakMiddleware.ts
+++ b/libraries/botbuilder/src/setSpeakMiddleware.ts
@@ -11,20 +11,20 @@ const supportedChannels = new Set<string>([Channels.DirectlineSpeech, Channels.E
 function hasTag(tag: string, nodes: unknown[]): boolean {
     while (nodes.length) {
         const item = nodes.shift();
+        const zObject = z
+            .object({ tagName: z.string(), children: z.array(z.unknown()) })
+            .partial()
+            .nonstrict();
 
-        if (
-            z
-                .object({ tagName: z.string(), children: z.array(z.unknown()) })
-                .partial()
-                .nonstrict()
-                .check(item)
-        ) {
-            if (item.tagName === tag) {
+        if (zObject.safeParse(item).success) {
+            const itemParsed = zObject.parse(item);
+
+            if (itemParsed.tagName === tag) {
                 return true;
             }
 
-            if (item.children) {
-                nodes.push(...item.children);
+            if (itemParsed.children) {
+                nodes.push(...itemParsed.children);
             }
         }
     }

--- a/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
+++ b/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
@@ -144,6 +144,8 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
             const userTokenClient = context.turnState.get<UserTokenClient>(
                 (context.adapter as CloudAdapterBase).UserTokenClientKey
             );
+            const exchangeToken = ExchangeToken.safeParse(context.adapter);
+
             if (userTokenClient) {
                 tokenExchangeResponse = await userTokenClient.exchangeToken(
                     context.activity.from.id,
@@ -151,8 +153,8 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
                     context.activity.channelId,
                     { token: tokenExchangeRequest.token }
                 );
-            } else if (ExchangeToken.check(context.adapter)) {
-                tokenExchangeResponse = await context.adapter.exchangeToken(
+            } else if (exchangeToken.success) {
+                tokenExchangeResponse = await exchangeToken.data.exchangeToken(
                     context,
                     this.oAuthConnectionName,
                     context.activity.from.id,

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -257,7 +257,7 @@ describe('CloudAdapter', function () {
     describe('connectNamedPipe', function () {
         it('throws for bad args', async function () {
             const includesParam = (param) => (err) => {
-                assert(err.message.includes(`at ${param}`), err.message);
+                assert(err.message.includes(`${param}`), err.message);
                 return true;
             };
 

--- a/libraries/botbuilder/tsconfig.json
+++ b/libraries/botbuilder/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["es2015", "dom"],
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "skipLibCheck": true,
   },
   "include": [
     "src/**/*"

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -37,7 +37,7 @@
     "cross-fetch": "^3.0.5",
     "jsonwebtoken": "^9.0.0",
     "rsa-pem-from-mod-exp": "^0.8.4",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "uuid": "^8.3.2",
-    "zod": "~1.11.17",
+    "zod": "^3.0.0",
     "adaptivecards": "1.2.3"
   },
   "scripts": {

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -50,7 +50,7 @@ export function assertAttachmentView(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isAttachmentView(val: unknown): val is AttachmentView {
-    return attachmentView.check(val);
+    return attachmentView.safeParse(val).success;
 }
 
 /**
@@ -88,7 +88,7 @@ export function assertAttachmentInfo(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isAttachmentInfo(val: unknown): val is AttachmentInfo {
-    return attachmentInfo.check(val);
+    return attachmentInfo.safeParse(val).success;
 }
 
 /**
@@ -175,7 +175,7 @@ export function assertChannelAccount(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isChannelAccount(val: unknown): val is ChannelAccount {
-    return channelAccount.check(val);
+    return channelAccount.safeParse(val).success;
 }
 
 /**
@@ -241,7 +241,7 @@ export function assertConversationAccount(val: unknown, ..._args: unknown[]): as
  * @internal
  */
 export function isConversationAccount(val: unknown): val is ConversationAccount {
-    return conversationAccount.check(val);
+    return conversationAccount.safeParse(val).success;
 }
 
 /**
@@ -269,7 +269,7 @@ export function assertMessageReaction(val: unknown, ..._args: unknown[]): assert
  * @internal
  */
 export function isMessageReaction(val: unknown): val is MessageReaction {
-    return messageReaction.check(val);
+    return messageReaction.safeParse(val).success;
 }
 
 /**
@@ -334,7 +334,7 @@ export function assertCardAction(val: unknown, ..._args: unknown[]): asserts val
  * @internal
  */
 export function isCardAction(val: unknown): val is CardAction {
-    return cardAction.check(val);
+    return cardAction.safeParse(val).success;
 }
 
 /**
@@ -368,7 +368,7 @@ export function assertSuggestedActions(val: unknown, ..._args: unknown[]): asser
  * @internal
  */
 export function isSuggestedActions(val: unknown): val is SuggestedActions {
-    return suggestedActions.check(val);
+    return suggestedActions.safeParse(val).success;
 }
 
 /**
@@ -416,7 +416,7 @@ export function assertAttachment(val: unknown, ..._args: unknown[]): asserts val
  * @internal
  */
 export function isAttachment(val: unknown): val is Attachment {
-    return attachment.check(val);
+    return attachment.safeParse(val).success;
 }
 
 /**
@@ -446,7 +446,7 @@ export function assertEntity(val: unknown, ..._args: unknown[]): asserts val is 
  * @internal
  */
 export function isEntity(val: unknown): val is Entity {
-    return entity.check(val);
+    return entity.safeParse(val).success;
 }
 
 /**
@@ -508,7 +508,7 @@ export function assertConversationReference(val: unknown, ..._args: unknown[]): 
  * @internal
  */
 export function isConversationReference(val: unknown): val is ConversationReference {
-    return conversationReference.check(val);
+    return conversationReference.safeParse(val).success;
 }
 
 /**
@@ -565,7 +565,7 @@ export function assertSemanticAction(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isSemanticAction(val: unknown): val is SemanticAction {
-    return semanticAction.check(val);
+    return semanticAction.safeParse(val).success;
 }
 
 /**
@@ -816,7 +816,7 @@ export function assertActivity(val: unknown, ..._args: unknown[]): asserts val i
  * @internal
  */
 export function isActivity(val: unknown): val is Activity {
-    return activity.check(val);
+    return activity.safeParse(val).success;
 }
 
 /**
@@ -829,6 +829,16 @@ export interface ActivityTimestamps extends Activity {
     rawExpiration?: string;
     rawLocalTimestamp?: string;
 }
+
+export const conversationParametersObject = z.object({
+    isGroup: z.boolean(),
+    bot: channelAccount,
+    members: z.array(channelAccount).optional(),
+    topicName: z.string().optional(),
+    tenantId: z.string().optional(),
+    activity: activity,
+    channelData: z.unknown().optional(),
+});
 
 /**
  * Parameters for creating a new conversation

--- a/testing/botbuilder-test-utils/package.json
+++ b/testing/botbuilder-test-utils/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "nanoid": "^3.1.31",
     "node-forge": "^1.3.0",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14173,6 +14173,11 @@ z-schema@~3.18.3:
   optionalDependencies:
     commander "^2.7.1"
 
+zod@^3.0.0:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+
 zod@~1.11.17:
   version "1.11.17"
   resolved "https://registry.yarnpkg.com/zod/-/zod-1.11.17.tgz#2aae9e91fc66128116ae9844e8f416a95f453f8e"


### PR DESCRIPTION
#minor

## Description
This PR migrates the use of zod 1.11.17 to ^3.0.0 to avoid [ReDoS](https://security.snyk.io/vuln/SNYK-JS-ZOD-5925617) vulnerability.

## Specific Changes
  - Updated zod version to **^3.0.0** in 
       - botbuilder
       - botframework-schema
       - botframework-connector
       - botbuilder-tests-utils
  - Replaced use of **_check_** method with **_safeParse_**.

## Testing
The following image shows some bot samples working after the update.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/f0c46286-413f-4098-8bd8-fc25ad0b1beb)
![image](https://github.com/southworks/botbuilder-js/assets/122501764/542cdf97-e3e4-45d5-8e86-f82540e2a323)