### PR TITLE
fix: [#4544] JwtTokenExtractor.getIdentity:err! FetchError: request to https://login.botframework.com/v1/.well-known/openidconfiguration

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -35,7 +35,9 @@
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",
     "cross-fetch": "^3.0.5",
+    "https-proxy-agent": "^7.0.2",
     "jsonwebtoken": "^9.0.0",
+    "node-fetch": "^2.6.7",
     "rsa-pem-from-mod-exp": "^0.8.4",
     "zod": "^3.22.4"
   },

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -12,7 +12,7 @@ import { EndorsementsValidator } from './endorsementsValidator';
 import { OpenIdMetadata } from './openIdMetadata';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
-import { ProxySettings } from '@azure/ms-rest-js';
+import { ProxySettings } from '@azure/core-http';
 
 /**
  * A JWT token processing class that gets identity information and performs security token validation.

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -12,6 +12,7 @@ import { EndorsementsValidator } from './endorsementsValidator';
 import { OpenIdMetadata } from './openIdMetadata';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
+import { ProxySettings } from '@azure/ms-rest-js';
 
 /**
  * A JWT token processing class that gets identity information and performs security token validation.
@@ -32,17 +33,23 @@ export class JwtTokenExtractor {
      * @param tokenValidationParameters Token validation parameters.
      * @param metadataUrl Metadata Url.
      * @param allowedSigningAlgorithms Allowed signing algorithms.
+     * @param proxySettings The proxy settings for the request.
      */
-    constructor(tokenValidationParameters: VerifyOptions, metadataUrl: string, allowedSigningAlgorithms: string[]) {
+    constructor(
+        tokenValidationParameters: VerifyOptions,
+        metadataUrl: string,
+        allowedSigningAlgorithms: string[],
+        proxySettings?: ProxySettings
+    ) {
         this.tokenValidationParameters = { ...tokenValidationParameters };
         this.tokenValidationParameters.algorithms = allowedSigningAlgorithms;
-        this.openIdMetadata = JwtTokenExtractor.getOrAddOpenIdMetadata(metadataUrl);
+        this.openIdMetadata = JwtTokenExtractor.getOrAddOpenIdMetadata(metadataUrl, proxySettings);
     }
 
-    private static getOrAddOpenIdMetadata(metadataUrl: string): OpenIdMetadata {
+    private static getOrAddOpenIdMetadata(metadataUrl: string, proxySettings?: ProxySettings): OpenIdMetadata {
         let metadata = this.openIdMetadataCache.get(metadataUrl);
         if (!metadata) {
-            metadata = new OpenIdMetadata(metadataUrl);
+            metadata = new OpenIdMetadata(metadataUrl, proxySettings);
             this.openIdMetadataCache.set(metadataUrl, metadata);
         }
 

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -8,9 +8,11 @@
 
 import * as getPem from 'rsa-pem-from-mod-exp';
 import base64url from 'base64url';
-import fetch from 'cross-fetch';
+import fetch from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
+import { ProxySettings } from '@azure/ms-rest-js';
 
 /**
  * Class in charge of manage OpenId metadata.
@@ -23,8 +25,9 @@ export class OpenIdMetadata {
      * Initializes a new instance of the [OpenIdMetadata](xref:botframework-connector.OpenIdMetadata) class.
      *
      * @param url Metadata Url.
+     * @param proxySettings The proxy settings for the request.
      */
-    constructor(private url: string) {}
+    constructor(private url: string, private proxySettings?: ProxySettings) {}
 
     /**
      * Gets the Signing key.
@@ -56,7 +59,12 @@ export class OpenIdMetadata {
      * @private
      */
     private async refreshCache(): Promise<void> {
-        const res = await fetch(this.url);
+        let agent = null;
+        if (this.proxySettings) {
+            const proxyUrl = `http://${this.proxySettings.host}:${this.proxySettings.port}`;
+            agent = new HttpsProxyAgent(proxyUrl);
+        }
+        const res = await fetch(this.url, { agent: agent });
 
         if (res.ok) {
             const openIdConfig = (await res.json()) as IOpenIdConfig;

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -12,7 +12,7 @@ import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
-import { ProxySettings } from '@azure/ms-rest-js';
+import { ProxySettings } from '@azure/core-http';
 
 /**
  * Class in charge of manage OpenId metadata.

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -298,7 +298,8 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         const tokenExtractor = new JwtTokenExtractor(
             verifyOptions,
             this.toBotFromEmulatorOpenIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
+            this.connectorClientOptions?.proxySettings
         );
 
         const parts: string[] = authHeader.split(' ');
@@ -384,7 +385,8 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             verifyOptions,
             this.toBotFromEmulatorOpenIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
+            this.connectorClientOptions?.proxySettings
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
@@ -470,7 +472,8 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             tokenValidationParameters,
             this.toBotFromChannelOpenIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
+            this.connectorClientOptions?.proxySettings
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,6 +2838,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.0.tgz#536802b76bc0b34aa50195eb2442276d613e3434"
+  integrity sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==
+  dependencies:
+    debug "^4.3.4"
+
 agentkeepalive@^4.1.3:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
@@ -7526,6 +7533,14 @@ https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
+  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 humanize-ms@^1.2.1:


### PR DESCRIPTION
Fixes # 4544
#minor

## Description
This PR fixes the error thrown in openIdMetadata when the bot is used behind a proxy server by setting the proxy's URL in the fetch agent.

## Specific Changes
- Updated `parameterizedBotFrameworkAuthentication` to pass the proxy settings to _jwtTokenExtractor_.
- Updated `jwtTokenExtractor` to pass the proxy settings to _openIdMetadata_.
- Updated `openIdMetada` to set the agent in the fetch, containing the proxy URL.
- Replaced `cross-fetch` with `node-fetch` to pass the agent option.

## Testing
We tested this using different tools to simulate HTTP and HTTPS proxies.
These images show the request intercepted by the proxy and the bot working.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/860ab4ce-cd0a-4a24-a734-cd276245f027)