### PR TITLE
bump: Updating debug called versions

### DIFF
--- a/testing/browser-functional/browser-echo-bot/yarn.lock
+++ b/testing/browser-functional/browser-echo-bot/yarn.lock
@@ -3895,9 +3895,9 @@ debug@4, debug@^4.0.0, debug@^4.3.1:
     ms "2.1.2"
 
 debug@^4.1.0, debug@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
   dependencies:
     ms "2.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,9 +2493,9 @@
     "@types/node" "*"
 
 "@types/debug@^4.1.4":
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
-  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
 


### PR DESCRIPTION
Fixes # 90662

## Description
Updating the version of _debug_ to use any of the versions that fix the vulnerability

Patched versions

- 2.6.9
- 3.1.0
- 3.2.7
- 4.3.1

## Specific Changes
Update dependencies if possible and add resolutions if not.

Testing
The following images show the _debug_ versions installed after the update.