### PR TITLE
feat: Add TS 5.6 and ESNext target support

### DIFF
--- a/libraries/adaptive-expressions/.gitignore
+++ b/libraries/adaptive-expressions/.gitignore
@@ -6,3 +6,4 @@ coverage
 /**/.antlr
 /**/*.interp
 tests/expressionProperty.test.js
+!types/**

--- a/libraries/adaptive-expressions/etc/adaptive-expressions.api.md
+++ b/libraries/adaptive-expressions/etc/adaptive-expressions.api.md
@@ -1927,7 +1927,7 @@ export class FuncInvokeExpContext extends PrimaryExpressionContext {
 
 // @public
 export class FunctionTable implements Map<string, ExpressionEvaluator> {
-    get [Symbol.iterator](): () => IterableIterator<[string, ExpressionEvaluator]>;
+    get [Symbol.iterator](): () => MapIterator<[string, ExpressionEvaluator]>;
     get [Symbol.toStringTag](): string;
     // (undocumented)
     add(item: {
@@ -1942,15 +1942,15 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
     add(key: string, value: customFunction): void;
     clear(): void;
     delete(key: string): boolean;
-    entries(): IterableIterator<[string, ExpressionEvaluator]>;
+    entries(): MapIterator<[string, ExpressionEvaluator]>;
     forEach(_callbackfn: (value: ExpressionEvaluator, key: string, map: Map<string, ExpressionEvaluator>) => void, _thisArg?: any): void;
     get(key: string): ExpressionEvaluator;
     has(key: string): boolean;
     get isReadOnly(): boolean;
-    keys(): IterableIterator<string>;
+    keys(): MapIterator<string>;
     set(key: string, value: ExpressionEvaluator): this;
     get size(): number;
-    values(): IterableIterator<ExpressionEvaluator>;
+    values(): MapIterator<ExpressionEvaluator>;
 }
 
 // @public

--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -16,14 +16,16 @@
     "type": "git",
     "url": "https://github.com/Microsoft/botbuilder-js.git"
   },
-  "main": "./lib/index.js",
-  "browser": "./lib/browser.js",
-  "typings": "./lib/index.d.ts",
+  "main": "lib/index.js",
+  "browser": "lib/browser.js",
+  "types": "lib/index.d.ts",
+  "typesVersions": {
+    "<5.6": { "*": [ "types/ts5.6/*", "lib" ] }
+  },
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.1",
     "@types/atob-lite": "^2.0.2",
     "@types/btoa-lite": "^1.0.2",
-    "@types/lodash.isequal": "^4.5.8",
     "@types/lru-cache": "^5.1.1",
     "antlr4ts": "0.5.0-alpha.4",
     "atob-lite": "^2.0.0",
@@ -33,7 +35,7 @@
     "d3-format": "^2.0.0",
     "dayjs": "^1.11.13",
     "jspath": "^0.4.0",
-    "lodash.isequal": "^4.5.0",
+    "lodash": "^4.17.21",
     "lru-cache": "^5.1.1",
     "uuid": "^10.0.0",
     "fast-xml-parser": "^4.4.1",
@@ -62,6 +64,7 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "types"
   ]
 }

--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -20,7 +20,7 @@
   "browser": "lib/browser.js",
   "types": "lib/index.d.ts",
   "typesVersions": {
-    "<5.6": { "*": [ "types/ts5.6/*", "lib" ] }
+    "<5.6": { "*": [ "types/ts5.6/*" ] }
   },
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.1",

--- a/libraries/adaptive-expressions/src/functionTable.ts
+++ b/libraries/adaptive-expressions/src/functionTable.ts
@@ -23,7 +23,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
      *
      * @returns A list of string values.
      */
-    keys(): IterableIterator<string> {
+    keys(): MapIterator<string> {
         const keysOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.keys()).concat(
             Array.from(this.customFunctions.keys())
         );
@@ -35,7 +35,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
      *
      * @returns A list of [ExpressionEvaluator](xref:adaptive-expressions.ExpressionEvaluator).
      */
-    values(): IterableIterator<ExpressionEvaluator> {
+    values(): MapIterator<ExpressionEvaluator> {
         const valuesOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.values()).concat(
             Array.from(this.customFunctions.values())
         );
@@ -168,7 +168,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
      * Returns an iterable of key, value pairs for every entry in the map.
      * Not implemented.
      */
-    entries(): IterableIterator<[string, ExpressionEvaluator]> {
+    entries(): MapIterator<[string, ExpressionEvaluator]> {
         throw Error('entries function not implemented');
     }
 
@@ -176,7 +176,7 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
      * Returns an iterable of key, value pairs.
      * Not implemented.
      */
-    get [Symbol.iterator](): () => IterableIterator<[string, ExpressionEvaluator]> {
+    get [Symbol.iterator](): () => MapIterator<[string, ExpressionEvaluator]> {
         throw Error('Symbol.iterator function not implemented');
     }
 

--- a/libraries/adaptive-expressions/src/functionUtils.ts
+++ b/libraries/adaptive-expressions/src/functionUtils.ts
@@ -14,8 +14,7 @@ import { ExpressionType } from './expressionType';
 import { MemoryInterface } from './memory';
 import { Options } from './options';
 import { ReturnType } from './returnType';
-// eslint-disable-next-line lodash/import-scope
-import isEqual from 'lodash.isequal';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Verify the result of an expression is of the appropriate type and return a string if not.

--- a/libraries/adaptive-expressions/tests/tsconfig.json
+++ b/libraries/adaptive-expressions/tests/tsconfig.json
@@ -6,5 +6,8 @@
     "declarationMap": false,
     "sourceMap": false
   },
-  "include": ["*.ts"]
+  "include": [
+    "*.ts",
+    "../types/**/*"
+  ]
 }

--- a/libraries/adaptive-expressions/tsconfig.json
+++ b/libraries/adaptive-expressions/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "types/**/*"
   ]
 }

--- a/libraries/adaptive-expressions/types/ts5.6/lib/index.d.ts
+++ b/libraries/adaptive-expressions/types/ts5.6/lib/index.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare global {
+    interface MapIterator<T> extends IterableIterator<T> {}
+}
+
+// @ts-ignore - the following export is only required for projects referencing adaptive-expressions, otherwise it will fail at build time.
+export * from '../../../lib';

--- a/testing/consumer-test/run.ts
+++ b/testing/consumer-test/run.ts
@@ -5,23 +5,28 @@ import { promisify } from 'util';
 
 const execp = promisify(exec);
 
-const versions = ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5'];
+const versions = ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6'];
 
 (async () => {
     const flags = minimist(process.argv.slice(2), {
-        boolean: ['versbose'],
+        boolean: ['verbose'],
         alias: { v: 'verbose' },
     });
 
     try {
-        console.log(`Running typescript consumer test against ["${versions.join('", "')}"]`);
+        const [minTarget, maxTarget] = ['es6', 'esnext'];
+        console.log(
+            `Running typescript consumer test against ["${versions.join(
+                '", "'
+            )}"] with '${minTarget}' and '${maxTarget}' targets.`
+        );
 
         const results = await pmap(
             versions,
             (version) =>
                 Promise.all([
-                    execp(`npx -p typescript@${version} tsc -p tsconfig-test.json`),
-                    execp(`npx -p typescript@${version} tsc -p tsconfig-test.json --lib es2018`),
+                    execp(`npx -p typescript@${version} tsc -p tsconfig-test.json --target ${minTarget}`),
+                    execp(`npx -p typescript@${version} tsc -p tsconfig-test.json --target ${maxTarget}`),
                 ])
                     .then(() => ({ err: null, version, success: true }))
                     .catch((err) => ({ err, version, success: false })),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,18 +3050,6 @@
   resolved "https://registry.yarnpkg.com/@types/jspath/-/jspath-0.4.2.tgz#c51f930d5428a786da9c12a6e0077b1f9d148c3c"
   integrity sha512-NltGdfyWyW36ZToRhwuQhzRRKuw29NSaMEwTZ4eGFlS49ZzbZ4fDXTC+JfTpSVSUy6ru+fR+nXypWSkKVE5zMQ==
 
-"@types/lodash.isequal@^4.5.8":
-  version "4.5.8"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz#b30bb6ff6a5f6c19b3daf389d649ac7f7a250499"
-  integrity sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
-
 "@types/lodash@^4.17.7":
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.7.tgz#2f776bcb53adc9e13b2c0dfd493dfcbd7de43612"


### PR DESCRIPTION
Related issue # 4746
#minor

## Description
This PR adds TypeScript 5.6 and ESNext target support for the test:consumer script.
The FunctionTable inside the adaptive-expressions project has been updated to support both es6 and esnext targets, alongside, lodash.isequal has been replaced for lodash, updating the import statement.

## Specific Changes
  - Updated adaptive-expressions package.json, adding typesVersions with custom types for versions below 5.6.
  - Replaced lodash.isequal for lodash.
  - Updated FunctionTable class, changing IterableIterator for MapIterator due to the combination of TS 5.6 and ESNext requires using MapIterator.
    - To address this disparity, we created a MapIterator type that extends from IterableIterator for all versions of TS below 5.6.
  - Updated test:consumer script, adding TS 5.6 and ESNext target.

## Testing
The following image shows the test:consumer script working with all TS versions, and es6 and ESNext targets.
![image](https://github.com/user-attachments/assets/fb1cde19-79c8-407e-a023-e467acb4f30a)
