### PR TITLE
fix: Add counter to onError trigger to break possible loops

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/conditionals.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/conditionals.test.js
@@ -44,4 +44,12 @@ describe('ConditionalsTests', function () {
     it('OnRepromptDialog', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'ConditionalsTests_OnRepromptDialog');
     });
+
+    it('OnError loop limit', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'ConditionalsTests_OnErrorLoop');
+    });
+
+    it('OnError default loop limit', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'ConditionalsTests_OnErrorLoopDefaultLimit');
+    });
 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ConditionalsTests/ConditionalsTests_OnErrorLoop.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ConditionalsTests/ConditionalsTests_OnErrorLoop.test.dialog
@@ -1,0 +1,65 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "ErrorLoop",
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in BeginDialog."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in BeginDialog."
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in OnError."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in OnError."
+                    }
+                ],
+                "executionLimit": 3
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in BeginDialog."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Exception in OnError."
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ConditionalsTests/ConditionalsTests_OnErrorLoopDefaultLimit.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ConditionalsTests/ConditionalsTests_OnErrorLoopDefaultLimit.test.dialog
@@ -1,0 +1,92 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "ErrorLoop",
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in BeginDialog."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in BeginDialog."
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in OnError."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in OnError."
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in BeginDialog."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Exception in OnError."
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -1794,6 +1794,10 @@ export class OnError extends OnDialogEvent {
     // (undocumented)
     static $kind: string;
     constructor(actions?: Dialog[], condition?: string);
+    // (undocumented)
+    currentExecutionLimit: () => number;
+    execute(actionContext: ActionContext): Promise<ActionChangeList[]>;
+    executionLimit: NumberExpression;
     onCreateChangeList(actionContext: ActionContext, dialogOptions?: any): ActionChangeList;
 }
 

--- a/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnError.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnError.schema
@@ -3,5 +3,16 @@
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
     "title": "On error",
     "description": "Action to perform when an 'Error' dialog event occurs.",
-    "type": "object"
+    "type": "object",
+    "properties": {
+        "executionLimit": {
+            "$ref": "schema:#/definitions/numberExpression",
+            "title": "Execution limit",
+            "description": "Number of executions allowed for this trigger. Used to break loops in case of errors inside the trigger.",
+            "examples": [
+                3,
+                "=f(x)"
+            ]
+        }
+    }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnError.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnError.uischema
@@ -3,7 +3,8 @@
     "form": {
         "order": [
             "condition",
-            "*"
+            "*",
+            "executionLimit"
         ],
         "hidden": [
             "actions"

--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -823,6 +823,8 @@ export class TurnPath {
     // (undocumented)
     static readonly dialogEvent = "turn.dialogEvent";
     // (undocumented)
+    static readonly executionLimit = "turn.executionLimit";
+    // (undocumented)
     static readonly interrupted = "turn.interrupted";
     // (undocumented)
     static readonly lastResult = "turn.lastresult";

--- a/libraries/botbuilder-dialogs/src/memory/turnPath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/turnPath.ts
@@ -45,4 +45,7 @@ export class TurnPath {
 
     /// This is a bool which if set means that the turncontext.activity has been consumed by some component in the system.
     static readonly activityProcessed = 'turn.activityProcessed';
+
+    /// Used to limit the execution of a trigger avoiding infinite loops in case of errors.
+    static readonly executionLimit = 'turn.executionLimit';
 }

--- a/libraries/tests.schema
+++ b/libraries/tests.schema
@@ -6260,6 +6260,15 @@
         }
       },
       "properties": {
+        "executionLimit": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Execution limit",
+          "description": "Number of executions allowed for this trigger. Used to break loops in case of errors inside the trigger.",
+          "examples": [
+            3,
+            "=f(x)"
+          ]
+        },
         "condition": {
           "$ref": "#/definitions/condition",
           "title": "Condition",

--- a/libraries/tests.uischema
+++ b/libraries/tests.uischema
@@ -851,7 +851,8 @@
       "label": "Error occurred",
       "order": [
         "condition",
-        "*"
+        "*",
+        "executionLimit"
       ],
       "subtitle": "Error event"
     }


### PR DESCRIPTION
#minor

## Description
This PR adds a counter in the loop that executes the _onError_ trigger to detect and break possible infinite loops when there's an error inside the _onError_ handler.
It also includes a new property to the _onError_, to make the limit of executions configurable for the users (default value: 10).

## Specific Changes
- Added `executionLimit` property to the _onError_ trigger and read it in the override of the _execute_ method.
- Updated _internalRun_ method in `DialogHelper` to evaluate the execution limit property and break the loop in case of detecting one.
- Added _executionLimit_ property to `TurnPath` to be able to store the value in memory.

## Testing
These images show the scenarios we tested with the new implementation.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/cd7430d5-e34c-40c4-a264-8c8c1ab606b7)