### PR TITLE
fix: [#4582] UserAssignedIdentity(WorkloadIdentity) auth fails with 'scope https://api.botframework.com is not valid'

### DIFF
--- a/libraries/botframework-connector/src/auth/managedIdentityAuthenticator.ts
+++ b/libraries/botframework-connector/src/auth/managedIdentityAuthenticator.ts
@@ -30,6 +30,11 @@ export class ManagedIdentityAuthenticator {
         ok(resource?.trim(), 'ManagedIdentityAuthenticator.constructor(): missing resource.');
         ok(tokenProviderFactory, 'ManagedIdentityAuthenticator.constructor(): missing tokenProviderFactory.');
 
+        const scopePostfix = '/.default';
+        if (!resource.endsWith(scopePostfix)) {
+            resource = `${resource}${scopePostfix}`;
+        }
+
         this.resource = resource;
         this.tokenProvider = tokenProviderFactory.createAzureServiceTokenProvider(appId);
     }

--- a/libraries/botframework-connector/tests/auth/managedIdentityAuthenticator.test.js
+++ b/libraries/botframework-connector/tests/auth/managedIdentityAuthenticator.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const { JwtTokenProviderFactory, ManagedIdentityAuthenticator } = require('../../lib');
 
 const testAppId = 'foo';
-const testAudience = 'bar';
+const testAudience = 'bar/.default';
 const authResult = {
     token: '123',
     expiresOnTimestamp: 3000,


### PR DESCRIPTION
Fixes # 4582
#minor

## Description
This PR adds the `/.default` suffix to the scope for MSI communication.

## Specific Changes
- Updated `ManagedIdentityAuthenticator` to add the suffix to the scope.

## Testing
These images show the fix working with a bot deployed in _AKS_ and another one deployed in an _Azure App Service_.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/08e88fae-f003-4de6-8bcd-51d4f0d6812c)
