### PR TITLE
refactor: Improve calculateChangeHash to avoid circular reference errors

### DIFF
--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -82,8 +82,10 @@ export class BotState implements PropertyManager {
     load(context: TurnContext, force = false): Promise<any> {
         const cached: CachedBotState = context.turnState.get(this.stateKey);
         if (!context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY)) {
-            context.turnState.set(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY, (key, properties) =>
-                this.skippedProperties.set(key, properties)
+            context.turnState.set(
+                CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY,
+                (state: BotState, key: string, properties: string[] = null) =>
+                    state.skippedProperties.set(key, properties)
             );
         }
         if (force || !cached || !cached.state) {

--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -133,6 +133,7 @@ export function calculateChangeHash(item: StoreItem): string {
         return result;
     }
 
+    // eslint-disable-next-line  @typescript-eslint/no-unused-vars
     const { eTag, ...rest } = item;
 
     try {

--- a/libraries/botbuilder-core/tests/botState.test.js
+++ b/libraries/botbuilder-core/tests/botState.test.js
@@ -168,8 +168,8 @@ describe('BotState', function () {
 
         // Save changes into storage.
         const skipProperties = context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY);
-        skipProperties('house', ['refrigerator', 'table', 'pants']); // Multiple props.
-        skipProperties('chair'); // Single prop (key used as prop).
+        skipProperties(botState, 'house', ['refrigerator', 'table', 'pants']); // Multiple props.
+        skipProperties(botState, 'chair'); // Single prop (key used as prop).
         await botState.saveChanges(context);
         const updatedState = context.turnState.get(botState.stateKey);
         const storageState = await storage.read([storageKey]);

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -211,7 +211,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
         // Skip properties from the bot's state cache hash due to unwanted conversationState behavior.
         const skipProperties = dc.context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY);
         const props: (keyof SkillDialogOptions)[] = ['conversationIdFactory', 'conversationState', 'skillClient'];
-        skipProperties(this._dialogOptionsStateKey, props);
+        skipProperties(this.dialogOptions.conversationState, this._dialogOptionsStateKey, props);
 
         // Get the activity to send to the skill.
         options = {} as BeginSkillDialogOptions;


### PR DESCRIPTION
#minor

## Description
This PR updates the internal BotState cache hash functionality to prevent `JSON.stringify` from throwing circular reference errors, and generates from the resulted string a hash using the `node:crypto` library.

## Specific Changes
  - Updates the `calculateChangeHash` with an improved functionality.
  - Prevent the `JSON.stringify` from throwing circular reference errors.
  - Detect circular objects and replace the reference with a string value pointing out to the located path, helpful for future debugging and tracing.
  - Added the `node:crypto` library to generate a hash value that is easier to use for debugging and storing.
  - Updates the BotState cache handler to skip properties in the desired state instead of the first state assigned in the `context.turnState`.

## Testing
The following images show how this new functionality detects and replaces circular references, and the generated hash string.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/45e6e7d7-97a4-4314-b0cb-39630f0dcaeb)
![image](https://github.com/southworks/botbuilder-js/assets/62260472/40f18496-ee41-4369-87c5-05fbec16e5a9)