### PR TITLE
bump: [#4684] Upgrade filenamify using tsup for building esm-only package

### DIFF
--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "npm-run-all clean build:tsc build:tsup",
     "build:tsc": "tsc -b",
-    "build:tsup": "tsup src/**/* --format cjs,esm --sourcemap --outDir lib",
+    "build:tsup": "tsup src/ --format cjs,esm --sourcemap --outDir lib",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
     "build:rollup": "yarn clean && yarn build:tsc && yarn build:tsup && api-extractor run --verbose --local",
     "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -36,7 +36,7 @@
     "botframework-schema": "4.1.6",
     "botframework-streaming": "4.1.6",
     "dayjs": "^1.11.13",
-    "filenamify": "^4.3.0",
+    "filenamify": "^6.0.0",
     "fs-extra": "^11.2.0",
     "htmlparser2": "^9.0.1",
     "uuid": "^10.0.0",
@@ -49,14 +49,16 @@
     "node-mocks-http": "^1.16.0"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "npm-run-all clean build:tsc build:tsup",
+    "build:tsc": "tsc -b",
+    "build:tsup": "tsup src/**/* --format cjs,esm --sourcemap --outDir lib",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
-    "build:rollup": "yarn clean && yarn build && api-extractor run --verbose --local",
+    "build:rollup": "yarn clean && yarn build:tsc && yarn build:tsup && api-extractor run --verbose --local",
     "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",
     "depcheck": "depcheck --config ../../.depcheckrc",
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
-    "test": "npm-run-all build test:mocha",
+    "test": "npm-run-all build:tsc build:tsup test:mocha",
     "test:compat": "api-extractor run --verbose",
     "test:mocha": "nyc mocha tests"
   },

--- a/libraries/botbuilder/src/fileTranscriptStore.ts
+++ b/libraries/botbuilder/src/fileTranscriptStore.ts
@@ -8,7 +8,6 @@
 import { join, parse } from 'path';
 import { mkdirp, pathExists, readdir, readFile, remove, writeFile } from 'fs-extra';
 import { Activity, PagedResult, TranscriptInfo, TranscriptStore } from 'botbuilder-core';
-import filenamify from 'filenamify';
 
 /**
  * @private
@@ -123,8 +122,8 @@ export class FileTranscriptStore implements TranscriptStore {
             throw new Error('activity cannot be null for logActivity()');
         }
 
-        const conversationFolder: string = this.getTranscriptFolder(activity.channelId, activity.conversation.id);
-        const activityFileName: string = this.getActivityFilename(activity);
+        const conversationFolder: string = await this.getTranscriptFolder(activity.channelId, activity.conversation.id);
+        const activityFileName: string = await this.getActivityFilename(activity);
 
         return this.saveActivity(activity, conversationFolder, activityFileName);
     }
@@ -153,7 +152,7 @@ export class FileTranscriptStore implements TranscriptStore {
         }
 
         const pagedResult: PagedResult<Activity> = { items: [], continuationToken: undefined };
-        const transcriptFolder: string = this.getTranscriptFolder(channelId, conversationId);
+        const transcriptFolder: string = await this.getTranscriptFolder(channelId, conversationId);
 
         const exists = await pathExists(transcriptFolder);
         if (!exists) {
@@ -195,7 +194,7 @@ export class FileTranscriptStore implements TranscriptStore {
         }
 
         const pagedResult: PagedResult<TranscriptInfo> = { items: [], continuationToken: undefined };
-        const channelFolder: string = this.getChannelFolder(channelId);
+        const channelFolder: string = await this.getChannelFolder(channelId);
 
         const exists = await pathExists(channelFolder);
         if (!exists) {
@@ -230,7 +229,7 @@ export class FileTranscriptStore implements TranscriptStore {
             throw new Error('Missing conversationId');
         }
 
-        const transcriptFolder: string = this.getTranscriptFolder(channelId, conversationId);
+        const transcriptFolder: string = await this.getTranscriptFolder(channelId, conversationId);
 
         return remove(transcriptFolder);
     }
@@ -256,28 +255,29 @@ export class FileTranscriptStore implements TranscriptStore {
     /**
      * @private
      */
-    private getActivityFilename(activity: Activity): string {
-        return `${getTicks(activity.timestamp)}-${this.sanitizeKey(activity.id)}.json`;
+    private async getActivityFilename(activity: Activity): Promise<string> {
+        return `${getTicks(activity.timestamp)}-${await this.sanitizeKey(activity.id)}.json`;
     }
 
     /**
      * @private
      */
-    private getChannelFolder(channelId: string): string {
-        return join(this.rootFolder, this.sanitizeKey(channelId));
+    private async getChannelFolder(channelId: string): Promise<string> {
+        return join(this.rootFolder, await this.sanitizeKey(channelId));
     }
 
     /**
      * @private
      */
-    private getTranscriptFolder(channelId: string, conversationId: string): string {
-        return join(this.rootFolder, this.sanitizeKey(channelId), this.sanitizeKey(conversationId));
+    private async getTranscriptFolder(channelId: string, conversationId: string): Promise<string> {
+        return join(this.rootFolder, await this.sanitizeKey(channelId), await this.sanitizeKey(conversationId));
     }
 
     /**
      * @private
      */
-    private sanitizeKey(key: string): string {
-        return filenamify(key);
+    private async sanitizeKey(key: string): Promise<string> {
+        const filenamify = await import('filenamify');
+        return filenamify.default(key);
     }
 }

--- a/libraries/botbuilder/tsconfig.json
+++ b/libraries/botbuilder/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["es2015", "dom"],
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "emitDeclarationOnly": true
   },
   "include": [
     "src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6161,7 +6161,7 @@ escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -6680,19 +6680,17 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-filename-reserved-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
-  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+filename-reserved-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz#3d5dd6d4e2d73a3fed2ebc4cd0b3448869a081f7"
+  integrity sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==
 
-filenamify@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.3.0.tgz#62391cb58f02b09971c9d4f9d63b3cf9aba03106"
-  integrity sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==
+filenamify@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-6.0.0.tgz#38def94098c62154c42a41d822650f5f55bcbac2"
+  integrity sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==
   dependencies:
-    filename-reserved-regex "^2.0.0"
-    strip-outer "^1.0.1"
-    trim-repeated "^1.0.0"
+    filename-reserved-regex "^3.0.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -11704,7 +11702,16 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11791,7 +11798,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11853,13 +11867,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-strip-outer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
-  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
-  dependencies:
-    escape-string-regexp "^1.0.2"
 
 strnum@^1.0.5:
   version "1.0.5"
@@ -12212,13 +12219,6 @@ trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
-
-trim-repeated@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
-  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
-  dependencies:
-    escape-string-regexp "^1.0.2"
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"
@@ -13067,7 +13067,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13089,6 +13089,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Addresses # 4684
#minor

## Description
This PR updates the `filenamify` package to its latest version 6.0.0. Starting on version 5.x, this package is ESM-only, so we used tsup + dynamic import to be able to use this version.

## Specific Changes
  - Updated `filenamify` from 4.3.0 and 6.0.0 in _botbuilder_ library.
  - Updated the `build` script in _botbuilder's package.json_ to use _tsup_, keeping tsc to generate the _.d.ts_ files (issue).
  - Updated `botbuilder/tsconfig.json` file adding the _emitDeclarationOnly_ property in true.
  - Updated `fileTranscriptStore` class to dynamically import the package _filenamify_. We had to mark the `sanitizeKey` function as async for this.

## Testing
The following images show the installed version and the unit tests passing after the changes.
![image](https://github.com/user-attachments/assets/f9c9b323-c762-41d9-9db9-725068c0568f)
![image](https://github.com/user-attachments/assets/8ab17381-cc40-4d6c-9b05-575f26ed6e75)

