### PR TITLE
port: [#6813][#6798] Not able to create instance of BlobsTranscriptStore using TokenCredential instead of connectionString and containerName

### DIFF
--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -30,19 +30,18 @@ export interface BlobsStorageOptions {
 
 // @public
 export class BlobsTranscriptStore implements TranscriptStore {
-    constructor(connectionString: string, containerName: string, options?: BlobsTranscriptStoreOptions);
+    constructor(connectionString: string, containerName: string, options?: BlobsTranscriptStoreOptions, blobServiceUri?: string, tokenCredential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential);
     deleteTranscript(channelId: string, conversationId: string): Promise<void>;
     getTranscriptActivities(channelId: string, conversationId: string, continuationToken?: string, startDate?: Date): Promise<PagedResult<Activity>>;
     listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>>;
     logActivity(activity: Activity, options?: BlobsTranscriptStoreOptions): Promise<void>;
-    }
+}
 
 // @public
 export interface BlobsTranscriptStoreOptions {
     decodeTranscriptKey?: boolean;
     storagePipelineOptions?: StoragePipelineOptions;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
@@ -11,7 +11,7 @@ const containerName = process.env.AZURE_BLOB_STORAGE_CONTAINER;
 const maybeClient = () =>
     connectionString && containerName ? new BlobsTranscriptStore(connectionString, containerName) : null;
 
-describe('BlobsStorage', function () {
+describe('BlobsTranscriptStore', function () {
     const client = maybeClient();
     const maybeIt = client ? it : it.skip;
 
@@ -69,6 +69,11 @@ describe('BlobsStorage', function () {
         it('throws for bad args', function () {
             assert.throws(() => new BlobsTranscriptStore(), 'throws for missing connectionString');
             assert.throws(() => new BlobsTranscriptStore('connectionString'), 'throws for missing containerName');
+            assert.throws(() => new BlobsTranscriptStore(null, null, null, [], {}), 'throws for missing url');
+            assert.throws(
+                () => new BlobsTranscriptStore(null, null, null, 'url', {}),
+                ReferenceError('Invalid credential type.')
+            );
         });
 
         it('succeeds for good args', function () {


### PR DESCRIPTION
Fixes # 4715
#minor

## Description
This PR allows the use of Token Credentials to authenticate and create an instance of _BlobsTranscriptStore_.

## Specific Changes
  - Added parameters _**blobServiceUri**_ and _**tokenCredential**_  in _BlobsTranscriptStore_ constructors. 
  - Added constructor validations in unit tests.

## Testing
The following images show the bot working and saving transcripts using _BlobsTranscriptStore_ instantiated with token credentials.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/7a7f9bab-1cfe-456b-b11c-e2696172968b)
![image](https://github.com/southworks/botbuilder-js/assets/122501764/4e1d6320-3f2b-4745-a6d2-f59da11ac7ba)