### PR TITLE
refactor: Improve calculateChangeHash to avoid circular reference errors

### DIFF
--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -121,6 +121,7 @@ export function calculateChangeHash(item: StoreItem): string {
         return result;
     }
 
+    // eslint-disable-next-line  @typescript-eslint/no-unused-vars
     const { eTag, ...rest } = item;
 
     try {


### PR DESCRIPTION
#minor

## Description
This PR updates the internal BotState cache hash functionality to prevent `JSON.stringify` from throwing circular reference errors, and generates from the resulted string a hash using the `node:crypto` library.

## Specific Changes
  - Updates the `calculateChangeHash` with an improved functionality.
  - Prevent the `JSON.stringify` from throwing circular reference errors.
  - Detect circular objects and replace the reference with a string value pointing out to the located path, helpful for future debugging and tracing.
  - Added the `node:crypto` library to generate a hash value that is easier to use for debugging and storing.

## Testing
The following images show how this new functionality detects and replaces circular references, and the generated hash string.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/45e6e7d7-97a4-4314-b0cb-39630f0dcaeb)
![image](https://github.com/southworks/botbuilder-js/assets/62260472/40f18496-ee41-4369-87c5-05fbec16e5a9)