### PR TITLE
fix: Remove CVE-2020-7753 vulnerability in trim

### DIFF
--- a/testing/browser-functional/browser-echo-bot/package.json
+++ b/testing/browser-functional/browser-echo-bot/package.json
@@ -37,9 +37,11 @@
     "webpack-dev-server": "^4.15.2"
   },
   "resolutions": {
-    "follow-redirects": "^1.15.4"
+    "follow-redirects": "^1.15.4",
+    "trim": "0.0.3"
   },
   "overrides": {
-    "follow-redirects": "^1.15.4"
+    "follow-redirects": "^1.15.4",
+    "trim": "0.0.3"
   }
 }

--- a/testing/browser-functional/browser-echo-bot/yarn.lock
+++ b/testing/browser-functional/browser-echo-bot/yarn.lock
@@ -5503,10 +5503,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Addresses # 4684
#minor

## Description
This PR updates the version of the package `trim` to avoid the [CVE-2020-7753](https://security.snyk.io/vuln/SNYK-JS-TRIM-1017038) vulnerability.
We added a `yarn` resolution as we cannot update the [botframework-webchat](https://www.npmjs.com/package/botframework-webchat) dependency to latest version due to node engine compatibility issues.
`yarn install` will show warnings but they can be dismissed as the `trim` versions are fully compatible.
![image](https://github.com/southworks/botbuilder-js/assets/64077347/395962dd-507a-4da5-a663-0425edcb4639)

## Specific Changes
  - Updated `trim` from `0.0.1` to `0.0.3` 

## Testing
We verified that [trim@0.0.3](https://www.npmjs.com/package/trim/v/0.0.3?activeTab=code) can be used as an in-place substitute for [trim@0.0.1](https://www.npmjs.com/package/trim/v/0.0.1?activeTab=code) and that the patched version is updated in `yarn.lock`.
![image](https://github.com/southworks/botbuilder-js/assets/64077347/8c75714e-f0de-4e03-ba9d-a184cd235f96)