### PR TITLE
fix: CodeQL SM04509 issue

### DIFF
--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -87,7 +87,7 @@ export class EvaluationOptions {
                                     this.strictMode = true;
                                 }
                             } else if (key.toLowerCase() === this.replaceNullKey.toLowerCase()) {
-                                this.nullSubstitution = (path) => value.replace(this.nullKeyReplaceStrRegex, path);
+                                this.nullSubstitution = (path) => value.replace(this.nullKeyReplaceStrRegex, `${path}`);
                             } else if (key.toLowerCase() === this.lineBreakKey.toLowerCase()) {
                                 this.LineBreakStyle =
                                     value.toLowerCase() === LGLineBreakStyle.Markdown.toString().toLowerCase()

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -87,10 +87,7 @@ export class EvaluationOptions {
                                     this.strictMode = true;
                                 }
                             } else if (key.toLowerCase() === this.replaceNullKey.toLowerCase()) {
-                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                                this.nullSubstitution = (path) =>
-                                    // eslint-disable-next-line security/detect-eval-with-expression
-                                    eval('`' + value.replace(this.nullKeyReplaceStrRegex, '${path}') + '`'); // CodeQL [SM04509] Eval on content that is from a trusted source
+                                this.nullSubstitution = (path) => value.replace(this.nullKeyReplaceStrRegex, path);
                             } else if (key.toLowerCase() === this.lineBreakKey.toLowerCase()) {
                                 this.LineBreakStyle =
                                     value.toLowerCase() === LGLineBreakStyle.Markdown.toString().toLowerCase()


### PR DESCRIPTION
#minor

## Description
This PR removes `eval()` from the **botbuilder-lg** package.
There is no need for side-effects at execution time for the `nullSubstitution` lambda function.
Additionally, the related CodeQL and ESLint suppressions have been removed, as there is no use for them anymore.
![image](https://github.com/southworks/botbuilder-js/assets/64077347/db87bf54-b4b7-4ff3-9d11-9c56f349656e)

## Specific Changes
  - Removed unnecesary `eval()` code.
  - Removed ESLint suppression for `security/detect-eval-with-expression`.
  - Removed ESLint suppression for `@typescript-eslint/no-unused-vars`.
  - Removed CodeQL suppression for SM04509.

## Testing
The following image shows `EvaluationOptions` tests passing (along with all other tests).
![image](https://github.com/southworks/botbuilder-js/assets/64077347/41e0d31c-f489-484b-ac8c-2dabc8806224)