### PR TITLE
feat: Support Single Tenant authentication through BotFramework-Emulator

### DIFF
--- a/libraries/botframework-connector/src/auth/authenticationConstants.ts
+++ b/libraries/botframework-connector/src/auth/authenticationConstants.ts
@@ -173,6 +173,11 @@ export namespace AuthenticationConstants {
     export const ServiceUrlClaim = 'serviceurl';
 
     /**
+     * Tenant ID claim name. As used in Microsoft AAD tokens.
+     */
+    export const TenantIdClaim = "tid";
+
+    /**
      * AppId used for creating skill claims when there is no appId and password configured.
      */
     export const AnonymousSkillAppId = 'AnonymousSkill';

--- a/libraries/botframework-connector/src/auth/authenticationConstants.ts
+++ b/libraries/botframework-connector/src/auth/authenticationConstants.ts
@@ -175,7 +175,7 @@ export namespace AuthenticationConstants {
     /**
      * Tenant ID claim name. As used in Microsoft AAD tokens.
      */
-    export const TenantIdClaim = "tid";
+    export const TenantIdClaim = 'tid';
 
     /**
      * AppId used for creating skill claims when there is no appId and password configured.

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -75,10 +75,17 @@ export namespace EmulatorValidation {
             return false;
         }
 
+        //Validation to manage the issuer object as a string[].
         if (Array.isArray(ToBotFromBotOrEmulatorTokenValidationParameters.issuer)) {
-            const tid = '/' + token.payload.tid + '/';
+            const tid = token?.payload?.tid ? '/' + token.payload.tid + '/' : '';
 
-            if (ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tid)) == null) {
+            //Validate if there is an existing issuer with the same tid value.
+            if (
+                tid != '' &&
+                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tid)) == null
+            ) {
+                //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
+                //This allows use of the SingleTenant authentication through Emulator.
                 const newIssuer = 'https://sts.windows.net' + tid;
                 ToBotFromBotOrEmulatorTokenValidationParameters.issuer.push(newIssuer);
             }

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -77,16 +77,16 @@ export namespace EmulatorValidation {
 
         //Validation to manage the issuer object as a string[].
         if (Array.isArray(ToBotFromBotOrEmulatorTokenValidationParameters.issuer)) {
-            const tid = token?.payload?.tid ? '/' + token.payload.tid + '/' : '';
+            const tenantId = token?.payload?.tid ?? '';
 
             //Validate if there is an existing issuer with the same tid value.
             if (
-                tid != '' &&
-                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tid)) == null
+                tenantId != '' &&
+                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) == null
             ) {
                 //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
                 //This allows use of the SingleTenant authentication through Emulator.
-                const newIssuer = 'https://sts.windows.net' + tid;
+                const newIssuer = AuthenticationConstants.ValidTokenIssuerUrlTemplateV1 + `${tenantId}/`;
                 ToBotFromBotOrEmulatorTokenValidationParameters.issuer.push(newIssuer);
             }
         }

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -83,7 +83,7 @@ export namespace EmulatorValidation {
             if (
                 tenantId != '' &&
                 ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) ==
-                null
+                    null
             ) {
                 //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
                 //This allows use of the SingleTenant authentication through Emulator.

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -69,21 +69,21 @@ export namespace EmulatorValidation {
         }
 
         // Is there an Issuer?
-        const issuer: string = token.payload.iss;
+        const issuer: string = token.payload[AuthenticationConstants.IssuerClaim];
         if (!issuer) {
             // No Issuer, means it's not from the Emulator.
             return false;
         }
 
-        //Validation to manage the issuer object as a string[].
+        //Validation to manage the issuer object as a string.
         if (Array.isArray(ToBotFromBotOrEmulatorTokenValidationParameters.issuer)) {
-            const tenantId = token?.payload?.tid ?? '';
+            const tenantId = token?.payload[AuthenticationConstants.TenantIdClaim] ?? '';
 
             //Validate if there is an existing issuer with the same tid value.
             if (
                 tenantId != '' &&
                 ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) ==
-                    null
+                null
             ) {
                 //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
                 //This allows use of the SingleTenant authentication through Emulator.

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -75,6 +75,15 @@ export namespace EmulatorValidation {
             return false;
         }
 
+        if (Array.isArray(ToBotFromBotOrEmulatorTokenValidationParameters.issuer)) {
+            const tid = '/' + token.payload.tid + '/';
+
+            if (ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tid)) == null) {
+                const newIssuer = 'https://sts.windows.net' + tid;
+                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.push(newIssuer);
+            }
+        }
+
         // Is the token issues by a source we consider to be the emulator?
         if (
             ToBotFromEmulatorTokenValidationParameters.issuer &&

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -82,7 +82,8 @@ export namespace EmulatorValidation {
             //Validate if there is an existing issuer with the same tid value.
             if (
                 tenantId != '' &&
-                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) == null
+                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) ==
+                    null
             ) {
                 //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
                 //This allows use of the SingleTenant authentication through Emulator.


### PR DESCRIPTION
#minor

## Description
This PR includes a dynamic way to validate the access token _**issuer**_ value depending on the tenant ID used in Emulator.

## Specific Changes
  - Added logic to validate the _**tid**_ and _**issuer**_ values to allow the Single Tenant authentication

## Testing
The following image shows the Emulator working with a bot using Single Tenant authentication.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/8d0a35cd-5ecc-4b02-8f64-2e134a2c2708)