### PR TITLE
bump: Update follow-redirects to avoid vulnerability

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -40,7 +40,7 @@
     "zod": "^3.22.4"
   },
   "resolutions": {
-    "follow-redirects": "1.14.7"
+    "follow-redirects": "^1.14.8"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "**/request-promise/tough-cookie": "^4.1.3",
     "**/request-promise-native/tough-cookie": "^4.1.3",
     "**/istanbul-lib-instrument/@babel/core": "^7.23.2",
-    "**/@babel/plugin-proposal-class-properties/@babel/core": "^7.23.2"
+    "**/@babel/plugin-proposal-class-properties/@babel/core": "^7.23.2",
+    "follow-redirects": "^1.14.8"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6428,15 +6428,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
-
-follow-redirects@^1.15.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.8, follow-redirects@^1.15.0:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#minor

## Description
This PR updates the _**follow-redirects**_ package to avoid the _Exposure of Sensitive Information to an Unauthorized Actor_ vulnerability.

## Specific Changes
  - Updated _**follow-redirects**_ package from 1.14.7 to ^1.14.8.
  - Added _**follow-redirects**_ resolution to the version ^1.14.8.

## Testing
The following image shows the unit tests passing after the update.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/d33a805a-0abb-4b60-9ae6-c4853560ba11)
