### PR TITLE
fix: HSA-wrw9-m778-g6mc vulnerability with bl

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4111,13 +4111,6 @@ bl@^5.0.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bl@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
-  integrity sha512-pfqikmByp+lifZCS0p6j6KreV6kNU6Apzpm2nKOk+94cZb/jvle55+JxWiByUQ0Wo/+XnDXEy5MxxKMb6r0VIw==
-  dependencies:
-    readable-stream "~1.0.26"
-
 bluebird@^3.5.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"


### PR DESCRIPTION
#minor

## Description
This PR updates the _**bl**_ versions grater than 4.0.0 to avoid the [HSA-wrw9-m778-g6mc](https://github.com/advisories/GHSA-wrw9-m778-g6mc) vulnerability.

## Specific Changes
  - Updated _bl_ to versions greater than 4.0.0 in _yarn.lock_ file.

## Testing
The following image shows the _bl_ versions installed.
![image](https://github.com/user-attachments/assets/8559d587-ea95-4203-937c-c6ccb1eb67d3)
