### PR TITLE
port: [#4632] Support Federated Identity Credential

### DIFF
--- a/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
@@ -1,0 +1,87 @@
+/**
+ * @module botframework-connector
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ConfidentialClientApplication, ManagedIdentityApplication } from '@azure/msal-node';
+import { AppCredentials } from './appCredentials';
+import { AuthenticatorResult } from './authenticatorResult';
+import { MsalAppCredentials } from './msalAppCredentials';
+
+/**
+ * Federated Credentials auth implementation.
+ */
+export class FederatedAppCredentials extends AppCredentials {
+    private credentials: MsalAppCredentials;
+    private managedIdentityClientAssertion: ManagedIdentityApplication;
+    private clientAudience: string;
+
+    /**
+     * Initializes a new instance of the [FederatedAppCredentials](xref:botframework-connector.FederatedAppCredentials) class.
+     *
+     * @param {string} appId App ID for the Application.
+     * @param {string} clientId Client ID for the managed identity assigned to the bot.
+     * @param {string} channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
+     *   * **Required** for SingleTenant app types.
+     *   * **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
+     * @param {string} oAuthScope **Optional**. The scope for the token.
+     * @param {string} clientAudience **Optional**. The Audience used in the Client's Federated Credential. **Default** (_api://AzureADTokenExchange_).
+     */
+    constructor(
+        appId: string,
+        clientId: string,
+        channelAuthTenant?: string,
+        oAuthScope?: string,
+        clientAudience?: string
+    ) {
+        super(appId, channelAuthTenant, oAuthScope);
+        this.clientAudience = clientAudience ?? 'api://AzureADTokenExchange';
+        this.managedIdentityClientAssertion = new ManagedIdentityApplication({
+            managedIdentityIdParams: { userAssignedClientId: clientId },
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async getToken(forceRefresh = false): Promise<string> {
+        this.credentials ??= new MsalAppCredentials(
+            this.createClientApplication(await this.fetchExternalToken(forceRefresh)),
+            this.oAuthEndpoint,
+            this.oAuthEndpoint,
+            this.oAuthScope
+        );
+        return this.credentials.getToken(forceRefresh);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected refreshToken(): Promise<AuthenticatorResult> {
+        // This will never be executed because we are using MsalAppCredentials.getToken underneath.
+        throw new Error('Method not implemented.');
+    }
+
+    private createClientApplication(clientAssertion: string) {
+        return new ConfidentialClientApplication({
+            auth: {
+                clientId: this.appId,
+                authority: this.oAuthEndpoint,
+                clientAssertion,
+            },
+        });
+    }
+
+    private async fetchExternalToken(forceRefresh = false): Promise<string> {
+        const response = await this.managedIdentityClientAssertion.acquireToken({
+            resource: this.clientAudience,
+            forceRefresh,
+        });
+        return response.accessToken;
+    }
+}

--- a/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
@@ -7,6 +7,7 @@
  */
 
 import { ConfidentialClientApplication, ManagedIdentityApplication } from '@azure/msal-node';
+import { ok } from 'assert';
 import { AppCredentials } from './appCredentials';
 import { AuthenticatorResult } from './authenticatorResult';
 import { MsalAppCredentials } from './msalAppCredentials';
@@ -40,6 +41,9 @@ export class FederatedAppCredentials extends AppCredentials {
         clientAudience?: string
     ) {
         super(appId, channelAuthTenant, oAuthScope);
+
+        ok(appId?.trim(), 'FederatedAppCredentials.constructor(): missing appId.');
+
         this.clientAudience = clientAudience ?? 'api://AzureADTokenExchange';
         this.managedIdentityClientAssertion = new ManagedIdentityApplication({
             managedIdentityIdParams: { userAssignedClientId: clientId },

--- a/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
@@ -1,0 +1,70 @@
+/**
+ * @module botframework-connector
+ */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ok } from 'assert';
+import type { ServiceClientCredentials } from '@azure/core-http';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { FederatedAppCredentials } from './federatedAppCredentials';
+
+/**
+ * A Federated Credentials implementation of the [ServiceClientCredentialsFactory](xref:botframework-connector.ServiceClientCredentialsFactory) interface.
+ */
+export class FederatedServiceClientCredentialsFactory extends ServiceClientCredentialsFactory {
+    /**
+     * Initializes a new instance of the [FederatedServiceClientCredentialsFactory](xref:botframework-connector.FederatedServiceClientCredentialsFactory) class.
+     * @param {string} appId App ID for the Application.
+     * @param {string} clientId Client ID for the managed identity assigned to the bot.
+     * @param {string} tenantId Tenant ID of the Azure AD tenant where the bot is created.
+     *   * **Required** for SingleTenant app types.
+     *   * **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
+     * @param {string} clientAudience **Optional**. The Audience used in the Client's Federated Credential. **Default** (_api://AzureADTokenExchange_).
+     */
+    constructor(
+        private appId: string,
+        private clientId: string,
+        private tenantId?: string,
+        private clientAudience?: string
+    ) {
+        super();
+
+        ok(appId?.trim(), 'FederatedServiceClientCredentialsFactory.constructor(): missing appId.');
+        ok(clientId?.trim(), 'FederatedServiceClientCredentialsFactory.constructor(): missing clientId.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isValidAppId(appId = ''): Promise<boolean> {
+        return appId === this.appId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isAuthenticationDisabled(): Promise<boolean> {
+        // Auth is always enabled for FIC.
+        return;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async createCredentials(
+        appId: string,
+        audience: string,
+        loginEndpoint: string,
+        validateAuthority: boolean
+    ): Promise<ServiceClientCredentials> {
+        ok(
+            await this.isValidAppId(appId),
+            'FederatedServiceClientCredentialsFactory.createCredentials(): Invalid App ID.'
+        );
+
+        return new FederatedAppCredentials(this.appId, this.clientId, this.tenantId, audience, this.clientAudience);
+    }
+}

--- a/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
@@ -15,6 +15,7 @@ import { FederatedAppCredentials } from './federatedAppCredentials';
 export class FederatedServiceClientCredentialsFactory extends ServiceClientCredentialsFactory {
     /**
      * Initializes a new instance of the [FederatedServiceClientCredentialsFactory](xref:botframework-connector.FederatedServiceClientCredentialsFactory) class.
+     *
      * @param {string} appId App ID for the Application.
      * @param {string} clientId Client ID for the managed identity assigned to the bot.
      * @param {string} tenantId Tenant ID of the Azure AD tenant where the bot is created.
@@ -54,12 +55,7 @@ export class FederatedServiceClientCredentialsFactory extends ServiceClientCrede
     /**
      * @inheritdoc
      */
-    async createCredentials(
-        appId: string,
-        audience: string,
-        loginEndpoint: string,
-        validateAuthority: boolean
-    ): Promise<ServiceClientCredentials> {
+    async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
         ok(
             await this.isValidAppId(appId),
             'FederatedServiceClientCredentialsFactory.createCredentials(): Invalid App ID.'

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -8,6 +8,7 @@
 
 export * from './allowedCallersClaimsValidator';
 export * from './appCredentials';
+export * from './aseChannelValidation';
 export * from './authenticateRequestResult';
 export * from './authenticationConfiguration';
 export * from './authenticationConstants';
@@ -22,9 +23,10 @@ export * from './claimsIdentity';
 export * from './connectorFactory';
 export * from './credentialProvider';
 export * from './emulatorValidation';
-export * from './aseChannelValidation';
 export * from './endorsementsValidator';
 export * from './enterpriseChannelValidation';
+export * from './federatedAppCredentials';
+export * from './federatedServiceClientCredentialsFactory';
 export * from './governmentChannelValidation';
 export * from './governmentConstants';
 export * from './jwtTokenProviderFactory';


### PR DESCRIPTION
Fixes # 4632
#minor

Ported from https://github.com/microsoft/botbuilder-dotnet/pull/ 6838

## Description
This PR ports the Federated Credentials from DotNet's repo. The implementation is similar except in the `fetchExternalToken`, since it requires the Audience value to be provided, by default it uses 'api://AzureADTokenExchange'.

## Specific Changes
  - Retrieving the clientAssertion token functionality has being extracted from the [ManagedIdentity FIC sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/Managed-Identity/FIC).
  - Added FederatedAppCredentials class, it gathers a token from a Managed identity resource, and provides the clientAssertion to MSAL.
  - Added FederatedServiceClientCredentialsFactory class, so it can be used from CloudAdapter config.

**Bot usage example**
![image](https://github.com/user-attachments/assets/986db68f-bcf1-4b38-88e3-f8d1966abec0)

## Testing
As we FIC [isn't available for third-party apps](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/Managed-Identity/FIC#note), we encountered the following error (same error when testing DotNet's implementation).
![image](https://github.com/user-attachments/assets/0f409eb7-587b-4fc7-8387-4bd4c6a54e4d)
