### PR TITLE
fix: Remove undefined value in @azure/msal-node

### DIFF
--- a/libraries/botframework-connector/src/auth/msalAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/msalAppCredentials.ts
@@ -70,8 +70,8 @@ export class MsalAppCredentials extends AppCredentials {
             typeof maybeClientApplicationOrAppId === 'string'
                 ? maybeClientApplicationOrAppId
                 : typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
-                ? maybeAppIdOrAppPasswordOrCertificate
-                : undefined;
+                    ? maybeAppIdOrAppPasswordOrCertificate
+                    : undefined;
 
         super(appId, undefined, maybeScope);
 
@@ -91,7 +91,7 @@ export class MsalAppCredentials extends AppCredentials {
             auth.clientSecret =
                 typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
                     ? maybeAppIdOrAppPasswordOrCertificate
-                    : undefined;
+                    : "";
 
             this.clientApplication = new ConfidentialClientApplication({ auth });
         }

--- a/libraries/botframework-connector/src/auth/msalAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/msalAppCredentials.ts
@@ -70,8 +70,8 @@ export class MsalAppCredentials extends AppCredentials {
             typeof maybeClientApplicationOrAppId === 'string'
                 ? maybeClientApplicationOrAppId
                 : typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
-                    ? maybeAppIdOrAppPasswordOrCertificate
-                    : undefined;
+                ? maybeAppIdOrAppPasswordOrCertificate
+                : undefined;
 
         super(appId, undefined, maybeScope);
 
@@ -89,9 +89,7 @@ export class MsalAppCredentials extends AppCredentials {
                     : undefined;
 
             auth.clientSecret =
-                typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
-                    ? maybeAppIdOrAppPasswordOrCertificate
-                    : "";
+                typeof maybeAppIdOrAppPasswordOrCertificate === 'string' ? maybeAppIdOrAppPasswordOrCertificate : '';
 
             this.clientApplication = new ConfidentialClientApplication({ auth });
         }


### PR DESCRIPTION
#minor

## Description
This PR avoids the undefined reference for thumbprint value in the _ConfidentialClientApplication_ instance in _msalAppCredentials_ for the latest versions of _@azure/msal-node_.

## Specific Changes
  - Replaced undefined value by an empty string in _clientSecret_ definition.

## Testing
The following image shows a bot working with node 20 and the latest version of _@azure/msal-node_ after the update.
![image](https://github.com/user-attachments/assets/cad62a98-185e-4eed-bb06-f9d2d380f935)