### PR TITLE
port: [#6793][#6792] Composer Bot with QnA Intent recognized triggers duplicate QnA queries

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/adaptiveDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/adaptiveDialog.test.js
@@ -147,6 +147,10 @@ describe('AdaptiveDialogTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'AdaptiveDialog_TopLevelFallbackMultipleActivities');
     });
 
+    it('TestOnQnAMatch', async function () {
+        await TestUtils.runTestScript(resourceExplorer, 'AdaptiveDialog_OnQnAMatch');
+    });
+
     it('TestBindingTwoWayAcrossAdaptiveDialogs', async function () {
         await TestUtils.runTestScript(resourceExplorer, 'TestBindingTwoWayAcrossAdaptiveDialogs');
     });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/AdaptiveDialogTests/AdaptiveDialog_OnQnAMatch.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/AdaptiveDialogTests/AdaptiveDialog_OnQnAMatch.test.dialog
@@ -1,0 +1,74 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "outer",
+    "autoEndDialog": false,
+    "recognizer": {
+      "$kind": "Microsoft.RegexRecognizer",
+      "intents": [
+        {
+          "intent": "BeginIntent",
+          "pattern": "begin"
+        },
+        {
+          "intent": "QnAMatch",
+          "pattern": "qna"
+        }
+      ]
+    },
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "BeginIntent",
+        "actions": [
+          {
+            "$kind": "Microsoft.TextInput",
+            "maxTurnCount": 3,
+            "alwaysPrompt": true,
+            "allowInterruptions": false,
+            "prompt": "Which event should I emit?",
+            "validations": []
+          },
+          {
+            "$kind": "Microsoft.EmitEvent",
+            "eventName": "activityReceived",
+            "eventValue": "=turn.activity",
+            "handledProperty": "turn.eventHandled",
+            "bubbleEvent": true
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "QnAMatch",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "QnAMatch event triggered"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "begin"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Which event should I emit?"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "qna"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "QnAMatch event triggered"
+    }
+  ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -1877,6 +1877,8 @@ export class OnQnAMatch extends OnIntent {
     // (undocumented)
     static $kind: string;
     constructor(actions?: Dialog[], condition?: string);
+    // (undocumented)
+    static qnaMatchIntent: string;
 }
 
 // @public

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -42,7 +42,7 @@ import isEqual from 'lodash/isEqual';
 import { ActionContext } from './actionContext';
 import { AdaptiveDialogState } from './adaptiveDialogState';
 import { AdaptiveEvents } from './adaptiveEvents';
-import { OnCondition, OnIntent } from './conditions';
+import { OnCondition, OnIntent, OnQnAMatch } from './conditions';
 import { DialogSetConverter, LanguageGeneratorConverter, RecognizerConverter } from './converters';
 import { EntityAssignment } from './entityAssignment';
 import { EntityAssignmentComparer } from './entityAssignmentComparer';
@@ -547,16 +547,28 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                     break;
                 case AdaptiveEvents.activityReceived:
                     if (activity.type === ActivityTypes.Message) {
-                        // Recognize utterance (ignore handled)
-                        const recognizeUtteranceEvent: DialogEvent = {
-                            name: AdaptiveEvents.recognizeUtterance,
-                            value: activity,
-                            bubble: false,
-                        };
-                        await this.processEvent(actionContext, recognizeUtteranceEvent, true);
+                        let recognized = actionContext.state.getValue<RecognizerResult>(TurnPath.recognized);
+                        const activityProcessed = actionContext.state.getValue<boolean>(TurnPath.activityProcessed);
 
-                        // Emit leading RecognizedIntent event
-                        const recognized = actionContext.state.getValue<RecognizerResult>(TurnPath.recognized);
+                        // Avoid reprocessing recognized activity for OnQnAMatch.
+                        const isOnQnAMatchProcessed =
+                            activityProcessed &&
+                            Object.prototype.hasOwnProperty.call(recognized?.intents, OnQnAMatch.qnaMatchIntent) ===
+                                true;
+                                
+                        if (!isOnQnAMatchProcessed) {
+                            // Recognize utterance (ignore handled)
+                            const recognizeUtteranceEvent: DialogEvent = {
+                                name: AdaptiveEvents.recognizeUtterance,
+                                value: activity,
+                                bubble: false,
+                            };
+                            await this.processEvent(actionContext, recognizeUtteranceEvent, true);
+
+                            // Emit leading RecognizedIntent event
+                            recognized = actionContext.state.getValue<RecognizerResult>(TurnPath.recognized);
+                        }
+
                         const recognizedIntentEvent: DialogEvent = {
                             name: AdaptiveEvents.recognizedIntent,
                             value: recognized,

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -555,7 +555,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                             activityProcessed &&
                             Object.prototype.hasOwnProperty.call(recognized?.intents, OnQnAMatch.qnaMatchIntent) ===
                                 true;
-                                
+
                         if (!isOnQnAMatchProcessed) {
                             // Recognize utterance (ignore handled)
                             const recognizeUtteranceEvent: DialogEvent = {

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onQnAMatch.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onQnAMatch.ts
@@ -8,13 +8,13 @@
 import { Dialog } from 'botbuilder-dialogs';
 import { OnIntent } from './onIntent';
 
-const qnaMatchIntent = 'QnAMatch';
-
 /**
  * Actions triggered when a MessageUpdateActivity is received.
  */
 export class OnQnAMatch extends OnIntent {
     static $kind = 'Microsoft.OnQnAMatch';
+    // this is a duplicate of QnAMakerRecognizer.QnAMatchIntent, but copying this here removes need to have dependency between QnA and Adaptive assemblies.
+    static qnaMatchIntent = 'QnAMatch';
 
     /**
      * Initializes a new instance of the [OnQnAMatch](xref:botbuilder-dialogs-adaptive.OnQnAMatch) class.
@@ -23,6 +23,6 @@ export class OnQnAMatch extends OnIntent {
      * @param condition Optional. Condition which needs to be met for the actions to be executed.
      */
     constructor(actions: Dialog[] = [], condition?: string) {
-        super(qnaMatchIntent, [], actions, condition);
+        super(OnQnAMatch.qnaMatchIntent, [], actions, condition);
     }
 }


### PR DESCRIPTION
#minor

## Description
This PR ports the PR # 6793 which fixes the double QnA trace issue.

## Specific Changes
  - Updated _**AdaptiveDialog**_ to avoid reprocessing recognized activities by adding a condition if the recognized event was already processed.
  - Added unit tests to validate the new condition works.

## Testing
The following image shows how it just throws one trace by every message.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/c1f673fb-2582-4b7b-b405-5c9ed3889c5c)
