### PR TITLE
bump: Update @azure/msal-node and @azure/msal-browser

### DIFF
--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@azure/core-http": "^3.0.2",
-    "@azure/msal-node": "1.18.4",
+    "@azure/msal-node": "^1.18.4",
     "axios": "^1.6.0",
     "botbuilder-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@azure/core-http": "^3.0.2",
-    "@azure/msal-node": "^1.2.0",
+    "@azure/msal-node": "1.18.4",
     "axios": "^1.6.0",
     "botbuilder-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -39,8 +39,7 @@
     "node-fetch": "^2.6.7",
     "rsa-pem-from-mod-exp": "^0.8.4",
     "zod": "^3.22.4",
-    "openssl-wrapper": "^0.3.4",
-    "axios": "^0.21.1"
+    "openssl-wrapper": "^0.3.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/core-http": "^3.0.2",
     "@azure/identity": "^2.0.4",
-    "@azure/msal-node": "^1.2.0",
+    "@azure/msal-node": "1.18.4",
     "base64url": "^3.0.0",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",
@@ -39,7 +39,8 @@
     "node-fetch": "^2.6.7",
     "rsa-pem-from-mod-exp": "^0.8.4",
     "zod": "^3.22.4",
-    "openssl-wrapper": "^0.3.4"
+    "openssl-wrapper": "^0.3.4",
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/core-http": "^3.0.2",
     "@azure/identity": "^2.0.4",
-    "@azure/msal-node": "1.18.4",
+    "@azure/msal-node": "^1.18.4",
     "base64url": "^3.0.0",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "follow-redirects": "^1.14.8",
     "@types/ramda": "0.26.0",
     "@azure/msal-browser": "^2.38.3",
-    "@azure/msal-node": "1.18.4"
+    "@azure/msal-node": "^1.18.4"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "follow-redirects": "^1.14.8",
     "@types/ramda": "0.26.0",
     "@azure/msal-browser": "^2.38.3",
-    "@azure/msal-node": "^1.18.4"
+    "@azure/msal-node": "^1.18.4",
+    "axios": "0.21.1"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "**/istanbul-lib-instrument/@babel/core": "^7.23.2",
     "**/@babel/plugin-proposal-class-properties/@babel/core": "^7.23.2",
     "follow-redirects": "^1.14.8",
-    "@types/ramda": "0.26.0"
+    "@types/ramda": "0.26.0",
+    "@azure/msal-browser": "^2.38.3",
+    "@azure/msal-node": "1.18.4"
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",

--- a/tools/package.json
+++ b/tools/package.json
@@ -30,7 +30,7 @@
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
     "@azure/identity": "^2.0.4",
-    "@azure/ms-rest-azure-env":"^2.0.0",
+    "@azure/ms-rest-azure-env": "^2.0.0",
     "@types/request": "^2.47.1",
     "botframework-connector": "4.1.6",
     "dotenv": "^4.0.0",
@@ -39,7 +39,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@azure/msal-node": "^1.2.0",
+    "@azure/msal-node": "1.18.4",
     "async": "^2.6.1",
     "colors": "1.1.2",
     "fs-extra": "^5.0.0",

--- a/tools/package.json
+++ b/tools/package.json
@@ -39,7 +39,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@azure/msal-node": "1.18.4",
+    "@azure/msal-node": "^1.18.4",
     "async": "^2.6.1",
     "colors": "1.1.2",
     "fs-extra": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,30 +3652,12 @@ axe-core@^4.7.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
-axios@^0.21.1, axios@~0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@0.21.1, axios@^1.4.0, axios@^1.6.0, axios@~0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^1.4.0:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
-  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
-  dependencies:
-    follow-redirects "^1.15.4"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
-  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.10.0"
 
 babel-loader@^8.0.6:
   version "8.1.0"
@@ -6786,7 +6768,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.8, follow-redirects@^1.15.0, follow-redirects@^1.15.4:
+follow-redirects@^1.10.0, follow-redirects@^1.14.8:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
@@ -11172,11 +11154,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,7 +226,7 @@
   dependencies:
     debug "^4.1.1"
 
-"@azure/msal-node@1.18.4", "@azure/msal-node@^1.3.0":
+"@azure/msal-node@^1.18.4", "@azure/msal-node@^1.3.0":
   version "1.18.4"
   resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.18.4.tgz#c921b0447c92fb3b0cb1ebf5a9a76fcad2ec7c21"
   integrity sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,17 +207,17 @@
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
 
-"@azure/msal-browser@^2.16.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.17.0.tgz#beb7d91e6123534b42c0d2ce85eda42a136a8555"
-  integrity sha512-NDK0NfsiRkjUU4V4jTt++aUPVg3JnRF4zV3B6WEOXDMH3OCbSJyqdO1WhdUWgMNQZz6Dk9bO/c6Bf4vUEgg+WA==
+"@azure/msal-browser@^2.16.0", "@azure/msal-browser@^2.38.3":
+  version "2.38.3"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.38.3.tgz#2f131fa9b7a8a9546fc8d34e5d99ce4c18b04147"
+  integrity sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==
   dependencies:
-    "@azure/msal-common" "^5.0.0"
+    "@azure/msal-common" "13.3.1"
 
-"@azure/msal-common@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-13.3.0.tgz#dfa39810e0fbce6e07ca85a2cf305da58d30b7c9"
-  integrity sha512-/VFWTicjcJbrGp3yQP7A24xU95NiDMe23vxIU1U6qdRPFsprMDNUohMudclnd+WSHE4/McqkZs/nUU3sAKkVjg==
+"@azure/msal-common@13.3.1":
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-13.3.1.tgz#012465bf940d12375dc47387b754ccf9d6b92180"
+  integrity sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==
 
 "@azure/msal-common@^4.5.1":
   version "4.5.1"
@@ -226,30 +226,13 @@
   dependencies:
     debug "^4.1.1"
 
-"@azure/msal-common@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-5.0.0.tgz#4e927b9bdc3715e0b043ece01360c73739ef52c1"
-  integrity sha512-b3QXfW0BlGZs3mQ59rkVGcArzeMGd1RjHxyRez5bCB1F/F3jRmn2nY9jGamrILPBFz7weGpJiouW1VmDmAuk7Q==
+"@azure/msal-node@1.18.4", "@azure/msal-node@^1.3.0":
+  version "1.18.4"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.18.4.tgz#c921b0447c92fb3b0cb1ebf5a9a76fcad2ec7c21"
+  integrity sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==
   dependencies:
-    debug "^4.1.1"
-
-"@azure/msal-node@^1.2.0":
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.18.3.tgz#e265556d4db0340590eeab5341469fb6740251d0"
-  integrity sha512-lI1OsxNbS/gxRD4548Wyj22Dk8kS7eGMwD9GlBZvQmFV8FJUXoXySL1BiNzDsHUE96/DS/DHmA+F73p1Dkcktg==
-  dependencies:
-    "@azure/msal-common" "13.3.0"
+    "@azure/msal-common" "13.3.1"
     jsonwebtoken "^9.0.0"
-    uuid "^8.3.0"
-
-"@azure/msal-node@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.3.1.tgz#55c8915c9bc5222dbe152ffd67f9357b83461fde"
-  integrity sha512-c3bSdXUBpjUehx7mdI5iY+mwMF1mTz1qrVppH5LTD3SfbousRaFN9F2phAeaejVnCzbKzFPl4TTHxOJbkBVXHA==
-  dependencies:
-    "@azure/msal-common" "^5.0.0"
-    axios "^0.21.1"
-    jsonwebtoken "^8.5.1"
     uuid "^8.3.0"
 
 "@azure/storage-blob@^12.15.0":
@@ -8742,7 +8725,7 @@ jsonschema@^1.4.0:
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
   integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
 
-jsonwebtoken@9.0.0, jsonwebtoken@^8.5.1, jsonwebtoken@^9.0.0:
+jsonwebtoken@9.0.0, jsonwebtoken@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
   integrity sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==


### PR DESCRIPTION
#minor

## Description
This PR updates the versions of the packages **_@azure/msal-node_** and _**@azure/msal-browser**_ to avoid the use of deprecated versions.

## Specific Changes
  - Updated _**@azure/msal-node**_ to ^1.18.4 in _botbuilder, botframework-connector_ and _tools_.
  - Added resolutions _**axios: 0.21.4,**_ **_@azure/msal-node: ^1.18.4_** and _**@azure/msal-browser: ^2.38.3**_.

## Testing
The following image shows an _echo bot_ working with authentication after the updates.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/250f651c-67e8-4f5d-8b3b-3af9408d9dfe)
