### PR TITLE
Fix AgentSettings Circular Structure and improve internals

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -259,9 +259,6 @@ export class BrowserSessionStorage extends MemoryStorage {
     constructor();
 }
 
-// @public (undocumented)
-export const CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY: unique symbol;
-
 // @public
 export interface CachedBotState {
     hash: string;

--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -25,8 +25,6 @@ export interface CachedBotState {
     hash: string;
 }
 
-export const CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY = Symbol('cachedBotStateSkipPropertiesHandler');
-
 /**
  * Base class for the frameworks state persistance scopes.
  *
@@ -40,7 +38,6 @@ export const CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY = Symbol('cachedBotSta
  */
 export class BotState implements PropertyManager {
     private stateKey = Symbol('state');
-    private skippedProperties = new Map();
 
     /**
      * Creates a new BotState instance.
@@ -77,13 +74,6 @@ export class BotState implements PropertyManager {
      */
     public load(context: TurnContext, force = false): Promise<any> {
         const cached: CachedBotState = context.turnState.get(this.stateKey);
-        if (!context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY)) {
-            context.turnState.set(
-                CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY,
-                (state: BotState, key: string, properties: string[] = null) =>
-                    state.skippedProperties.set(key, properties)
-            );
-        }
         if (force || !cached || !cached.state) {
             return Promise.resolve(this.storageKey(context)).then((key: string) => {
                 return this.storage.read([key]).then((items: StoreItems) => {
@@ -115,8 +105,7 @@ export class BotState implements PropertyManager {
      */
     public saveChanges(context: TurnContext, force = false): Promise<void> {
         let cached: CachedBotState = context.turnState.get(this.stateKey);
-        const state = this.skipProperties(cached?.state);
-        if (force || (cached && cached.hash !== calculateChangeHash(state))) {
+        if (force || (cached && cached.hash !== calculateChangeHash(cached?.state))) {
             return Promise.resolve(this.storageKey(context)).then((key: string) => {
                 if (!cached) {
                     cached = { state: {}, hash: '' };
@@ -127,19 +116,7 @@ export class BotState implements PropertyManager {
 
                 return this.storage.write(changes).then(() => {
                     // Update change hash and cache
-                    cached.hash = calculateChangeHash(state);
-
-                    // why does this happen in JS?  It doesn't in the other platforms.
-                    // the issue is related to 'skipProperties', which nulls out those
-                    // properties in 'cached'.  This replaces the state in 'context',
-                    // and could change the values of references.
-                    //
-                    // Should 'calculateChangeHash' also consider the skipProperties?
-                    //
-                    // See SkillDialog.sendToSkill
-                    //
-                    // At any rate, would not expect saveChanges to alter the members
-                    // of a class in use.
+                    cached.hash = calculateChangeHash(cached.state);
                     context.turnState.set(this.stateKey, cached);
                 });
             });
@@ -203,46 +180,5 @@ export class BotState implements PropertyManager {
         const cached: CachedBotState = context.turnState.get(this.stateKey);
 
         return typeof cached === 'object' && typeof cached.state === 'object' ? cached.state : undefined;
-    }
-
-    /**
-     * Skips properties from the cached state object.
-     *
-     * @remarks Primarily used to skip properties before calculating the hash value in the calculateChangeHash function.
-     * @param state Dictionary of state values.
-     * @returns Dictionary of state values, without the skipped properties.
-     */
-    private skipProperties(state: CachedBotState['state']): CachedBotState['state'] {
-        if (!state || !this.skippedProperties.size) {
-            return state;
-        }
-
-        const skipHandler = (key: string) => {
-            if (this.skippedProperties.has(key)) {
-                return this.skippedProperties.get(key) ?? [key];
-            }
-        };
-
-        const inner = ([key, value], skip = []) => {
-            if (value === null || value === undefined || skip.includes(key)) {
-                return;
-            }
-
-            if (Array.isArray(value)) {
-                return value.map((e) => inner([null, e], skip));
-            }
-
-            if (typeof value !== 'object') {
-                return value.valueOf();
-            }
-
-            return Object.entries(value).reduce((acc, [k, v]) => {
-                const skipResult = skipHandler(k) ?? [];
-                acc[k] = inner([k, v], [...skip, ...skipResult]);
-                return acc;
-            }, {});
-        };
-
-        return inner([null, state]);
     }
 }

--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -6,7 +6,8 @@
  * Licensed under the MIT License.
  */
 import { TurnContext } from './turnContext';
-import { Assertion, assert } from 'botbuilder-stdlib';
+import { Assertion, assert, stringify } from 'botbuilder-stdlib';
+import { createHash } from 'crypto';
 
 /**
  * Callback to calculate a storage key.
@@ -115,10 +116,11 @@ export const assertStoreItems: Assertion<StoreItems> = (val, path) => {
  * @param item Item to calculate the change hash for.
  */
 export function calculateChangeHash(item: StoreItem): string {
-    const cpy: any = { ...item };
-    if (cpy.eTag) {
-        delete cpy.eTag;
-    }
+    // eslint-disable-next-line  @typescript-eslint/no-unused-vars
+    const { eTag, ...rest } = item;
 
-    return JSON.stringify(cpy);
+    const result = stringify(rest);
+    const hash = createHash('sha256', { encoding: 'utf-8' });
+    const hashed = hash.update(result).digest('hex');
+    return hashed;
 }

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/package.json
@@ -42,6 +42,7 @@
     "botbuilder": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
+    "botframework-connector": "4.1.6",
     "express": "^4.17.1",
     "zod": "~1.11.17"
   }

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
@@ -9,6 +9,7 @@ import type { Server } from 'http';
 import type { ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core';
 import { Configuration, getRuntimeServices } from 'botbuilder-dialogs-adaptive-runtime';
 import { json, urlencoded } from 'body-parser';
+import type { ConnectorClientOptions } from 'botframework-connector';
 
 // Explicitly fails checks for `""`
 const NonEmptyString = z.string().refine((str) => str.length > 0, { message: 'must be non-empty string' });
@@ -38,6 +39,11 @@ const TypedOptions = z.object({
      * Path inside applicationRoot that should be served as static files
      */
     staticDirectory: NonEmptyString,
+
+    /**
+     * Used when creating ConnectorClients.
+     */
+    connectorClientOptions: z.object({}).nonstrict() as z.ZodObject<any, any, ConnectorClientOptions>,
 });
 
 /**
@@ -51,6 +57,7 @@ const defaultOptions: Options = {
     skillsEndpointPrefix: '/api/skills',
     port: 3978,
     staticDirectory: 'wwwroot',
+    connectorClientOptions: {},
 };
 
 /**
@@ -65,7 +72,9 @@ export async function start(
     settingsDirectory: string,
     options: Partial<Options> = {}
 ): Promise<void> {
-    const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
+    const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory, {
+        connectorClientOptions: options.connectorClientOptions,
+    });
     const [, listen] = await makeApp(services, configuration, applicationRoot, options);
 
     listen();

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
@@ -43,6 +43,7 @@ const TypedOptions = z.object({
     /**
      * Used when creating ConnectorClients.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     connectorClientOptions: z.object({}).nonstrict() as z.ZodObject<any, any, ConnectorClientOptions>,
 });
 

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -541,6 +541,7 @@ function registerQnAComponents(services: ServiceCollection, configuration: Confi
 export async function getRuntimeServices(
     applicationRoot: string,
     settingsDirectory: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     defaultServices?: Record<string, any>
 ): Promise<[ServiceCollection, Configuration]>;
 
@@ -555,6 +556,7 @@ export async function getRuntimeServices(
 export async function getRuntimeServices(
     applicationRoot: string,
     configuration: Configuration,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     defaultServices?: Record<string, any>
 ): Promise<[ServiceCollection, Configuration]>;
 
@@ -564,6 +566,7 @@ export async function getRuntimeServices(
 export async function getRuntimeServices(
     applicationRoot: string,
     configurationOrSettingsDirectory: Configuration | string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     defaultServices: Record<string, any> = {}
 ): Promise<[ServiceCollection, Configuration]> {
     // Resolve configuration

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import http from 'http';
-import https from 'https';
-
 import * as z from 'zod';
 import fs from 'fs';
 import path from 'path';
@@ -504,6 +501,7 @@ function registerQnAComponents(services: ServiceCollection, configuration: Confi
  *
  * @param applicationRoot absolute path to root of application
  * @param settingsDirectory directory where settings files are located
+ * @param defaultServices services to use as default
  * @returns service collection and configuration
  *
  * @remarks
@@ -542,7 +540,8 @@ function registerQnAComponents(services: ServiceCollection, configuration: Confi
  */
 export async function getRuntimeServices(
     applicationRoot: string,
-    settingsDirectory: string
+    settingsDirectory: string,
+    defaultServices?: Record<string, any>
 ): Promise<[ServiceCollection, Configuration]>;
 
 /**
@@ -550,11 +549,13 @@ export async function getRuntimeServices(
  *
  * @param applicationRoot absolute path to root of application
  * @param configuration a fully initialized configuration instance to use
+ * @param defaultServices services to use as default
  * @returns service collection and configuration
  */
 export async function getRuntimeServices(
     applicationRoot: string,
-    configuration: Configuration
+    configuration: Configuration,
+    defaultServices?: Record<string, any>
 ): Promise<[ServiceCollection, Configuration]>;
 
 /**
@@ -562,7 +563,8 @@ export async function getRuntimeServices(
  */
 export async function getRuntimeServices(
     applicationRoot: string,
-    configurationOrSettingsDirectory: Configuration | string
+    configurationOrSettingsDirectory: Configuration | string,
+    defaultServices: Record<string, any> = {}
 ): Promise<[ServiceCollection, Configuration]> {
     // Resolve configuration
     let configuration: Configuration;
@@ -587,28 +589,14 @@ export async function getRuntimeServices(
 
     const services = new ServiceCollection({
         botFrameworkClientFetch: undefined,
-        connectorClientOptions: {
-            agentSettings: {
-                http: new http.Agent({
-                    keepAlive: true,
-                    maxSockets: 128,
-                    maxFreeSockets: 32,
-                    timeout: 60000,
-                }),
-                https: new https.Agent({
-                    keepAlive: true,
-                    maxSockets: 128,
-                    maxFreeSockets: 32,
-                    timeout: 60000,
-                }),
-            },
-        },
+        connectorClientOptions: undefined,
         customAdapters: new Map(),
         declarativeTypes: [],
         memoryScopes: [],
         middlewares: new MiddlewareSet(),
         pathResolvers: [],
         serviceClientCredentialsFactory: undefined,
+        ...defaultServices,
     });
 
     services.addFactory<ResourceExplorer, { declarativeTypes: ComponentDeclarativeTypes[] }>(

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -10,6 +10,8 @@ const {
     ConversationState,
     UserState,
     useBotState,
+    BotState,
+    calculateChangeHash,
 } = require('botbuilder-core');
 const { TestUtils } = require('..');
 const { createHash } = require('crypto');

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -5,13 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import {
-    Activity,
-    ActivityTypes,
-    StringUtils,
-    TurnContext,
-    CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY,
-} from 'botbuilder';
+import { Activity, ActivityTypes, StringUtils, TurnContext } from 'botbuilder';
 import { ActivityTemplate } from '../templates';
 import { ActivityTemplateConverter } from '../converters';
 import { AdaptiveEvents } from '../adaptiveEvents';
@@ -156,7 +150,17 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
      * @param options Optional options used to configure the skill dialog.
      */
     constructor(options?: SkillDialogOptions) {
-        super(Object.assign({ skill: {} } as SkillDialogOptions, options));
+        super(
+            Object.assign({ skill: {} } as SkillDialogOptions, options, {
+                // This is an alternative to the toJSON function because when the SkillDialogOptions are saved into the Storage,
+                // when the information is retrieved, it doesn't have the properties that were declared in the toJSON function.
+                _replace(): Omit<SkillDialogOptions, 'conversationState' | 'skillClient' | 'conversationIdFactory'> {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { conversationState, skillClient, conversationIdFactory, ...rest } = this;
+                    return rest;
+                },
+            })
+        );
     }
 
     /**
@@ -201,10 +205,6 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
         // Store the initialized dialogOptions in state so we can restore these values when the dialog is resumed.
         dc.activeDialog.state[this._dialogOptionsStateKey] = this.dialogOptions;
-        // Skip properties from the bot's state cache hash due to unwanted conversationState behavior.
-        const skipProperties = dc.context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY);
-        const props: (keyof SkillDialogOptions)[] = ['conversationIdFactory', 'conversationState', 'skillClient'];
-        skipProperties(this.dialogOptions.conversationState, this._dialogOptionsStateKey, props);
 
         // Get the activity to send to the skill.
         options = {} as BeginSkillDialogOptions;

--- a/libraries/botbuilder-stdlib/src/index.ts
+++ b/libraries/botbuilder-stdlib/src/index.ts
@@ -6,3 +6,4 @@ export * from './types';
 export { delay } from './delay';
 export { maybeCast } from './maybeCast';
 export { retry } from './retry';
+export { stringify } from './stringify';

--- a/libraries/botbuilder-stdlib/src/stringify.ts
+++ b/libraries/botbuilder-stdlib/src/stringify.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Encapsulates JSON.stringify function to detect and handle different types of errors (eg. Circular Structure).
+ * @remarks
+ * Circular Structure:
+ *   - It detects when the provided value has circular references and replace them with [Circular *.{path to the value being referenced}].
+ * @example
+ * // Circular Structure:
+ *     {
+ *       "item": {
+ *         "name": "parent",
+ *         "parent": null,
+ *         "child": {
+ *           "name": "child",
+ *           "parent": "[Circular *.item]" // => obj.item.child.parent = obj.item
+ *         }
+ *       }
+ *     }
+ *
+ * @param value — A JavaScript value, usually an object or array, to be converted.
+ * @param replacer — A function that transforms the results.
+ * @param space — Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+ */
+export function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number) {
+    if (!value) {
+        return '';
+    }
+
+    try {
+        return JSON.stringify(value, stringifyReplacer(replacer), space);
+    } catch (error) {
+        if (!error?.message.includes('circular structure')) {
+            throw error;
+        }
+
+        const seen = new WeakMap();
+        return JSON.stringify(
+            value,
+            function stringifyCircularReplacer(key, val) {
+                const value = stringifyReplacer(replacer)(key, val);
+
+                const path = seen.get(value);
+                if (path) {
+                    return `[Circular *${path.join('.')}]`;
+                }
+
+                const parent = seen.get(this) ?? [];
+                seen.set(value, [...parent, key]);
+                return value;
+            },
+            space
+        );
+    }
+}
+
+function stringifyReplacer(replacer?: (key: string, value: any) => any) {
+    return function stringifyReplacer(this: any, key: string, val: any) {
+        const replacerValue = replacer ? replacer(key, val).bind(this) : val;
+        if (replacerValue === null || replacerValue === undefined || typeof replacerValue !== 'object') {
+            return replacerValue;
+        }
+
+        const toJSONValue = replacerValue.toJSON ? replacerValue.toJSON(key) : replacerValue;
+        return toJSONValue._replace ? toJSONValue._replace() : toJSONValue;
+    };
+}

--- a/libraries/botbuilder-stdlib/src/stringify.ts
+++ b/libraries/botbuilder-stdlib/src/stringify.ts
@@ -22,7 +22,9 @@
  * @param value — A JavaScript value, usually an object or array, to be converted.
  * @param replacer — A function that transforms the results.
  * @param space — Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+ * @returns The converted JavaScript value to a JavaScript Object Notation (JSON) string.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number) {
     if (!value) {
         return '';
@@ -55,7 +57,9 @@ export function stringify(value: any, replacer?: (key: string, value: any) => an
     }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stringifyReplacer(replacer?: (key: string, value: any) => any) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function stringifyReplacer(this: any, key: string, val: any) {
         const replacerValue = replacer ? replacer(key, val).bind(this) : val;
         if (replacerValue === null || replacerValue === undefined || typeof replacerValue !== 'object') {

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -145,7 +145,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.credentialsFactory,
             this.toChannelFromBotLoginUrl,
             this.botFrameworkClientFetch,
-            this.connectorClientOptions?.agentSettings
+            this.connectorClientOptions
         );
     }
 


### PR DESCRIPTION
#minor

## Description
This PR replaces the `skipProperties` functionality with an internal `_replacer` function when the `JSON.stringify` function gets called in the `calculateChangeHash`.
The `calculateChangeHash` has been changed to use a new internal `stringify` function, that allows to detect and handle Circular Structures.
Additionally, the AgentSettings configuration has being added to the `getRuntimeServices` function, so internal functionalities can use them. Not only that, the SkillClient has being updated based on this configuration, that work for both Composer and non-Composer bots.

## Specific Changes
  - The `BotState` class has being updated, removing all the `skipProperties` functionality.
  - The `calculateChangeHash` has being refactored to handle Circular Structures and generate a hash, instead of a plain `JSON.stringify` value, so it is easier to debug and identify.
  - Added the `ConnectorClientOptions` to the `start` and `getRuntimeServices` functions for Composer bots, so it can be customizable, and delegate to the internal `CoreBot` to use.
  - The `BeginSkill` has being updated, removing the `skipProperties` and introducing the new internal `_replace` function, for the `stringify` functionality to execute.
  - Added a new `stringify` function that encapsulates the native `JSON.stringify` function, with the addition to handle Circular Structures and expose the internal `_replacer` function to customize it.
  - Updated the internal `botFrameworkClientFetchImpl` function to use a single instance of `axios` and handle its configuration from `ConnectorClientOptions`.

## Testing
The following images show how the `ConnectorClientOptions` can be provided from a Composer bot perspective, the new `stringify` functionality that detects and replaces circular references, and the generated hash string.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/50b2964b-ce51-4549-8ba8-3f478d3c20e1)
![image](https://github.com/southworks/botbuilder-js/assets/62260472/45e6e7d7-97a4-4314-b0cb-39630f0dcaeb)
![image](https://github.com/southworks/botbuilder-js/assets/62260472/40f18496-ee41-4369-87c5-05fbec16e5a9)