### PR TITLE
fix: [#4545] Please upgrade zod package - botbuilder

### DIFF
--- a/libraries/adaptive-expressions/etc/adaptive-expressions.api.md
+++ b/libraries/adaptive-expressions/etc/adaptive-expressions.api.md
@@ -206,7 +206,7 @@ export class BoolExpression extends ExpressionProperty<boolean> {
 
 // @public
 export class BoolExpressionConverter {
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_2" needs to be exported by the entry point index.d.ts
     convert(value: Input_2 | BoolExpression): BoolExpression;
 }
 
@@ -330,7 +330,7 @@ export class Clause extends Expression {
 // @public
 export class CommonRegex {
     static CreateRegex(pattern: string): RegExp;
-    }
+}
 
 // @public (undocumented)
 export class CommonRegexLexer extends Lexer {
@@ -1010,7 +1010,7 @@ export interface CommonRegexVisitor<Result> extends ParseTreeVisitor<Result> {
 // @public
 export class ComparisonEvaluator extends ExpressionEvaluator {
     constructor(type: string, func: (arg0: any[]) => boolean, validator: ValidateExpressionDelegate, verify?: VerifyExpression);
-    }
+}
 
 // @public
 export class Constant extends Expression {
@@ -1018,7 +1018,7 @@ export class Constant extends Expression {
     deepEquals(other: Expression): boolean;
     toString(): string;
     value: any;
-    }
+}
 
 // @public
 export function convertCSharpDateTimeToDayjs(fmtString: string): string;
@@ -1099,9 +1099,9 @@ export class EnumExpression<T> extends ExpressionProperty<T> {
 // @public
 export class EnumExpressionConverter<T> {
     constructor(enumValue: unknown);
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_3" needs to be exported by the entry point index.d.ts
     convert(value: Input_3<T> | EnumExpression<T>): EnumExpression<T>;
-    }
+}
 
 // @public
 export type EvaluateExpressionDelegate = (expression: Expression, state: MemoryInterface, options: Options) => ValueWithError;
@@ -1518,7 +1518,7 @@ export class ExpressionEvaluator {
     tryEvaluate: (expression: Expression, state: MemoryInterface, options: Options) => ValueWithError;
     type: string;
     validateExpression: (expression: Expression) => void;
-    }
+}
 
 // @public
 export class ExpressionFunctions {
@@ -2054,7 +2054,7 @@ export class IntExpression extends ExpressionProperty<number> {
 
 // @public
 export class IntExpressionConverter {
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_4" needs to be exported by the entry point index.d.ts
     convert(value: Input_4 | IntExpression): IntExpression;
 }
 
@@ -2677,7 +2677,7 @@ export interface MemoryInterface {
 // @public
 export class MultivariateNumericEvaluator extends ExpressionEvaluator {
     constructor(type: string, func: (args: any[]) => number, verify?: VerifyExpression);
-    }
+}
 
 // @public (undocumented)
 export class NameContext extends ParserRuleContext {
@@ -2707,8 +2707,7 @@ class Node_2 {
     toString(builder?: string[], indent?: number): string;
     tree: TriggerTree;
     readonly triggers: Trigger[];
-    }
-
+}
 export { Node_2 as Node }
 
 // @public (undocumented)
@@ -2789,14 +2788,14 @@ export class NumberExpression extends ExpressionProperty<number> {
 
 // @public
 export class NumberExpressionConverter {
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_5" needs to be exported by the entry point index.d.ts
     convert(value: Input_5 | NumberExpression): NumberExpression;
 }
 
 // @public
 export class NumberTransformEvaluator extends ExpressionEvaluator {
     constructor(type: string, func: (args: any[]) => number);
-    }
+}
 
 // @public (undocumented)
 export class NumericAtomContext extends PrimaryExpressionContext {
@@ -2814,7 +2813,7 @@ export class NumericAtomContext extends PrimaryExpressionContext {
 // @public
 export class NumericEvaluator extends ExpressionEvaluator {
     constructor(type: string, func: (args: any[]) => any);
-    }
+}
 
 // @public
 export class ObjectExpression<T> extends ExpressionProperty<T> {
@@ -2823,7 +2822,7 @@ export class ObjectExpression<T> extends ExpressionProperty<T> {
 
 // @public
 export class ObjectExpressionConverter<T extends object = {}> {
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_6" needs to be exported by the entry point index.d.ts
     convert(value: Input_6<T> | ObjectExpression<T>): ObjectExpression<T>;
 }
 
@@ -3102,7 +3101,6 @@ enum ReturnType_2 {
     Object = 4,
     String = 8
 }
-
 export { ReturnType_2 as ReturnType }
 
 // @public (undocumented)
@@ -3240,7 +3238,7 @@ export class StringExpression extends ExpressionProperty<string> {
 
 // @public
 export class StringExpressionConverter {
-    // Warning: (ae-forgotten-export) The symbol "Input" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Input_7" needs to be exported by the entry point index.d.ts
     convert(value: Input_7 | StringExpression): StringExpression;
 }
 
@@ -3311,14 +3309,14 @@ export class TextContentContext extends ParserRuleContext {
 // @public
 export class TimeTransformEvaluator extends ExpressionEvaluator {
     constructor(type: string, func: (timestamp: Date, numOfTransformation: number) => Date);
-    }
+}
 
 // @public
 export class TimeZoneConverter {
     static ianaToWindows(ianaTimeZoneId: string): string;
     static verifyTimeZoneStr(timezoneStr: string): boolean;
     static windowsToIana(windowsTimeZoneId: string): string;
-    }
+}
 
 // @public
 export class Trigger {
@@ -3329,7 +3327,7 @@ export class Trigger {
     readonly originalExpression: Expression;
     relationship(other: Trigger, comparers: PredicateComparers): RelationshipType;
     toString(builder?: string[], indent?: number): string;
-    }
+}
 
 // @public
 export class TriggerTree {
@@ -3345,7 +3343,7 @@ export class TriggerTree {
     totalTriggers: number;
     treeToString(indent?: number): string;
     verifyTree(): Node_2;
-    }
+}
 
 // @public (undocumented)
 export class TripleOpExpContext extends ExpressionContext {
@@ -3412,7 +3410,6 @@ export type ValueWithError = {
 
 // @public
 export type VerifyExpression = (value: any, expression: Expression, child: number) => string | undefined;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
+++ b/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
@@ -63,8 +63,8 @@ export interface AnswerSpanResponse {
     text: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "QnAMakerClient" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "QnAMakerTelemetryClient" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "QnAMakerClient_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "QnAMakerTelemetryClient_2" needs to be exported by the entry point index.d.ts
 //
 // @public
 export class CustomQuestionAnswering implements QnAMakerClient_2, QnAMakerTelemetryClient_2 {
@@ -94,7 +94,7 @@ export class CustomQuestionAnswering implements QnAMakerClient_2, QnAMakerTeleme
         [key: string]: number;
     }): Promise<void>;
     get telemetryClient(): BotTelemetryClient;
-    }
+}
 
 // @public
 export interface DateTimeSpec {
@@ -228,7 +228,7 @@ export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRe
     // (undocumented)
     static $kind: string;
     applicationId: StringExpression;
-    // Warning: (ae-forgotten-export) The symbol "DynamicList" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "DynamicList_2" needs to be exported by the entry point index.d.ts
     dynamicLists: ArrayExpression<DynamicList_2>;
     endpoint: StringExpression;
     endpointKey: StringExpression;
@@ -287,7 +287,7 @@ export class LuisBotComponent extends BotComponent {
 export class LuisComponentRegistration extends ComponentRegistration {
     constructor();
     getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[];
-    }
+}
 
 // @public
 export interface LuisPredictionOptions extends msRest.RequestOptionsBase {
@@ -327,7 +327,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
     }>;
     get telemetryClient(): BotTelemetryClient;
     static topIntent(results?: RecognizerResult, defaultIntent?: string, minScore?: number): string;
-    }
+}
 
 // @public (undocumented)
 export interface LuisRecognizerOptions {
@@ -467,7 +467,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
         [key: string]: number;
     }): Promise<void>;
     get telemetryClient(): BotTelemetryClient;
-    }
+}
 
 // @public (undocumented)
 export const QNAMAKER_TRACE_LABEL = "QnAMaker Trace";
@@ -499,7 +499,7 @@ export const QnAMakerClientKey: unique symbol;
 export class QnAMakerComponentRegistration extends ComponentRegistration {
     constructor();
     getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[];
-    }
+}
 
 // Warning: (ae-forgotten-export) The symbol "QnAMakerDialogConfiguration" needs to be exported by the entry point index.d.ts
 //
@@ -741,7 +741,6 @@ export function validateExternalEntity(entity: ExternalEntity): void;
 
 // @public
 export function validateListElement(element: ListElement): void;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
+++ b/libraries/botbuilder-dialogs-adaptive-testing/etc/botbuilder-dialogs-adaptive-testing.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { Activity } from 'botbuilder-core';
 import { BotComponent } from 'botbuilder-core';
 import { ClientRequest } from 'http';
@@ -155,7 +157,6 @@ class CustomEvent_2<T = unknown> extends TestAction implements CustomEventConfig
     name: string;
     value?: T;
 }
-
 export { CustomEvent_2 as CustomEvent }
 
 // @public (undocumented)
@@ -215,14 +216,14 @@ export class MockLuisLoader implements CustomDeserializer<MockLuisRecognizer, Lu
     constructor(_resourceExplorer: ResourceExplorer, _configuration?: Record<string, string>);
     // (undocumented)
     load(config: LuisAdaptiveRecognizerConfiguration, type: Newable<MockLuisRecognizer>): MockLuisRecognizer;
-    }
+}
 
 // @public
 export class MockLuisRecognizer extends Recognizer {
     constructor(recognizer: LuisAdaptiveRecognizer, resourceDir: string, name: string);
     // (undocumented)
     recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: Record<string, string>, telemetryMetrics?: Record<string, number>): Promise<RecognizerResult>;
-    }
+}
 
 // @public
 export class MockSettingsMiddleware implements Middleware {
@@ -385,7 +386,6 @@ export interface UserTypingConfiguration {
     // (undocumented)
     user?: string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -185,7 +185,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     get schema(): object;
     selector: TriggerSelector;
     triggers: OnCondition[];
-    }
+}
 
 // @public (undocumented)
 export interface AdaptiveDialogConfiguration extends DialogConfiguration {
@@ -538,7 +538,7 @@ export class ChoiceOptionsSet implements ChoiceFactoryOptions, TemplateInterface
     inlineOrMore?: string;
     // (undocumented)
     inlineSeparator?: string;
-    }
+}
 
 // @public (undocumented)
 export enum ChoiceOutputFormat {
@@ -552,7 +552,7 @@ export enum ChoiceOutputFormat {
 export class ChoiceSet extends Array<Choice> implements TemplateInterface<ChoiceSet, DialogStateManager> {
     constructor(obj: any);
     bind(dialogContext: DialogContext, data?: DialogStateManager): Promise<ChoiceSet>;
-    }
+}
 
 // @public
 export class CodeAction<O extends object = {}> extends Dialog<O> {
@@ -827,7 +827,7 @@ export class DialogExpression extends ExpressionProperty<Dialog> {
 export class DialogExpressionConverter implements Converter<Input, DialogExpression> {
     constructor(_resourceExplorer: ResourceExplorer);
     convert(value: Input | DialogExpression): DialogExpression;
-    }
+}
 
 // @public (undocumented)
 export type DialogProperty = Dialog | DialogExpression | Property;
@@ -1251,7 +1251,7 @@ export class IfCondition<O extends object = {}> extends Dialog<O> implements Dia
     getDependencies(): Dialog[];
     protected onComputeId(): string;
     protected get trueScope(): ActionScope;
-    }
+}
 
 // @public (undocumented)
 export interface IfConditionConfiguration extends DialogConfiguration {
@@ -1395,7 +1395,7 @@ export class LanguageGeneratorManager<T = unknown, D extends Record<string, unkn
     constructor(resourceManager: ResourceExplorer);
     languageGenerators: Map<string, LanguageGenerator<T, D>>;
     static resourceExplorerResolver(locale: string, resourceMapping: Map<string, Resource[]>): ImportResolverDelegate;
-    }
+}
 
 // @public
 export const languageGeneratorManagerKey: unique symbol;
@@ -1468,7 +1468,7 @@ export class MostSpecificSelector extends TriggerSelector implements MostSpecifi
     select(context: ActionContext): Promise<OnCondition[]>;
     // (undocumented)
     selector: TriggerSelector;
-    }
+}
 
 // @public (undocumented)
 export interface MostSpecificSelectorConfiguration {
@@ -2360,7 +2360,7 @@ export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<strin
     generate(dialogContext: DialogContext, template: string, data: D): Promise<T>;
     // (undocumented)
     id: string;
-    }
+}
 
 // @public (undocumented)
 export interface TemplateEngineLanguageGeneratorConfiguration {
@@ -2494,7 +2494,7 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
     // (undocumented)
     static $kind: string;
     constructor();
-    // Warning: (ae-forgotten-export) The symbol "D" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "D_2" needs to be exported by the entry point index.d.ts
     activity: TemplateInterface<Partial<Activity>, D_2 & O>;
     activityId: StringExpression;
     beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
@@ -2523,7 +2523,6 @@ export class UrlEntityRecognizer extends TextEntityRecognizer {
 
 // @public
 export function useTelemetry(dialogManager: DialogManager, telemetryClient: BotTelemetryClient): DialogManager;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -40,7 +40,7 @@
     "fs-extra": "^7.0.1",
     "htmlparser2": "^6.0.1",
     "uuid": "^8.3.2",
-    "zod": "^3.0.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -40,7 +40,7 @@
     "fs-extra": "^7.0.1",
     "htmlparser2": "^6.0.1",
     "uuid": "^8.3.2",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -38,7 +38,7 @@ import {
 } from 'botframework-streaming';
 
 // Note: this is _okay_ because we pass the result through `validateAndFixActivity`. Should not be used otherwise.
-const ActivityT = z.custom<Activity>((val) => z.record(z.unknown()).check(val), { message: 'Activity' });
+const ActivityT = z.custom<Activity>((val) => z.record(z.unknown()).safeParse(val).success, { message: 'Activity' });
 
 /**
  * An adapter that implements the Bot Framework Protocol and can be hosted in different cloud environmens both public and private.
@@ -118,7 +118,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
         // Ensure we have a parsed request body already. We rely on express/restify middleware to parse
         // request body and azure functions, which does it for us before invoking our code. Warn the user
         // to update their code and return an error.
-        if (!z.record(z.unknown()).check(req.body)) {
+        if (!z.record(z.unknown()).safeParse(req.body).success) {
             return end(
                 StatusCodes.BAD_REQUEST,
                 '`req.body` not an object, make sure you are using middleware to parse incoming requests.'

--- a/libraries/botbuilder/src/setSpeakMiddleware.ts
+++ b/libraries/botbuilder/src/setSpeakMiddleware.ts
@@ -11,20 +11,20 @@ const supportedChannels = new Set<string>([Channels.DirectlineSpeech, Channels.E
 function hasTag(tag: string, nodes: unknown[]): boolean {
     while (nodes.length) {
         const item = nodes.shift();
+        const zObject = z
+            .object({ tagName: z.string(), children: z.array(z.unknown()) })
+            .partial()
+            .nonstrict();
 
-        if (
-            z
-                .object({ tagName: z.string(), children: z.array(z.unknown()) })
-                .partial()
-                .nonstrict()
-                .check(item)
-        ) {
-            if (item.tagName === tag) {
+        if (zObject.safeParse(item).success) {
+            const itemParsed = zObject.parse(item);
+
+            if (itemParsed.tagName === tag) {
                 return true;
             }
 
-            if (item.children) {
-                nodes.push(...item.children);
+            if (itemParsed.children) {
+                nodes.push(...itemParsed.children);
             }
         }
     }

--- a/libraries/botbuilder/src/setSpeakMiddleware.ts
+++ b/libraries/botbuilder/src/setSpeakMiddleware.ts
@@ -42,7 +42,7 @@ export class SetSpeakMiddleware implements Middleware {
      * @param voiceName The SSML voice name attribute value.
      * @param fallbackToTextForSpeak true if an empty Activity.Speak is populated with Activity.Text.
      */
-    constructor(private readonly voiceName: string | null, private readonly fallbackToTextForSpeak: boolean) { }
+    constructor(private readonly voiceName: string | null, private readonly fallbackToTextForSpeak: boolean) {}
 
     /**
      * Processes an incoming activity.
@@ -73,8 +73,9 @@ export class SetSpeakMiddleware implements Middleware {
                                 activity.speak = `<voice name='${this.voiceName}'>${activity.speak}</voice>`;
                             }
 
-                            activity.speak = `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='${activity.locale ?? 'en-US'
-                                }'>${activity.speak}</speak>`;
+                            activity.speak = `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='${
+                                activity.locale ?? 'en-US'
+                            }'>${activity.speak}</speak>`;
                         }
                     }
                 })

--- a/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
+++ b/libraries/botbuilder/src/teams/teamsSSOTokenExchangeMiddleware.ts
@@ -144,6 +144,8 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
             const userTokenClient = context.turnState.get<UserTokenClient>(
                 (context.adapter as CloudAdapterBase).UserTokenClientKey
             );
+            const exchangeToken = ExchangeToken.safeParse(context.adapter);
+
             if (userTokenClient) {
                 tokenExchangeResponse = await userTokenClient.exchangeToken(
                     context.activity.from.id,
@@ -151,8 +153,8 @@ export class TeamsSSOTokenExchangeMiddleware implements Middleware {
                     context.activity.channelId,
                     { token: tokenExchangeRequest.token }
                 );
-            } else if (ExchangeToken.check(context.adapter)) {
-                tokenExchangeResponse = await context.adapter.exchangeToken(
+            } else if (exchangeToken.success) {
+                tokenExchangeResponse = await exchangeToken.data.exchangeToken(
                     context,
                     this.oAuthConnectionName,
                     context.activity.from.id,

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -80,7 +80,7 @@ describe('CloudAdapter', function () {
                 return this.configuration;
             }
 
-            set(_path, _val) { }
+            set(_path, _val) {}
         }
 
         const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
@@ -128,7 +128,7 @@ describe('CloudAdapter', function () {
             mock.verify();
         });
 
-        it.skip('throws exception on expired token', async function () {
+        it('throws exception on expired token', async function () {
             const consoleStub = sandbox.stub(console, 'error');
 
             // Expired token with removed AppID

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -257,7 +257,7 @@ describe('CloudAdapter', function () {
     describe('connectNamedPipe', function () {
         it('throws for bad args', async function () {
             const includesParam = (param) => (err) => {
-                assert(err.message.includes(`at ${param}`), err.message);
+                assert(err.message.includes(`${param}`), err.message);
                 return true;
             };
 

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -80,7 +80,7 @@ describe('CloudAdapter', function () {
                 return this.configuration;
             }
 
-            set(_path, _val) {}
+            set(_path, _val) { }
         }
 
         const activity = { type: ActivityTypes.Invoke, value: 'invoke' };
@@ -128,7 +128,7 @@ describe('CloudAdapter', function () {
             mock.verify();
         });
 
-        it('throws exception on expired token', async function () {
+        it.skip('throws exception on expired token', async function () {
             const consoleStub = sandbox.stub(console, 'error');
 
             // Expired token with removed AppID

--- a/libraries/botbuilder/tsconfig.json
+++ b/libraries/botbuilder/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "lib": ["es2015", "dom"],
     "outDir": "lib",
-    "rootDir": "src",
-    "skipLibCheck": true,
+    "rootDir": "src"
   },
   "include": [
     "src/**/*"

--- a/libraries/botbuilder/tsconfig.json
+++ b/libraries/botbuilder/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["es2015", "dom"],
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "skipLibCheck": true,
   },
   "include": [
     "src/**/*"

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -37,7 +37,7 @@
     "cross-fetch": "^3.0.5",
     "jsonwebtoken": "^9.0.0",
     "rsa-pem-from-mod-exp": "^0.8.4",
-    "zod": "^3.0.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -37,7 +37,7 @@
     "cross-fetch": "^3.0.5",
     "jsonwebtoken": "^9.0.0",
     "rsa-pem-from-mod-exp": "^0.8.4",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AdaptiveCard } from 'adaptivecards';
+import * as z from 'zod';
 
 // @public
 export type AceCardSize = 'Medium' | 'Large';
@@ -485,14 +486,14 @@ export interface CardAction {
 // @public
 export interface CardBarComponent extends BaseCardComponent {
     componentName: 'cardBar';
-    // Warning: (ae-forgotten-export) The symbol "CardImage" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CardImage_2" needs to be exported by the entry point index.d.ts
     icon?: CardImage_2;
     title?: string;
 }
 
 // @public
 export interface CardButtonBase {
-    // Warning: (ae-forgotten-export) The symbol "CardAction" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CardAction_2" needs to be exported by the entry point index.d.ts
     action: CardAction_2;
     id?: string;
 }
@@ -719,6 +720,944 @@ export interface ConversationParameters {
     tenantId?: string;
     topicName?: string;
 }
+
+// @public (undocumented)
+export const conversationParametersObject: z.ZodObject<{
+    isGroup: z.ZodBoolean;
+    bot: z.ZodObject<{
+        id: z.ZodString;
+        name: z.ZodString;
+        aadObjectId: z.ZodOptional<z.ZodString>;
+        role: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }, {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }>;
+    members: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        name: z.ZodString;
+        aadObjectId: z.ZodOptional<z.ZodString>;
+        role: z.ZodOptional<z.ZodString>;
+    }, "strip", z.ZodTypeAny, {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }, {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }>, "many">>;
+    topicName: z.ZodOptional<z.ZodString>;
+    tenantId: z.ZodOptional<z.ZodString>;
+    activity: z.ZodObject<{
+        type: z.ZodString;
+        id: z.ZodOptional<z.ZodString>;
+        timestamp: z.ZodOptional<z.ZodType<Date, z.ZodTypeDef, Date>>;
+        localTimestamp: z.ZodOptional<z.ZodType<Date, z.ZodTypeDef, Date>>;
+        localTimezone: z.ZodString;
+        callerId: z.ZodString;
+        serviceUrl: z.ZodString;
+        channelId: z.ZodString;
+        from: z.ZodObject<{
+            id: z.ZodString;
+            name: z.ZodString;
+            aadObjectId: z.ZodOptional<z.ZodString>;
+            role: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }>;
+        conversation: z.ZodObject<{
+            isGroup: z.ZodBoolean;
+            conversationType: z.ZodString;
+            tenantId: z.ZodOptional<z.ZodString>;
+            id: z.ZodString;
+            name: z.ZodString;
+            aadObjectId: z.ZodOptional<z.ZodString>;
+            role: z.ZodOptional<z.ZodString>;
+            properties: z.ZodOptional<z.ZodUnknown>;
+        }, "strip", z.ZodTypeAny, {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        }, {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        }>;
+        recipient: z.ZodObject<{
+            id: z.ZodString;
+            name: z.ZodString;
+            aadObjectId: z.ZodOptional<z.ZodString>;
+            role: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }>;
+        textFormat: z.ZodOptional<z.ZodString>;
+        attachmentLayout: z.ZodOptional<z.ZodString>;
+        membersAdded: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            id: z.ZodString;
+            name: z.ZodString;
+            aadObjectId: z.ZodOptional<z.ZodString>;
+            role: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }>, "many">>;
+        membersRemoved: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            id: z.ZodString;
+            name: z.ZodString;
+            aadObjectId: z.ZodOptional<z.ZodString>;
+            role: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }, {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }>, "many">>;
+        reactionsAdded: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            type: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            type?: string;
+        }, {
+            type?: string;
+        }>, "many">>;
+        reactionsRemoved: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            type: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            type?: string;
+        }, {
+            type?: string;
+        }>, "many">>;
+        topicName: z.ZodOptional<z.ZodString>;
+        historyDisclosed: z.ZodOptional<z.ZodBoolean>;
+        locale: z.ZodOptional<z.ZodString>;
+        text: z.ZodString;
+        speak: z.ZodOptional<z.ZodString>;
+        inputHint: z.ZodOptional<z.ZodString>;
+        summary: z.ZodOptional<z.ZodString>;
+        suggestedActions: z.ZodOptional<z.ZodObject<{
+            to: z.ZodArray<z.ZodString, "many">;
+            actions: z.ZodArray<z.ZodObject<{
+                type: z.ZodString;
+                title: z.ZodString;
+                image: z.ZodOptional<z.ZodString>;
+                text: z.ZodOptional<z.ZodString>;
+                displayText: z.ZodOptional<z.ZodString>;
+                value: z.ZodUnknown;
+                channelData: z.ZodUnknown;
+                imageAltText: z.ZodOptional<z.ZodString>;
+            }, "strip", z.ZodTypeAny, {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }, {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }>, "many">;
+        }, "strip", z.ZodTypeAny, {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        }, {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        }>>;
+        attachments: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            contentType: z.ZodString;
+            contentUrl: z.ZodOptional<z.ZodString>;
+            content: z.ZodOptional<z.ZodUnknown>;
+            name: z.ZodOptional<z.ZodString>;
+            thumbnailUrl: z.ZodOptional<z.ZodString>;
+        }, "strip", z.ZodTypeAny, {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }, {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }>, "many">>;
+        entities: z.ZodOptional<z.ZodArray<z.ZodEffects<z.ZodRecord<z.ZodString, z.ZodUnknown>, Record<string, unknown>, Record<string, unknown>>, "many">>;
+        channelData: z.ZodOptional<z.ZodUnknown>;
+        action: z.ZodOptional<z.ZodString>;
+        replyToId: z.ZodOptional<z.ZodString>;
+        label: z.ZodString;
+        valueType: z.ZodString;
+        value: z.ZodOptional<z.ZodUnknown>;
+        name: z.ZodOptional<z.ZodString>;
+        relatesTo: z.ZodOptional<z.ZodObject<{
+            ActivityId: z.ZodOptional<z.ZodString>;
+            user: z.ZodOptional<z.ZodObject<{
+                id: z.ZodString;
+                name: z.ZodString;
+                aadObjectId: z.ZodOptional<z.ZodString>;
+                role: z.ZodOptional<z.ZodString>;
+            }, "strip", z.ZodTypeAny, {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            }, {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            }>>;
+            locale: z.ZodOptional<z.ZodString>;
+            bot: z.ZodObject<{
+                id: z.ZodString;
+                name: z.ZodString;
+                aadObjectId: z.ZodOptional<z.ZodString>;
+                role: z.ZodOptional<z.ZodString>;
+            }, "strip", z.ZodTypeAny, {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            }, {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            }>;
+            conversation: z.ZodObject<{
+                isGroup: z.ZodBoolean;
+                conversationType: z.ZodString;
+                tenantId: z.ZodOptional<z.ZodString>;
+                id: z.ZodString;
+                name: z.ZodString;
+                aadObjectId: z.ZodOptional<z.ZodString>;
+                role: z.ZodOptional<z.ZodString>;
+                properties: z.ZodOptional<z.ZodUnknown>;
+            }, "strip", z.ZodTypeAny, {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            }, {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            }>;
+            channelId: z.ZodString;
+            serviceUrl: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        }, {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        }>>;
+        code: z.ZodOptional<z.ZodString>;
+        importance: z.ZodOptional<z.ZodString>;
+        deliveryMode: z.ZodOptional<z.ZodString>;
+        listenFor: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+        textHighlights: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            text: z.ZodString;
+            occurrence: z.ZodNumber;
+        }, "strip", z.ZodTypeAny, {
+            text?: string;
+            occurrence?: number;
+        }, {
+            text?: string;
+            occurrence?: number;
+        }>, "many">>;
+        semanticAction: z.ZodOptional<z.ZodObject<{
+            id: z.ZodString;
+            state: z.ZodString;
+            entities: z.ZodRecord<z.ZodString, z.ZodEffects<z.ZodRecord<z.ZodString, z.ZodUnknown>, Record<string, unknown>, Record<string, unknown>>>;
+        }, "strip", z.ZodTypeAny, {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        }, {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        }>>;
+    }, "strip", z.ZodTypeAny, {
+        type?: string;
+        id?: string;
+        timestamp?: Date;
+        localTimestamp?: Date;
+        localTimezone?: string;
+        callerId?: string;
+        serviceUrl?: string;
+        channelId?: string;
+        from?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        conversation?: {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        };
+        recipient?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        textFormat?: string;
+        attachmentLayout?: string;
+        membersAdded?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        membersRemoved?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        reactionsAdded?: {
+            type?: string;
+        }[];
+        reactionsRemoved?: {
+            type?: string;
+        }[];
+        topicName?: string;
+        historyDisclosed?: boolean;
+        locale?: string;
+        text?: string;
+        speak?: string;
+        inputHint?: string;
+        summary?: string;
+        suggestedActions?: {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        };
+        attachments?: {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }[];
+        entities?: Record<string, unknown>[];
+        channelData?: unknown;
+        action?: string;
+        replyToId?: string;
+        label?: string;
+        valueType?: string;
+        value?: unknown;
+        name?: string;
+        relatesTo?: {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        };
+        code?: string;
+        importance?: string;
+        deliveryMode?: string;
+        listenFor?: string[];
+        textHighlights?: {
+            text?: string;
+            occurrence?: number;
+        }[];
+        semanticAction?: {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        };
+    }, {
+        type?: string;
+        id?: string;
+        timestamp?: Date;
+        localTimestamp?: Date;
+        localTimezone?: string;
+        callerId?: string;
+        serviceUrl?: string;
+        channelId?: string;
+        from?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        conversation?: {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        };
+        recipient?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        textFormat?: string;
+        attachmentLayout?: string;
+        membersAdded?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        membersRemoved?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        reactionsAdded?: {
+            type?: string;
+        }[];
+        reactionsRemoved?: {
+            type?: string;
+        }[];
+        topicName?: string;
+        historyDisclosed?: boolean;
+        locale?: string;
+        text?: string;
+        speak?: string;
+        inputHint?: string;
+        summary?: string;
+        suggestedActions?: {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        };
+        attachments?: {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }[];
+        entities?: Record<string, unknown>[];
+        channelData?: unknown;
+        action?: string;
+        replyToId?: string;
+        label?: string;
+        valueType?: string;
+        value?: unknown;
+        name?: string;
+        relatesTo?: {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        };
+        code?: string;
+        importance?: string;
+        deliveryMode?: string;
+        listenFor?: string[];
+        textHighlights?: {
+            text?: string;
+            occurrence?: number;
+        }[];
+        semanticAction?: {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        };
+    }>;
+    channelData: z.ZodOptional<z.ZodUnknown>;
+}, "strip", z.ZodTypeAny, {
+    isGroup?: boolean;
+    bot?: {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    };
+    members?: {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }[];
+    topicName?: string;
+    tenantId?: string;
+    activity?: {
+        type?: string;
+        id?: string;
+        timestamp?: Date;
+        localTimestamp?: Date;
+        localTimezone?: string;
+        callerId?: string;
+        serviceUrl?: string;
+        channelId?: string;
+        from?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        conversation?: {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        };
+        recipient?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        textFormat?: string;
+        attachmentLayout?: string;
+        membersAdded?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        membersRemoved?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        reactionsAdded?: {
+            type?: string;
+        }[];
+        reactionsRemoved?: {
+            type?: string;
+        }[];
+        topicName?: string;
+        historyDisclosed?: boolean;
+        locale?: string;
+        text?: string;
+        speak?: string;
+        inputHint?: string;
+        summary?: string;
+        suggestedActions?: {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        };
+        attachments?: {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }[];
+        entities?: Record<string, unknown>[];
+        channelData?: unknown;
+        action?: string;
+        replyToId?: string;
+        label?: string;
+        valueType?: string;
+        value?: unknown;
+        name?: string;
+        relatesTo?: {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        };
+        code?: string;
+        importance?: string;
+        deliveryMode?: string;
+        listenFor?: string[];
+        textHighlights?: {
+            text?: string;
+            occurrence?: number;
+        }[];
+        semanticAction?: {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        };
+    };
+    channelData?: unknown;
+}, {
+    isGroup?: boolean;
+    bot?: {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    };
+    members?: {
+        id?: string;
+        name?: string;
+        aadObjectId?: string;
+        role?: string;
+    }[];
+    topicName?: string;
+    tenantId?: string;
+    activity?: {
+        type?: string;
+        id?: string;
+        timestamp?: Date;
+        localTimestamp?: Date;
+        localTimezone?: string;
+        callerId?: string;
+        serviceUrl?: string;
+        channelId?: string;
+        from?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        conversation?: {
+            isGroup?: boolean;
+            conversationType?: string;
+            tenantId?: string;
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+            properties?: unknown;
+        };
+        recipient?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        };
+        textFormat?: string;
+        attachmentLayout?: string;
+        membersAdded?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        membersRemoved?: {
+            id?: string;
+            name?: string;
+            aadObjectId?: string;
+            role?: string;
+        }[];
+        reactionsAdded?: {
+            type?: string;
+        }[];
+        reactionsRemoved?: {
+            type?: string;
+        }[];
+        topicName?: string;
+        historyDisclosed?: boolean;
+        locale?: string;
+        text?: string;
+        speak?: string;
+        inputHint?: string;
+        summary?: string;
+        suggestedActions?: {
+            to?: string[];
+            actions?: {
+                type?: string;
+                title?: string;
+                image?: string;
+                text?: string;
+                displayText?: string;
+                value?: unknown;
+                channelData?: unknown;
+                imageAltText?: string;
+            }[];
+        };
+        attachments?: {
+            contentType?: string;
+            contentUrl?: string;
+            content?: unknown;
+            name?: string;
+            thumbnailUrl?: string;
+        }[];
+        entities?: Record<string, unknown>[];
+        channelData?: unknown;
+        action?: string;
+        replyToId?: string;
+        label?: string;
+        valueType?: string;
+        value?: unknown;
+        name?: string;
+        relatesTo?: {
+            ActivityId?: string;
+            user?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            locale?: string;
+            bot?: {
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+            };
+            conversation?: {
+                isGroup?: boolean;
+                conversationType?: string;
+                tenantId?: string;
+                id?: string;
+                name?: string;
+                aadObjectId?: string;
+                role?: string;
+                properties?: unknown;
+            };
+            channelId?: string;
+            serviceUrl?: string;
+        };
+        code?: string;
+        importance?: string;
+        deliveryMode?: string;
+        listenFor?: string[];
+        textHighlights?: {
+            text?: string;
+            occurrence?: number;
+        }[];
+        semanticAction?: {
+            id?: string;
+            state?: string;
+            entities?: Record<string, Record<string, unknown>>;
+        };
+    };
+    channelData?: unknown;
+}>;
 
 // @public
 export interface ConversationReference {
@@ -1177,7 +2116,6 @@ interface Location_2 {
     longitude: number;
     timestamp?: number;
 }
-
 export { Location_2 as Location }
 
 // @public
@@ -1639,7 +2577,7 @@ export interface PagedMembersResult {
 }
 
 // @public @deprecated
-interface PaymentAddress_2 {
+export interface PaymentAddress {
     addressLine: string[];
     city: string;
     country: string;
@@ -1653,15 +2591,12 @@ interface PaymentAddress_2 {
     sortingCode: string;
 }
 
-export { PaymentAddress_2 as PaymentAddress }
-
 // @public @deprecated
 interface PaymentCurrencyAmount_2 {
     currency: string;
     currencySystem: string;
     value: string;
 }
-
 export { PaymentCurrencyAmount_2 as PaymentCurrencyAmount }
 
 // @public @deprecated
@@ -1669,7 +2604,7 @@ export interface PaymentDetails {
     displayItems: PaymentItem_2[];
     error: string;
     modifiers: PaymentDetailsModifier_2[];
-    shippingOptions: PaymentShippingOption_2[];
+    shippingOptions: PaymentShippingOption[];
     total: PaymentItem_2;
 }
 
@@ -1680,7 +2615,6 @@ interface PaymentDetailsModifier_2 {
     supportedMethods: string[];
     total: PaymentItem_2;
 }
-
 export { PaymentDetailsModifier_2 as PaymentDetailsModifier }
 
 // @public @deprecated
@@ -1689,7 +2623,6 @@ interface PaymentItem_2 {
     label: string;
     pending: boolean;
 }
-
 export { PaymentItem_2 as PaymentItem }
 
 // @public @deprecated
@@ -1697,11 +2630,10 @@ interface PaymentMethodData_2 {
     data: any;
     supportedMethods: string[];
 }
-
 export { PaymentMethodData_2 as PaymentMethodData }
 
 // @public @deprecated
-interface PaymentOptions_2 {
+export interface PaymentOptions {
     requestPayerEmail: boolean;
     requestPayerName: boolean;
     requestPayerPhone: boolean;
@@ -1709,17 +2641,14 @@ interface PaymentOptions_2 {
     shippingType: string;
 }
 
-export { PaymentOptions_2 as PaymentOptions }
-
 // @public @deprecated
 interface PaymentRequest_2 {
     details: PaymentDetails;
     expires: string;
     id: string;
     methodData: PaymentMethodData_2[];
-    options: PaymentOptions_2;
+    options: PaymentOptions;
 }
-
 export { PaymentRequest_2 as PaymentRequest }
 
 // @public @deprecated
@@ -1738,7 +2667,7 @@ export interface PaymentRequestCompleteResult {
 export interface PaymentRequestUpdate {
     details: PaymentDetails;
     id: string;
-    shippingAddress: PaymentAddress_2;
+    shippingAddress: PaymentAddress;
     shippingOption: string;
 }
 
@@ -1753,21 +2682,18 @@ interface PaymentResponse_2 {
     methodName: string;
     payerEmail: string;
     payerPhone: string;
-    shippingAddress: PaymentAddress_2;
+    shippingAddress: PaymentAddress;
     shippingOption: string;
 }
-
 export { PaymentResponse_2 as PaymentResponse }
 
 // @public @deprecated
-interface PaymentShippingOption_2 {
+export interface PaymentShippingOption {
     amount: PaymentCurrencyAmount_2;
     id: string;
     label: string;
     selected: boolean;
 }
-
-export { PaymentShippingOption_2 as PaymentShippingOption }
 
 // @public
 export interface Place {
@@ -2557,7 +3483,6 @@ export interface VideoCard {
 
 // @public
 export type ViewResponseType = 'Card' | 'QuickView' | 'NoOp';
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "uuid": "^8.3.2",
-    "zod": "~1.11.17",
+    "zod": "^3.0.0",
     "adaptivecards": "1.2.3"
   },
   "scripts": {

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "uuid": "^8.3.2",
-    "zod": "^3.0.0",
+    "zod": "^3.22.4",
     "adaptivecards": "1.2.3"
   },
   "scripts": {

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -50,7 +50,7 @@ export function assertAttachmentView(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isAttachmentView(val: unknown): val is AttachmentView {
-    return attachmentView.check(val);
+    return attachmentView.safeParse(val).success;
 }
 
 /**
@@ -88,7 +88,7 @@ export function assertAttachmentInfo(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isAttachmentInfo(val: unknown): val is AttachmentInfo {
-    return attachmentInfo.check(val);
+    return attachmentInfo.safeParse(val).success;
 }
 
 /**
@@ -175,7 +175,7 @@ export function assertChannelAccount(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isChannelAccount(val: unknown): val is ChannelAccount {
-    return channelAccount.check(val);
+    return channelAccount.safeParse(val).success;
 }
 
 /**
@@ -241,7 +241,7 @@ export function assertConversationAccount(val: unknown, ..._args: unknown[]): as
  * @internal
  */
 export function isConversationAccount(val: unknown): val is ConversationAccount {
-    return conversationAccount.check(val);
+    return conversationAccount.safeParse(val).success;
 }
 
 /**
@@ -269,7 +269,7 @@ export function assertMessageReaction(val: unknown, ..._args: unknown[]): assert
  * @internal
  */
 export function isMessageReaction(val: unknown): val is MessageReaction {
-    return messageReaction.check(val);
+    return messageReaction.safeParse(val).success;
 }
 
 /**
@@ -334,7 +334,7 @@ export function assertCardAction(val: unknown, ..._args: unknown[]): asserts val
  * @internal
  */
 export function isCardAction(val: unknown): val is CardAction {
-    return cardAction.check(val);
+    return cardAction.safeParse(val).success;
 }
 
 /**
@@ -368,7 +368,7 @@ export function assertSuggestedActions(val: unknown, ..._args: unknown[]): asser
  * @internal
  */
 export function isSuggestedActions(val: unknown): val is SuggestedActions {
-    return suggestedActions.check(val);
+    return suggestedActions.safeParse(val).success;
 }
 
 /**
@@ -416,7 +416,7 @@ export function assertAttachment(val: unknown, ..._args: unknown[]): asserts val
  * @internal
  */
 export function isAttachment(val: unknown): val is Attachment {
-    return attachment.check(val);
+    return attachment.safeParse(val).success;
 }
 
 /**
@@ -446,7 +446,7 @@ export function assertEntity(val: unknown, ..._args: unknown[]): asserts val is 
  * @internal
  */
 export function isEntity(val: unknown): val is Entity {
-    return entity.check(val);
+    return entity.safeParse(val).success;
 }
 
 /**
@@ -508,7 +508,7 @@ export function assertConversationReference(val: unknown, ..._args: unknown[]): 
  * @internal
  */
 export function isConversationReference(val: unknown): val is ConversationReference {
-    return conversationReference.check(val);
+    return conversationReference.safeParse(val).success;
 }
 
 /**
@@ -565,7 +565,7 @@ export function assertSemanticAction(val: unknown, ..._args: unknown[]): asserts
  * @internal
  */
 export function isSemanticAction(val: unknown): val is SemanticAction {
-    return semanticAction.check(val);
+    return semanticAction.safeParse(val).success;
 }
 
 /**
@@ -816,7 +816,7 @@ export function assertActivity(val: unknown, ..._args: unknown[]): asserts val i
  * @internal
  */
 export function isActivity(val: unknown): val is Activity {
-    return activity.check(val);
+    return activity.safeParse(val).success;
 }
 
 /**
@@ -829,6 +829,16 @@ export interface ActivityTimestamps extends Activity {
     rawExpiration?: string;
     rawLocalTimestamp?: string;
 }
+
+export const conversationParametersObject = z.object({
+    isGroup: z.boolean(),
+    bot: channelAccount,
+    members: z.array(channelAccount).optional(),
+    topicName: z.string().optional(),
+    tenantId: z.string().optional(),
+    activity: activity,
+    channelData: z.unknown().optional(),
+});
 
 /**
  * Parameters for creating a new conversation

--- a/libraries/botframework-streaming/etc/botframework-streaming.api.md
+++ b/libraries/botframework-streaming/etc/botframework-streaming.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { Duplex } from 'stream';
 import { DuplexOptions } from 'stream';
 import * as WebSocket_2 from 'ws';
@@ -21,7 +23,7 @@ export class ContentStream {
     get length(): number;
     readAsJson<T>(): Promise<T>;
     readAsString(): Promise<string>;
-    }
+}
 
 // @public
 export class HttpContent {
@@ -31,7 +33,7 @@ export class HttpContent {
     //
     // (undocumented)
     headers: IHttpContentHeaders;
-    }
+}
 
 // @public
 export interface INodeBuffer extends Uint8Array {
@@ -260,7 +262,7 @@ export interface INodeSocket {
     once(event: string | symbol, listener: (...args: any[]) => void): this;
     // (undocumented)
     pause(): this;
-    // Warning: (ae-forgotten-export) The symbol "WritableStream" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "WritableStream_2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     pipe<T extends WritableStream_2>(destination: T, options?: {
@@ -430,7 +432,7 @@ export class NamedPipeClient implements IStreamingTransportClient {
     connect(): Promise<void>;
     disconnect(): void;
     send(request: StreamingRequest): Promise<IReceiveResponse>;
-    }
+}
 
 // @public
 export class NamedPipeServer implements IStreamingTransportServer {
@@ -454,7 +456,7 @@ export class NodeWebSocket implements ISocket {
     write(buffer: INodeBuffer): void;
     // (undocumented)
     protected wsServer: WebSocket_2.Server;
-    }
+}
 
 // @public
 export class NodeWebSocketFactory extends NodeWebSocketFactoryBase {
@@ -515,7 +517,7 @@ export class WebSocketClient implements IStreamingTransportClient {
     connect(): Promise<void>;
     disconnect(): void;
     send(request: StreamingRequest): Promise<IReceiveResponse>;
-    }
+}
 
 // @public
 export class WebSocketServer implements IStreamingTransportServer {
@@ -524,8 +526,7 @@ export class WebSocketServer implements IStreamingTransportServer {
     get isConnected(): boolean;
     send(request: StreamingRequest): Promise<IReceiveResponse>;
     start(): Promise<string>;
-    }
-
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@azure/logger": "^1.0.2",
     "@azure/ms-rest-js": "^2.7.0",
-    "@microsoft/api-extractor": "^7.15.1",
+    "@microsoft/api-extractor": "^7.38.2",
     "@standardlabs/downlevel-dts": "^0.7.5",
     "@standardlabs/is-private": "^1.0.1",
     "@types/jsonwebtoken": "7.2.8",

--- a/testing/botbuilder-test-utils/package.json
+++ b/testing/botbuilder-test-utils/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "nanoid": "^3.1.31",
     "node-forge": "^1.3.0",
-    "zod": "~1.11.17"
+    "zod": "^3.0.0"
   }
 }

--- a/testing/botbuilder-test-utils/package.json
+++ b/testing/botbuilder-test-utils/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "nanoid": "^3.1.31",
     "node-forge": "^1.3.0",
-    "zod": "^3.0.0"
+    "zod": "^3.22.4"
   }
 }

--- a/testing/consumer-test/run.ts
+++ b/testing/consumer-test/run.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 
 const execp = promisify(exec);
 
-const versions = ['3.8', '3.9', '4.0', '4.1', '4.2', '4.3'];
+const versions = ['4.3', '4.4', '4.5', '4.6', '4.7', '4.8'];
 
 (async () => {
     const flags = minimist(process.argv.slice(2), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,32 +1523,32 @@
   dependencies:
     dotnet-2.0.0 "^1.4.4"
 
-"@microsoft/api-extractor-model@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.13.1.tgz#6dd9c4bd49b5d0d32b44c564a94c34b3c3aa2a87"
-  integrity sha512-PKAjDmAJ6X07tvqCHSN1PRaKq8bZQXF9QI6WGEMnCHNFWwXUoITOAcvFW0Ol3TzwHO5rLbuy/CqWebfhv8eOtw==
+"@microsoft/api-extractor-model@7.28.2":
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.28.2.tgz#91c66dd820ccc70e0c163e06b392d8363f1b9269"
+  integrity sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==
   dependencies:
-    "@microsoft/tsdoc" "0.13.2"
-    "@microsoft/tsdoc-config" "~0.15.2"
-    "@rushstack/node-core-library" "3.37.0"
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "~0.16.1"
+    "@rushstack/node-core-library" "3.61.0"
 
-"@microsoft/api-extractor@^7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.15.1.tgz#c3791933367ddded72a2f1d3c437e17fa050eac5"
-  integrity sha512-PYbGAvxbM5B6HbafXY7tJ4ObYpeUZrZFt9vlN68tpYG/7aeldMLAZSjTyB30VFXaGlArjeEooKZIcs2ZnVAbNg==
+"@microsoft/api-extractor@^7.38.2":
+  version "7.38.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.38.2.tgz#fbc329fbec2b27a160507d08d02b78018fd142ac"
+  integrity sha512-JOARuhTwOcOMIU0O2czscoJy3ddVzIRhSA9/7T1ALuZSNphgWsPk+Bv4E7AnBDmTV4pP4lBNLtCxEHjjpWaytQ==
   dependencies:
-    "@microsoft/api-extractor-model" "7.13.1"
-    "@microsoft/tsdoc" "0.13.2"
-    "@microsoft/tsdoc-config" "~0.15.2"
-    "@rushstack/node-core-library" "3.37.0"
-    "@rushstack/rig-package" "0.2.12"
-    "@rushstack/ts-command-line" "4.7.10"
+    "@microsoft/api-extractor-model" "7.28.2"
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "~0.16.1"
+    "@rushstack/node-core-library" "3.61.0"
+    "@rushstack/rig-package" "0.5.1"
+    "@rushstack/ts-command-line" "4.17.1"
     colors "~1.2.1"
     lodash "~4.17.15"
-    resolve "~1.17.0"
-    semver "~7.3.0"
+    resolve "~1.22.1"
+    semver "~7.5.4"
     source-map "~0.6.1"
-    typescript "~4.2.4"
+    typescript "~5.0.4"
 
 "@microsoft/bf-chatdown@^4.15.0":
   version "4.15.0"
@@ -1679,20 +1679,20 @@
   resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text/-/recognizers-text-1.3.1.tgz#eda98a9148101ecdb04ed1424082d472b04aabd9"
   integrity sha512-HikLoRUgSzM4OKP3JVBzUUp3Q7L4wgI17p/3rERF01HVmopcujY3i6wgx8PenCwbenyTNxjr1AwSDSVuFlYedQ==
 
-"@microsoft/tsdoc-config@~0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz#eb353c93f3b62ab74bdc9ab6f4a82bcf80140f14"
-  integrity sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==
+"@microsoft/tsdoc-config@~0.16.1":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz#b786bb4ead00d54f53839a458ce626c8548d3adf"
+  integrity sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==
   dependencies:
-    "@microsoft/tsdoc" "0.13.2"
+    "@microsoft/tsdoc" "0.14.2"
     ajv "~6.12.6"
     jju "~1.4.0"
     resolve "~1.19.0"
 
-"@microsoft/tsdoc@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz#3b0efb6d3903bd49edb073696f60e90df08efb26"
-  integrity sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==
+"@microsoft/tsdoc@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
+  integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
 "@netflix/nerror@^1.0.0":
   version "1.1.3"
@@ -1898,33 +1898,31 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.10.2.tgz#55bea904b2b91aa8a8675df9eaba5961bddb1def"
   integrity sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
 
-"@rushstack/node-core-library@3.37.0":
-  version "3.37.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.37.0.tgz#6e8ebfdbe2829d380bc827bbb450361fb48e142c"
-  integrity sha512-b0OGvl20zfepytLBnKsOtemtiadNZAVolXxaSYssV9VjXaLPF97oLvtLfwc58BX05ufIsrKZgXatnRo8YeffNg==
+"@rushstack/node-core-library@3.61.0":
+  version "3.61.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.61.0.tgz#7441a0d2ae5268b758a7a49588a78cd55af57e66"
+  integrity sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==
   dependencies:
-    "@types/node" "10.17.13"
     colors "~1.2.1"
     fs-extra "~7.0.1"
     import-lazy "~4.0.0"
     jju "~1.4.0"
-    resolve "~1.17.0"
-    semver "~7.3.0"
-    timsort "~0.3.0"
-    z-schema "~3.18.3"
+    resolve "~1.22.1"
+    semver "~7.5.4"
+    z-schema "~5.0.2"
 
-"@rushstack/rig-package@0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.2.12.tgz#c434d62b28e0418a040938226f8913971d0424c7"
-  integrity sha512-nbePcvF8hQwv0ql9aeQxcaMPK/h1OLAC00W7fWCRWIvD2MchZOE8jumIIr66HGrfG2X1sw++m/ZYI4D+BM5ovQ==
+"@rushstack/rig-package@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.5.1.tgz#6c9c283cc96b5bb1eae9875946d974ac5429bb21"
+  integrity sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==
   dependencies:
-    resolve "~1.17.0"
+    resolve "~1.22.1"
     strip-json-comments "~3.1.1"
 
-"@rushstack/ts-command-line@4.7.10":
-  version "4.7.10"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.7.10.tgz#a2ec6efb1945b79b496671ce90eb1be4f1397d31"
-  integrity sha512-8t042g8eerypNOEcdpxwRA3uCmz0duMo21rG4Z2mdz7JxJeylDmzjlU3wDdef2t3P1Z61JCdZB6fbm1Mh0zi7w==
+"@rushstack/ts-command-line@4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz#c78db928ce5b93f2e98fd9e14c24f3f3876e57f1"
+  integrity sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==
   dependencies:
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
@@ -2272,11 +2270,6 @@
   version "14.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
   integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
-
-"@types/node@10.17.13":
-  version "10.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
-  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
 "@types/node@^10.17.27":
   version "10.17.44"
@@ -4480,7 +4473,12 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.19.0, commander@^2.20.0, commander@^2.7.1:
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -8807,7 +8805,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4.0.0, lodash.get@^4.4.2:
+lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -8822,7 +8820,7 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
-lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -11372,7 +11370,7 @@ resolve@^1.13.1, resolve@~1.19.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resolve@^1.14.2, resolve@^1.22.3:
+resolve@^1.14.2, resolve@^1.22.3, resolve@~1.22.1:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -11380,13 +11378,6 @@ resolve@^1.14.2, resolve@^1.22.3:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@~1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
 
 responselike@1.0.2:
   version "1.0.2"
@@ -11673,17 +11664,10 @@ semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semve
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.4:
+semver@^7.5.4, semver@~7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@~7.3.0:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -12878,11 +12862,6 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-timsort@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
-  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
 tinyify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tinyify/-/tinyify-3.0.0.tgz#99d5f805191558c6d85dacabe634d617da5509e6"
@@ -13230,10 +13209,10 @@ typescript@^4.1.0-dev.20201026:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.0-dev.20201102.tgz#e1978890ac063bb3f13d067067905b312c1e0897"
   integrity sha512-kyL2MUGRx69NgowtHpnabYzNA3N8CR+XW51kL9my6MfSXyrojytW5P4YmaayHGQhWLRmzzdDvHfkf2PQBHgbUw==
 
-typescript@~4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@~5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uglify-js@^3.1.4:
   version "3.11.4"
@@ -13572,10 +13551,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
-  integrity sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==
+validator@^13.7.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -14162,18 +14141,18 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-z-schema@~3.18.3:
-  version "3.18.4"
-  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.18.4.tgz#ea8132b279533ee60be2485a02f7e3e42541a9a2"
-  integrity sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
+z-schema@~5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.6.tgz#46d6a687b15e4a4369e18d6cb1c7b8618fc256c5"
+  integrity sha512-+XR1GhnWklYdfr8YaZv/iu+vY+ux7V5DS5zH1DQf6bO5ufrt/5cgNhVO5qyhsjFXvsqQb/f08DWE9b6uPscyAg==
   dependencies:
-    lodash.get "^4.0.0"
-    lodash.isequal "^4.0.0"
-    validator "^8.0.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
   optionalDependencies:
-    commander "^2.7.1"
+    commander "^10.0.0"
 
-zod@^3.0.0:
+zod@^3.22.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14173,6 +14173,11 @@ z-schema@~3.18.3:
   optionalDependencies:
     commander "^2.7.1"
 
+zod@^3.0.0:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+
 zod@~1.11.17:
   version "1.11.17"
   resolved "https://registry.yarnpkg.com/zod/-/zod-1.11.17.tgz#2aae9e91fc66128116ae9844e8f416a95f453f8e"


### PR DESCRIPTION
#minor

## Description
This PR migrates the use of zod 1.11.17 to ^3.0.0 to avoid [ReDoS](https://security.snyk.io/vuln/SNYK-JS-ZOD-5925617) vulnerability.

## Specific Changes
  - Updated zod version to **^3.22.4** in 
       - botbuilder
       - botframework-schema
       - botframework-connector
       - botbuilder-tests-utils
  - Replaced use of **_check_** method with **_safeParse_**.

## Testing
The following image shows some bot samples working after the update.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/f0c46286-413f-4098-8bd8-fc25ad0b1beb)
![image](https://github.com/southworks/botbuilder-js/assets/122501764/542cdf97-e3e4-45d5-8e86-f82540e2a323)