### PR TITLE
refactor: Update pipelines to run with latest Node versions

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -18,13 +18,21 @@ jobs:
     name: depcheck
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,13 +18,21 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -18,13 +18,21 @@ jobs:
     name: test:compat
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -18,13 +18,21 @@ jobs:
     name: test:consumer
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-repoutils.yml
+++ b/.github/workflows/test-repoutils.yml
@@ -18,13 +18,21 @@ jobs:
     name: test:repoutils
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 16.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node16.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/test-schemas.yml
+++ b/.github/workflows/test-schemas.yml
@@ -18,13 +18,21 @@ jobs:
     name: test:schemas
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        node-version: [22.X]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: use node 14.x
+      - name: use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
+          node-version:  ${{ matrix.node-version }}
 
       - name: yarn cache dir
         id: yarn-cache-dir
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn
         run: yarn --frozen-lockfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,13 @@ jobs:
     name: "${{ github.workflow }} ${{ matrix.os }} (node ${{ matrix.node-version }})"
     runs-on: ${{ matrix.os }}-latest
 
+    timeout-minutes: 10
+    
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x, 22.X]
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +53,7 @@ jobs:
         run: yarn test:github
 
       - name: coveralls
-        if: matrix.node-version == '16.x'
+        if: matrix.node-version == '22.x'
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes # 90845

## Description
The PR updates the GitHub Actions files to run on node versions 18, 20 and 22.  

## Specific Changes
- Addition of a matrix for the use of pipelines in different versions of Node.
- Set versions 18, 20 and 22 to run by default. 

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->