### PR TITLE
fix: CVE-2024-39338 vulnerability with axios

### DIFF
--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -35,7 +35,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "mime-types": "^2.1.35",
     "unzipper": "^0.10.9"
   },

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/core-http": "^3.0.2",
     "@azure/msal-node": "^1.18.4",
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "botbuilder-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -30,7 +30,7 @@
     "@azure/core-http": "^3.0.2",
     "@azure/identity": "^2.0.4",
     "@azure/msal-node": "^1.18.4",
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "base64url": "^3.0.0",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "dotenv": "^8.6.0",
     "nightwatch": "^2.6.21",
     "selenium-server": "^3.141.59"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3621,10 +3621,10 @@ axe-core@^4.7.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
-axios@^1.4.0, axios@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.4.0, axios@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
+  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
#minor

## Description
This PR updates the _**axios**_ version to 1.7.4 to avoid the [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj) vulnerability.

## Specific Changes
  - Updated _axios_ from 1.7.2 to 1.7.4 in every library.

## Testing
The following image shows the _axios_ version installed.
![image](https://github.com/user-attachments/assets/da90a99b-ea37-426a-8522-42d556715b1c)