### PR TITLE
fix: [#4568] scoreThreshold no longer works in 4.17.0 and later

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
@@ -159,6 +159,30 @@ export class GenerateAnswerUtils {
         }
     }
 
+    /**
+     * Sorts all QnAMakerResult from highest-to-lowest scoring.
+     * Filters QnAMakerResults within threshold specified (default threshold: .001).
+     *
+     * @param {QnAMakerResult[]} answers Answers returned by QnA Maker.
+     * @param {QnAMakerOptions} queryOptions (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
+     * @returns {QnAMakerResult[]} the sorted and filtered results
+     */
+    static sortAnswersWithinThreshold(
+        answers: QnAMakerResult[] = [] as QnAMakerResult[],
+        queryOptions: QnAMakerOptions
+    ): QnAMakerResult[] {
+        const minScore: number = typeof queryOptions.scoreThreshold === 'number' ? queryOptions.scoreThreshold : 0.001;
+
+        if (answers.length === 1 && answers[0].id === -1) {
+            // if the answer is the default answer, don't filter it by score.
+            return answers;
+        }
+
+        return answers
+            .filter((ans: QnAMakerResult) => ans.score >= minScore)
+            .sort((a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score);
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private formatQnaResult(qnaResult: QnAMakerResults | any): QnAMakerResults {
         qnaResult.answers = qnaResult.answers.map((answer: QnAMakerResult & { qnaId?: number }) => {


### PR DESCRIPTION
Fixes # 4568
#minor

## Description
This PR reverts part of the changes in PR# 4208 where the function that filtered the QnAMaker results using the score threshold value set in the QnAMaker options.
It also includes a condition to skip the filter when the returned answer is the QnAMaker default answer.

## Specific Changes
- Adding back the `sortAnswersWithinThreshold` function in _generateAnswerUtils.ts_.
- Restored the call to the sort function in _QnAMaker_ class before returning the results.

## Testing
These images show the results returned when a score threshold is set with a value of 0.65:
![image](https://github.com/southworks/botbuilder-js/assets/44245136/24f5040f-c2b6-455a-94dc-5204d4ea796a)