### PR TITLE
fix: [#4684] ESLint issues in botbuilder-dialogs-adaptive

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/eslint.config.cjs
+++ b/libraries/botbuilder-dialogs-adaptive/eslint.config.cjs
@@ -1,13 +1,8 @@
-const onlyWarn = require("eslint-plugin-only-warn");
-const sharedConfig = require("../../eslint.config.cjs")
+const sharedConfig = require('../../eslint.config.cjs');
 
 module.exports = [
     ...sharedConfig,
     {
-        ignores: ["tests/choiceSet.test.js", "tests/expressionProperty.test.js"],
+        ignores: ['tests/choiceSet.test.js', 'tests/expressionProperty.test.js'],
     },
-    {
-        plugins: {
-            "only-warn": onlyWarn,
-        },
-    }];
+];

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -43,7 +43,6 @@
     "botbuilder-dialogs-declarative": "4.1.6",
     "botbuilder-lg": "4.1.6",
     "botframework-connector": "4.1.6",
-    "eslint-plugin-only-warn": "^1.1.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0"
   },

--- a/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actionContext.ts
@@ -32,7 +32,7 @@ export class ActionContext extends DialogContext {
         parentDialogContext: DialogContext,
         state: DialogState,
         actions: ActionState[],
-        changeKey: symbol
+        changeKey: symbol,
     ) {
         super(dialogs, parentDialogContext, state);
         this.actions = actions;

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/actionScope.ts
@@ -42,7 +42,8 @@ export interface ActionScopeConfiguration extends DialogConfiguration {
  */
 export class ActionScope<O extends object = {}>
     extends Dialog<O>
-    implements DialogDependencies, ActionScopeConfiguration {
+    implements DialogDependencies, ActionScopeConfiguration
+{
     /**
      * Creates a new `ActionScope` instance.
      *
@@ -144,7 +145,7 @@ export class ActionScope<O extends object = {}>
      */
     protected async onActionScopeResult(
         dc: DialogContext,
-        actionScopeResult: ActionScopeResult
+        actionScopeResult: ActionScopeResult,
     ): Promise<DialogTurnResult> {
         switch (actionScopeResult.actionScopeCommand) {
             case ActionScopeCommands.GotoAction:

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
@@ -39,7 +39,8 @@ export interface BaseInvokeDialogConfiguration extends DialogConfiguration {
  */
 export class BaseInvokeDialog<O extends object = {}>
     extends Dialog<O>
-    implements DialogDependencies, BaseInvokeDialogConfiguration {
+    implements DialogDependencies, BaseInvokeDialogConfiguration
+{
     /**
      * Initializes a new instance of the [BaseInvokeDialog](xref:botbuilder-dialogs-adaptive.BaseInvokeDialog) class.
      *

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -165,7 +165,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
                     const { conversationState, skillClient, conversationIdFactory, ...rest } = this;
                     return rest;
                 },
-            })
+            }),
         );
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogsBase.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/cancelAllDialogsBase.ts
@@ -39,7 +39,8 @@ export interface CancelAllDialogsBaseConfiguration extends DialogConfiguration {
  */
 export class CancelAllDialogsBase<O extends object = {}>
     extends Dialog<O>
-    implements CancelAllDialogsBaseConfiguration {
+    implements CancelAllDialogsBaseConfiguration
+{
     constructor();
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversation.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversation.ts
@@ -100,7 +100,7 @@ export class ContinueConversation extends Dialog implements ContinueConversation
                 value: this.value?.getValue(dc.state),
             },
             conversationReference,
-            true
+            true,
         );
 
         const queueStorage: QueueStorage = dc.context.turnState.get(DialogTurnStateConstants.queueStorage);

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversationLater.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/continueConversationLater.ts
@@ -110,7 +110,7 @@ export class ContinueConversationLater extends Dialog implements ContinueConvers
                 relatesTo: reference as ConversationReference,
             },
             reference,
-            true
+            true,
         );
         activity.value = this.value && this.value.getValue(dc.state);
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/editActions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/editActions.ts
@@ -36,7 +36,8 @@ export interface EditActionsConfiguration extends DialogConfiguration {
  */
 export class EditActions<O extends object = {}>
     extends Dialog<O>
-    implements DialogDependencies, EditActionsConfiguration {
+    implements DialogDependencies, EditActionsConfiguration
+{
     static $kind = 'Microsoft.EditActions';
 
     constructor();
@@ -120,15 +121,13 @@ export class EditActions<O extends object = {}>
         }
 
         if (dc.parent instanceof ActionContext) {
-            const planActions = this.actions.map(
-                (action: Dialog): ActionState => {
-                    return {
-                        dialogStack: [],
-                        dialogId: action.id,
-                        options: options,
-                    };
-                }
-            );
+            const planActions = this.actions.map((action: Dialog): ActionState => {
+                return {
+                    dialogStack: [],
+                    dialogId: action.id,
+                    options: options,
+                };
+            });
 
             const changes: ActionChangeList = {
                 changeType: this.changeType.getValue(dc.state),

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/editArray.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/editArray.ts
@@ -152,7 +152,7 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
 
         if (!this.itemsProperty) {
             throw new Error(
-                `EditArray: "${this.changeType.toString()}" operation couldn't be performed because the itemsProperty wasn't specified.`
+                `EditArray: "${this.changeType.toString()}" operation couldn't be performed because the itemsProperty wasn't specified.`,
             );
         }
 
@@ -224,7 +224,7 @@ export class EditArray<O extends object = {}> extends Dialog<O> implements EditA
             throw new Error(
                 `EditArray: "${this.changeType.toString()}" operation couldn't be performed for list "${
                     this.itemsProperty
-                }" because a value wasn't specified.`
+                }" because a value wasn't specified.`,
             );
         }
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
@@ -145,7 +145,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      */
     protected async onContinueLoop(
         dc: DialogContext,
-        _actionScopeResult: ActionScopeResult
+        _actionScopeResult: ActionScopeResult,
     ): Promise<DialogTurnResult> {
         return await this.nextItem(dc);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEachPage.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEachPage.ts
@@ -162,7 +162,7 @@ export class ForEachPage<O extends object = {}> extends ActionScope<O> implement
      */
     protected async onContinueLoop(
         dc: DialogContext,
-        _actionScopeResult: ActionScopeResult
+        _actionScopeResult: ActionScopeResult,
     ): Promise<DialogTurnResult> {
         return await this.nextPage(dc);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/getConversationMembers.ts
@@ -35,7 +35,8 @@ export interface GetConversationMembersConfiguration extends DialogConfiguration
  */
 export class GetConversationMembers<O extends object = {}>
     extends Dialog<O>
-    implements GetConversationMembersConfiguration {
+    implements GetConversationMembersConfiguration
+{
     static $kind = 'Microsoft.GetConversationMembers';
 
     constructor();

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
@@ -6,10 +6,10 @@
  * Licensed under the MIT License.
  */
 import { StatusCodes } from 'botbuilder-core';
-import fetch, { FetchError } from 'node-fetch';
+import fetch, { FetchError, Response, Headers } from 'node-fetch';
 import { Activity } from 'botbuilder';
 import { BoolProperty, EnumProperty, StringProperty, UnknownProperty } from '../properties';
-import { Response, Headers } from 'node-fetch';
+
 import { evaluateExpression } from '../jsonExtensions';
 
 import {

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/ifCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/ifCondition.ts
@@ -33,7 +33,8 @@ export interface IfConditionConfiguration extends DialogConfiguration {
  */
 export class IfCondition<O extends object = {}>
     extends Dialog<O>
-    implements DialogDependencies, IfConditionConfiguration {
+    implements DialogDependencies, IfConditionConfiguration
+{
     static $kind = 'Microsoft.IfCondition';
 
     constructor();

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
@@ -102,7 +102,7 @@ export class SendActivity<O extends object = {}> extends Dialog<O> implements Se
             {
                 utterance: dc.context.activity.text || '',
             },
-            options
+            options,
         );
 
         const activityResult = await this.activity.bind(dc, data);

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
@@ -123,7 +123,7 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
     protected onComputeId(): string {
         return `SetProperties[${StringUtils.ellipsis(
             this.assignments.map((item): string => item.property.toString()).join(','),
-            50
+            50,
         )}]`;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/switchCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/switchCondition.ts
@@ -39,7 +39,7 @@ type CaseInput = {
 class CasesConverter implements Converter<Array<CaseInput | Case>, Case[]> {
     convert(items: Array<CaseInput | Case>): Case[] {
         return items.map(
-            (item: CaseInput | Case): Case => (item instanceof Case ? item : new Case(item.value, item.actions))
+            (item: CaseInput | Case): Case => (item instanceof Case ? item : new Case(item.value, item.actions)),
         );
     }
 }
@@ -59,7 +59,8 @@ export interface SwitchConditionConfiguration extends DialogConfiguration {
  */
 export class SwitchCondition<O extends object = {}>
     extends Dialog<O>
-    implements DialogDependencies, SwitchConditionConfiguration {
+    implements DialogDependencies, SwitchConditionConfiguration
+{
     static $kind = 'Microsoft.SwitchCondition';
 
     constructor();
@@ -176,8 +177,8 @@ export class SwitchCondition<O extends object = {}>
                         caseScope.value,
                         Expression.orExpression(
                             Expression.equalsExpression(this.condition, new Constant(intVal)),
-                            Expression.equalsExpression(this.condition, new Constant(caseScope.value))
-                        )
+                            Expression.equalsExpression(this.condition, new Constant(caseScope.value)),
+                        ),
                     );
                     continue;
                 }
@@ -188,8 +189,8 @@ export class SwitchCondition<O extends object = {}>
                         caseScope.value,
                         Expression.orExpression(
                             Expression.equalsExpression(this.condition, new Constant(floatVal)),
-                            Expression.equalsExpression(this.condition, new Constant(caseScope.value))
-                        )
+                            Expression.equalsExpression(this.condition, new Constant(caseScope.value)),
+                        ),
                     );
                     continue;
                 }
@@ -200,8 +201,8 @@ export class SwitchCondition<O extends object = {}>
                         caseScope.value,
                         Expression.orExpression(
                             Expression.equalsExpression(this.condition, new Constant(true)),
-                            Expression.equalsExpression(this.condition, new Constant(caseScope.value))
-                        )
+                            Expression.equalsExpression(this.condition, new Constant(caseScope.value)),
+                        ),
                     );
                     continue;
                 }
@@ -211,8 +212,8 @@ export class SwitchCondition<O extends object = {}>
                         caseScope.value,
                         Expression.orExpression(
                             Expression.equalsExpression(this.condition, new Constant(false)),
-                            Expression.equalsExpression(this.condition, new Constant(caseScope.value))
-                        )
+                            Expression.equalsExpression(this.condition, new Constant(caseScope.value)),
+                        ),
                     );
                     continue;
                 }
@@ -221,7 +222,7 @@ export class SwitchCondition<O extends object = {}>
                 const { value } = new ValueExpression(caseScope.value).tryGetValue(dc.state);
                 this._caseExpresssions.set(
                     caseScope.value,
-                    Expression.equalsExpression(this.condition, new Constant(value))
+                    Expression.equalsExpression(this.condition, new Constant(value)),
                 );
             }
         }
@@ -234,7 +235,7 @@ export class SwitchCondition<O extends object = {}>
             const { value, error } = caseCondition.tryEvaluate(dc.state);
             if (error) {
                 throw new Error(
-                    `Expression evaluation resulted in an error. Expression: ${caseCondition.toString()}. Error: ${error}`
+                    `Expression evaluation resulted in an error. Expression: ${caseCondition.toString()}. Error: ${error}`,
                 );
             }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/telemetryTrackEventAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/telemetryTrackEventAction.ts
@@ -55,7 +55,8 @@ export interface TelemetryTrackEventActionConfiguration extends DialogConfigurat
  */
 export class TelemetryTrackEventAction<O extends object = {}>
     extends Dialog
-    implements TelemetryTrackEventActionConfiguration {
+    implements TelemetryTrackEventActionConfiguration
+{
     static $kind = 'Microsoft.TelemetryTrackEventAction';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/updateActivity.ts
@@ -120,7 +120,7 @@ export class UpdateActivity<O extends object = {}> extends Dialog<O> implements 
                 utterance: dc.context.activity.text || '',
             },
             dc.state,
-            options
+            options,
         );
         const activityResult = await this.activity.bind(dc, data);
 

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveBotComponent.ts
@@ -272,8 +272,8 @@ export class AdaptiveBotComponent extends BotComponent {
                                 loader: new DynamicBeginDialogDeserializer(resourceExplorer, resourceId),
                             }));
                     },
-                }
-            )
+                },
+            ),
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -58,9 +58,8 @@ import { FirstSelector, MostSpecificSelector } from './selectors';
 import { TriggerSelector } from './triggerSelector';
 import { TelemetryLoggerConstants } from './telemetryLoggerConstants';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isDialogDependencies(val: any): val is DialogDependencies {
-    return typeof ((val as unknown) as DialogDependencies).getDependencies === 'function';
+    return typeof (val as unknown as DialogDependencies).getDependencies === 'function';
 }
 
 export interface AdaptiveDialogConfiguration extends DialogConfiguration {
@@ -485,7 +484,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     protected async processEvent(
         actionContext: ActionContext,
         dialogEvent: DialogEvent,
-        preBubble: boolean
+        preBubble: boolean,
     ): Promise<boolean> {
         // Save into turn
         actionContext.state.setValue(TurnPath.dialogEvent, dialogEvent);
@@ -501,7 +500,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                 // we have received a RecognizedIntent event
                 // get the value and promote to turn.recognized, topintent, topscore and lastintent
                 const recognizedResult = actionContext.state.getValue<RecognizerResult>(
-                    `${TurnPath.dialogEvent}.value`
+                    `${TurnPath.dialogEvent}.value`,
                 );
                 const { intent, score } = getTopScoringIntent(recognizedResult);
                 actionContext.state.setValue(TurnPath.recognized, recognizedResult);
@@ -1069,7 +1068,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         properties: string[],
         turn: number,
         text: string,
-        entityToInfo: Record<string, EntityInfo[]>
+        entityToInfo: Record<string, EntityInfo[]>,
     ): void {
         Object.keys(entities).forEach((entityName) => {
             const instances = entities[this.instanceKey][entityName];
@@ -1084,7 +1083,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                 properties,
                 turn,
                 text,
-                entityToInfo
+                entityToInfo,
             );
         });
     }
@@ -1103,7 +1102,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         properties: string[],
         turn: number,
         text: string,
-        entityToInfo: Record<string, EntityInfo[]>
+        entityToInfo: Record<string, EntityInfo[]>,
     ): void {
         if (!name.startsWith('$')) {
             // Entities representing schema properties end in "Property" to prevent name collisions with the property itself.
@@ -1140,7 +1139,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                         property,
                         turn,
                         text,
-                        entityToInfo
+                        entityToInfo,
                     );
                 } else if (typeof entity === 'object' && entity !== null) {
                     if (isEmpty(entity)) {
@@ -1161,7 +1160,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                             properties,
                             turn,
                             text,
-                            entityToInfo
+                            entityToInfo,
                         );
                     }
                 } else if (isOp) {
@@ -1185,7 +1184,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         property: string,
         turn: number,
         text: string,
-        entityToInfo: Record<string, EntityInfo[]>
+        entityToInfo: Record<string, EntityInfo[]>,
     ): void {
         if (instance && rootInstance) {
             entityToInfo[name] ??= [];
@@ -1224,7 +1223,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         lastEvent: string,
         nextAssignment: EntityAssignment,
         askDefault: Record<string, string>,
-        dialogDefault: Record<string, unknown>
+        dialogDefault: Record<string, unknown>,
     ): EntityAssignment[] {
         const globalExpectedOnly: string[] = this.dialogSchema.schema[this.expectedOnlyKey] ?? [];
         const requiresValue: string[] = this.dialogSchema.schema[this.requiresValueKey] ?? [];
@@ -1240,7 +1239,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                             property: alternative.property,
                             operation: alternative.operation,
                             isExpected: expected.includes(alternative.property),
-                        })
+                        }),
                     );
                 }
             });
@@ -1262,7 +1261,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                                     property: propSchema.name,
                                     operation: entity.operation,
                                     isExpected,
-                                })
+                                }),
                             );
                         } else if (entity.property === entityName && !entity.value && !entity.operation && isExpected) {
                             // Recast property with no value as match for property entities.
@@ -1272,7 +1271,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                                     property: propSchema.name,
                                     operation: null,
                                     isExpected,
-                                })
+                                }),
                             );
                         }
                     }
@@ -1305,7 +1304,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                     if (!alternative.value) {
                         // If alternative matches one alternative, it answers chooseProperty.
                         const matches = nextAssignment.alternatives.filter((a) =>
-                            this.matchesAssignment(alternative, a)
+                            this.matchesAssignment(alternative, a),
                         );
                         if (matches.length === 1) {
                             assignments.push(
@@ -1313,7 +1312,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                                     value: alternative,
                                     operation: AdaptiveEvents.chooseProperty,
                                     isExpected: true,
-                                })
+                                }),
                             );
                         }
                     }
@@ -1331,7 +1330,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                             property: null,
                             operation: alternative.operation,
                             isExpected: false,
-                        })
+                        }),
                     );
                 }
             });
@@ -1383,7 +1382,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     private defaultOperation(
         assignment: EntityAssignment,
         askDefault: Record<string, string>,
-        dialogDefault: Record<string, unknown>
+        dialogDefault: Record<string, unknown>,
     ): string {
         let operation: string;
         if (assignment.property) {
@@ -1411,7 +1410,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                 ...acc,
                 [assignment.property]: [...(acc[assignment.property] ?? []), assignment],
             }),
-            {}
+            {},
         );
 
         const output: EntityAssignment[] = [];
@@ -1433,7 +1432,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
                                 (choice): boolean =>
                                     !isEqual(choice, candidate) ||
                                     (EntityInfo.sharesRoot(choice.value, candidate.value) &&
-                                        !EntityInfo.overlaps(choice.value, candidate.value))
+                                        !EntityInfo.overlaps(choice.value, candidate.value)),
                             );
                             output.push(candidate);
                         }
@@ -1449,7 +1448,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         actionContext: ActionContext,
         entities: NormalizedEntityInfos,
         existing: EntityAssignments,
-        lastEvent: string
+        lastEvent: string,
     ): Partial<EntityInfo>[] {
         const assignments = new EntityAssignments();
         const expected: string[] = actionContext.state.getValue(DialogPath.expectedProperties, []);
@@ -1462,7 +1461,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
 
         const nextAssignment = existing.nextAssignment;
         let candidates = this.removeOverlappingPerProperty(
-            this.candidates(entities, expected, lastEvent, nextAssignment, askDefaultOp, defaultOp)
+            this.candidates(entities, expected, lastEvent, nextAssignment, askDefaultOp, defaultOp),
         ).sort((a, b): number => (a.isExpected === b.isExpected ? 0 : a.isExpected ? -1 : 1));
 
         const usedEntities = new Set(candidates.map((candidate) => candidate.value));
@@ -1607,7 +1606,7 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     private mergeAssignments(
         newAssignments: EntityAssignments,
         old: EntityAssignments,
-        comparer: EntityAssignmentComparer
+        comparer: EntityAssignmentComparer,
     ): void {
         let list = old.assignments;
         for (const assign of newAssignments.assignments) {

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onActivity.ts
@@ -46,7 +46,7 @@ export class OnActivity extends OnDialogEvent implements OnActivityConfiguration
         // add constraints for activity type
         return Expression.andExpression(
             Expression.parse(`${TurnPath.activity}.type == '${this.type}'`),
-            super.createExpression()
+            super.createExpression(),
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseIntent.ts
@@ -39,13 +39,9 @@ export class OnChooseIntent extends OnIntent implements OnChooseIntentConfigurat
      */
     protected createExpression(): Expression {
         if (this.intents?.length) {
-            const constraints = this.intents.map(
-                (intent: string): Expression => {
-                    return Expression.parse(
-                        `contains(jPath(${TurnPath.recognized}, '.candidates.intent'), '${intent}')`
-                    );
-                }
-            );
+            const constraints = this.intents.map((intent: string): Expression => {
+                return Expression.parse(`contains(jPath(${TurnPath.recognized}, '.candidates.intent'), '${intent}')`);
+            });
             return Expression.andExpression(super.createExpression(), ...constraints);
         }
         return super.createExpression();

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
@@ -226,14 +226,14 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
                     return { value: changed, error: undefined };
                 },
                 ReturnType.Boolean,
-                FunctionUtils.validateUnary
+                FunctionUtils.validateUnary,
             );
             allExpressions.push(
                 new Expression(
                     ExpressionType.Ignore,
                     Expression.lookup(ExpressionType.Ignore),
-                    new Expression(evaluator.type, evaluator)
-                )
+                    new Expression(evaluator.type, evaluator),
+                ),
             );
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onContinueConversation.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onContinueConversation.ts
@@ -34,7 +34,7 @@ export class OnContinueConversation extends OnEventActivity {
         // add constraints for activity type
         return Expression.andExpression(
             Expression.parse(`${TurnPath.activity}.name == 'ContinueConversation'`),
-            super.createExpression()
+            super.createExpression(),
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
@@ -44,7 +44,7 @@ export class OnDialogEvent extends OnCondition implements OnDialogEventConfigura
     protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(`${TurnPath.dialogEvent}.name == '${this.event}'`),
-            super.createExpression()
+            super.createExpression(),
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
@@ -73,8 +73,8 @@ export class OnIntent extends OnDialogEvent implements OnIntentConfiguration {
                             return Expression.parse(`exists(${entity})`);
                         }
                         return Expression.parse(`exists(@${entity})`);
-                    })
-                )
+                    }),
+                ),
             );
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onUnknownIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onUnknownIntent.ts
@@ -17,8 +17,8 @@ import { OnDialogEvent } from './onDialogEvent';
  * there is no active plan being executed.
  * This trigger is run when the utterance is not recognized and the fallback consultation is happening
  * It will only trigger if and when
- *  * it is the leaf dialog AND
- *  * none of the parent dialogs handle the event
+ *  it is the leaf dialog AND
+ *  none of the parent dialogs handle the event
  * This provides the parent dialogs the opportunity to handle global commands as fallback interruption.
  */
 export class OnUnknownIntent extends OnDialogEvent {

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/dialogExpressionConverter.ts
@@ -42,6 +42,6 @@ export class DialogExpressionConverter implements Converter<Input, DialogExpress
             }
             return new DialogExpression(value);
         }
-        return new DialogExpression((value as unknown) as Dialog);
+        return new DialogExpression(value as unknown as Dialog);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
@@ -14,14 +14,18 @@ import { BeginDialogConfiguration, DynamicBeginDialog } from './actions';
  * Internal serializer for `DynamicBeginDialog` which bind the x.dialog resourceId to the DynamicBeginDialog.dialog property.
  */
 export class DynamicBeginDialogDeserializer
-    implements CustomDeserializer<DynamicBeginDialog, BeginDialogConfiguration> {
+    implements CustomDeserializer<DynamicBeginDialog, BeginDialogConfiguration>
+{
     /**
      * Intializes an instance of `DynamicBeginDialogDeserializer`.
      *
      * @param _resourceExplorer The `ResourceExplorer` used by the deserializer.
      * @param _resourceId The resource id of the dynamic dialog.
      */
-    constructor(private readonly _resourceExplorer: ResourceExplorer, private readonly _resourceId: string) {}
+    constructor(
+        private readonly _resourceExplorer: ResourceExplorer,
+        private readonly _resourceId: string,
+    ) {}
 
     /**
      * The method that loads the configuration object to a `DynamicBeginDialog` object.

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignment.ts
@@ -157,7 +157,7 @@ export class EntityAssignment implements EntityAssignmentConfiguration {
      */
     toString(): string {
         return `${this.isExpected ? '+' : ''}${this.event}: ${this.property} = ${this.operation}(${EntityInfo.toString(
-            this.value
+            this.value,
         )})`;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityInfo.ts
@@ -9,6 +9,7 @@
 /**
  * Extended information about an entity including $instance data.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface EntityInfo {
     /**
      * Name of entity.
@@ -86,6 +87,7 @@ export interface NormalizedEntityInfos {
 /**
  * Extended information about an entity including $instance data.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class EntityInfo {
     /**
      * Print an entity as a string.

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
@@ -81,7 +81,7 @@ export class LanguageGeneratorManager<T = unknown, D extends Record<string, unkn
             const resource = resources.find(
                 (u) =>
                     LanguageResourceLoader.parseLGFileName(u.id).prefix ===
-                    LanguageResourceLoader.parseLGFileName(resourceName).prefix
+                    LanguageResourceLoader.parseLGFileName(resourceName).prefix,
             );
 
             if (resource === undefined) {

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
@@ -20,10 +20,11 @@ export interface MultiLanguageGeneratorBaseConfiguration {
  */
 export abstract class MultiLanguageGeneratorBase<
         T = unknown,
-        D extends Record<string, unknown> = Record<string, unknown>
+        D extends Record<string, unknown> = Record<string, unknown>,
     >
     extends Configurable
-    implements LanguageGenerator<T, D>, MultiLanguageGeneratorBaseConfiguration {
+    implements LanguageGenerator<T, D>, MultiLanguageGeneratorBaseConfiguration
+{
     /**
      * Language policy required by language generator.
      */
@@ -50,7 +51,7 @@ export abstract class MultiLanguageGeneratorBase<
      */
     abstract tryGetGenerator(
         dialogContext: DialogContext,
-        locale: string
+        locale: string,
     ): { exist: boolean; result: LanguageGenerator<T, D> };
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
@@ -26,7 +26,8 @@ export interface ResourceMultiLanguageGeneratorConfiguration extends MultiLangua
  */
 export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string, unknown> = Record<string, unknown>>
     extends MultiLanguageGeneratorBase<T, D>
-    implements ResourceMultiLanguageGeneratorConfiguration {
+    implements ResourceMultiLanguageGeneratorConfiguration
+{
     static $kind = 'Microsoft.ResourceMultiLanguageGenerator';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/templateEngineLanguageGenerator.ts
@@ -22,7 +22,8 @@ export interface TemplateEngineLanguageGeneratorConfiguration {
  */
 export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<string, unknown> = Record<string, unknown>>
     extends Configurable
-    implements LanguageGenerator<T, D>, TemplateEngineLanguageGeneratorConfiguration {
+    implements LanguageGenerator<T, D>, TemplateEngineLanguageGeneratorConfiguration
+{
     static $kind = 'Microsoft.TemplateEngineLanguageGenerator';
 
     private readonly DEFAULTLABEL: string = 'Unknown';

--- a/libraries/botbuilder-dialogs-adaptive/src/input/ask.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/ask.ts
@@ -111,10 +111,10 @@ export class Ask extends SendActivity implements AskConfiguration {
             lastTrigger &&
             !expected.some(
                 (prop: string): boolean =>
-                    !lastExpectedProperties.some((lastProp: string): boolean => lastProp === prop)
+                    !lastExpectedProperties.some((lastProp: string): boolean => lastProp === prop),
             ) &&
             !lastExpectedProperties.some(
-                (lastProp: string): boolean => !expected.some((prop: string): boolean => prop === lastProp)
+                (lastProp: string): boolean => !expected.some((prop: string): boolean => prop === lastProp),
             ) &&
             lastTrigger.name === trigger.name
         ) {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/attachmentInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/attachmentInput.ts
@@ -26,7 +26,7 @@ export interface AttachmentInputConfiguration extends InputDialogConfiguration {
 export class AttachmentInput extends InputDialog implements AttachmentInputConfiguration {
     static $kind = 'Microsoft.AttachmentInput';
     outputFormat: EnumExpression<AttachmentOutputFormat> = new EnumExpression<AttachmentOutputFormat>(
-        AttachmentOutputFormat.first
+        AttachmentOutputFormat.first,
     );
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
@@ -141,7 +141,7 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
     protected trackGeneratorResultEvent(
         dc: DialogContext,
         activityTemplate: TemplateInterface<Partial<Activity>, DialogStateManager>,
-        msg: Partial<Activity>
+        msg: Partial<Activity>,
     ): void {
         const options = dc.state.getValue(ChoiceInput.OPTIONS_PROPERTY);
         const properties = {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
@@ -31,7 +31,6 @@ import {
     recognizeChoices,
 } from 'botbuilder-dialogs';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as Recognizers from '@microsoft/recognizers-text-choice';
 import { ChoiceOptionsSet } from './choiceOptionsSet';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
@@ -11,7 +11,6 @@ import { StringExpression, StringExpressionConverter } from 'adaptive-expression
 import { InputDialog, InputDialogConfiguration, InputState } from './inputDialog';
 import { StringProperty } from '../properties';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as Recognizers from '@microsoft/recognizers-text-date-time';
 
 export interface DateTimeInputConfiguration extends InputDialogConfiguration {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
@@ -397,7 +397,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
     protected trackGeneratorResultEvent(
         dc: DialogContext,
         activityTemplate: TemplateInterface<Partial<Activity>, DialogStateManager>,
-        msg: Partial<Activity>
+        msg: Partial<Activity>,
     ): void {
         this.telemetryClient.trackEvent({
             name: TelemetryLoggerConstants.GeneratorResultEvent,
@@ -424,7 +424,7 @@ export abstract class InputDialog extends Dialog implements InputDialogConfigura
         channelId: string,
         choices: Choice[],
         style: ListStyle,
-        options?: ChoiceFactoryOptions
+        options?: ChoiceFactoryOptions,
     ): Partial<Activity> {
         // Create temporary msg
         let msg: Partial<Activity>;

--- a/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/oauthInput.ts
@@ -15,6 +15,13 @@ import {
     tokenExchangeOperationName,
     tokenResponseEventName,
     verifyStateOperationName,
+    Activity,
+    ActivityTypes,
+    InputHints,
+    StatusCodes,
+    TokenExchangeInvokeRequest,
+    TokenResponse,
+    TurnContext,
 } from 'botbuilder';
 
 import {
@@ -24,16 +31,6 @@ import {
     StringExpression,
     StringExpressionConverter,
 } from 'adaptive-expressions';
-
-import {
-    Activity,
-    ActivityTypes,
-    InputHints,
-    StatusCodes,
-    TokenExchangeInvokeRequest,
-    TokenResponse,
-    TurnContext,
-} from 'botbuilder';
 
 import {
     Converter,

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGenerationBotComponent.ts
@@ -33,7 +33,7 @@ export class LanguageGenerationBotComponent extends BotComponent {
                         },
                     ];
                 },
-            })
+            }),
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/languageResourceLoader.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageResourceLoader.ts
@@ -36,7 +36,7 @@ export class LanguageResourceLoader {
                 const suffix = suffixs[index];
                 const resourcesWithSuffix = allResouces.filter(
                     (u): boolean =>
-                        this.parseLGFileName(u.id).language.toLocaleLowerCase() === suffix.toLocaleLowerCase()
+                        this.parseLGFileName(u.id).language.toLocaleLowerCase() === suffix.toLocaleLowerCase(),
                 );
                 resourcesWithSuffix.forEach((u): void => {
                     const resourceName = u.id;
@@ -57,7 +57,7 @@ export class LanguageResourceLoader {
 
             if (resourceMapping.has(locale)) {
                 const resourcesWithEmptySuffix = allResouces.filter(
-                    (u): boolean => this.parseLGFileName(u.id).language === ''
+                    (u): boolean => this.parseLGFileName(u.id).language === '',
                 );
                 resourcesWithEmptySuffix.forEach((u): void => {
                     const resourceName = u.id;
@@ -133,7 +133,7 @@ export class LanguageResourceLoader {
         for (const currentLocale of resourceMapping.keys()) {
             const currentResourcePool: Resource[] = resourceMapping.get(currentLocale);
             const existLocale = Array.from(resourcePoolDict.keys()).find((u) =>
-                this.hasSameResourcePool(resourcePoolDict.get(u), currentResourcePool)
+                this.hasSameResourcePool(resourcePoolDict.get(u), currentResourcePool),
             );
             if (existLocale === undefined) {
                 resourcePoolDict.set(currentLocale, currentResourcePool);

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/adaptiveRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/adaptiveRecognizer.ts
@@ -22,7 +22,7 @@ export abstract class AdaptiveRecognizer extends Recognizer implements AdaptiveR
      * (Optional) Flag that designates whether personally identifiable information (PII) should log to telemetry.
      */
     logPersonalInformation: BoolExpression = new BoolExpression(
-        '=settings.runtimeSettings.telemetry.logPersonalInformation'
+        '=settings.runtimeSettings.telemetry.logPersonalInformation',
     );
 
     /**
@@ -36,11 +36,11 @@ export abstract class AdaptiveRecognizer extends Recognizer implements AdaptiveR
     protected fillRecognizerResultTelemetryProperties(
         recognizerResult: RecognizerResult,
         telemetryProperties: Record<string, string>,
-        dialogContext: DialogContext
+        dialogContext: DialogContext,
     ): Record<string, string> {
         if (!dialogContext) {
             throw new Error(
-                'DialogContext needed for state in AdaptiveRecognizer.fillRecognizerResultTelemetryProperties method.'
+                'DialogContext needed for state in AdaptiveRecognizer.fillRecognizerResultTelemetryProperties method.',
             );
         }
         const { intent, score } = getTopScoringIntent(recognizerResult);
@@ -51,7 +51,7 @@ export abstract class AdaptiveRecognizer extends Recognizer implements AdaptiveR
             Intents: intentsCount > 0 ? JSON.stringify(recognizerResult.intents) : undefined,
             Entities: recognizerResult.entities ? JSON.stringify(recognizerResult.entities) : undefined,
             AdditionalProperties: JSON.stringify(
-                omit(recognizerResult, ['text', 'alteredText', 'intents', 'entities'])
+                omit(recognizerResult, ['text', 'alteredText', 'intents', 'entities']),
             ),
         };
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -60,7 +60,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: Record<string, string>,
-        telemetryMetrics?: Record<string, number>
+        telemetryMetrics?: Record<string, number>,
     ): Promise<RecognizerResult> {
         if (!this.recognizers.length) {
             return {
@@ -80,11 +80,11 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
                     dialogContext,
                     activity,
                     telemetryProperties,
-                    telemetryMetrics
+                    telemetryMetrics,
                 );
                 result['id'] = recognizer.id;
                 return result;
-            })
+            }),
         );
 
         const result = this.processResults(results);
@@ -92,7 +92,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
             dialogContext,
             TelemetryLoggerConstants.CrossTrainedRecognizerSetResultEvent,
             this.fillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext),
-            telemetryMetrics
+            telemetryMetrics,
         );
         return result;
     }
@@ -162,7 +162,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
                     // filter out redirect results and return `ChooseIntent`.
                     const recognizersWithRealIntents = pickBy(
                         recognizerResults,
-                        (value) => !this.isRedirect(getTopScoringIntent(value).intent)
+                        (value) => !this.isRedirect(getTopScoringIntent(value).intent),
                     );
                     return this.createChooseIntentResult(recognizersWithRealIntents);
                 }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/channelMentionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/channelMentionEntityRecognizer.ts
@@ -29,7 +29,7 @@ export class ChannelMentionEntityRecognizer extends AdaptiveRecognizer {
         _dialogContext: DialogContext,
         activity: Partial<Activity>,
         _telemetryProperties?: Record<string, string>,
-        _telemetryMetrics?: Record<string, number>
+        _telemetryMetrics?: Record<string, number>,
     ): Promise<RecognizerResult> {
         const result: RecognizerResult = {
             text: '',

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizer.ts
@@ -28,7 +28,7 @@ export class EntityRecognizer extends AdaptiveRecognizer {
         dialogContext: DialogContext,
         activity: Partial<Activity>,
         _telemetryProperties?: Record<string, string>,
-        _telemetryMetrics?: Record<string, number>
+        _telemetryMetrics?: Record<string, number>,
     ): Promise<RecognizerResult> {
         // Identify matched intents
         const text = activity.text ?? '';
@@ -56,7 +56,7 @@ export class EntityRecognizer extends AdaptiveRecognizer {
             dialogContext,
             dialogContext.context.activity.text,
             dialogContext.context.activity.locale,
-            entityPool
+            entityPool,
         );
         entityPool.push(...newEntities);
 
@@ -109,7 +109,7 @@ export class EntityRecognizer extends AdaptiveRecognizer {
         _dialogContext: DialogContext,
         _text: string,
         _locale: string,
-        _entities: Entity[]
+        _entities: Entity[],
     ): Promise<Entity[]> {
         return [];
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/entityRecognizerSet.ts
@@ -30,7 +30,7 @@ export class EntityRecognizerSet extends Array<EntityRecognizer> {
         dialogContext: DialogContext,
         text: string,
         locale: string,
-        entities: Entity[] = []
+        entities: Entity[] = [],
     ): Promise<Entity[]> {
         const allNewEntities: Entity[] = [];
         let entitiesToProcess: Entity[] = [...entities];
@@ -53,14 +53,14 @@ export class EntityRecognizerSet extends Array<EntityRecognizer> {
                         dialogContext,
                         text,
                         locale,
-                        entitiesToProcess
+                        entitiesToProcess,
                     );
                     for (let j = 0; j < newEntities.length; j++) {
                         const newEntity = newEntities[j];
-                        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+
                         if (
                             !allNewEntities.find(
-                                (entity) => !newEntity && JSON.stringify(entity) == JSON.stringify(newEntity)
+                                (entity) => !newEntity && JSON.stringify(entity) == JSON.stringify(newEntity),
                             )
                         ) {
                             allNewEntities.push(newEntity);

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
@@ -29,17 +29,15 @@ export abstract class TextEntityRecognizer extends EntityRecognizer {
         dialogContext: DialogContext,
         text: string,
         locale: string,
-        entities: Entity[]
+        entities: Entity[],
     ): Promise<Entity[]> {
         const culture = Culture.mapToNearestLanguage(locale ?? '');
         return entities
             .filter((e: Entity): boolean => e.type == 'text')
-            .map(
-                (e: Entity): TextEntity => {
-                    const textEntity = new TextEntity();
-                    return Object.assign(textEntity, e);
-                }
-            )
+            .map((e: Entity): TextEntity => {
+                const textEntity = new TextEntity();
+                return Object.assign(textEntity, e);
+            })
             .reduce((entities: Entity[], textEntity: TextEntity) => {
                 return entities.concat(
                     this._recognize(textEntity.text, culture).map((result: ModelResult) => {
@@ -47,14 +45,14 @@ export abstract class TextEntityRecognizer extends EntityRecognizer {
                             {
                                 type: result.typeName,
                             },
-                            result
+                            result,
                         );
                         delete newEntity.typeName;
                         // The text recognizer libraries return models with End => array inclusive endIndex.
                         // We want end to be (end-start) = length, length = endIndex - startIndex.
                         newEntity.end += 1;
                         return newEntity;
-                    })
+                    }),
                 );
             }, []);
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/multiLanguageRecognizer.ts
@@ -57,7 +57,7 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: { [key: string]: string },
-        telemetryMetrics?: { [key: string]: number }
+        telemetryMetrics?: { [key: string]: number },
     ): Promise<RecognizerResult> {
         let languagepolicy: LanguagePolicy = this.languagePolicy;
         if (!languagepolicy) {
@@ -91,13 +91,13 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
                     dialogContext,
                     activity,
                     telemetryProperties,
-                    telemetryMetrics
+                    telemetryMetrics,
                 );
                 this.trackRecognizerResult(
                     dialogContext,
                     TelemetryLoggerConstants.MultiLanguageRecognizerResultEvent,
                     this.fillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext),
-                    telemetryMetrics
+                    telemetryMetrics,
                 );
                 return result;
             }
@@ -112,7 +112,7 @@ export class MultiLanguageRecognizer extends AdaptiveRecognizer implements Multi
             dialogContext,
             TelemetryLoggerConstants.MultiLanguageRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
-            telemetryMetrics
+            telemetryMetrics,
         );
 
         return recognizerResult;

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/recognizerSet.ts
@@ -50,14 +50,12 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: { [key: string]: string },
-        telemetryMetrics?: { [key: string]: number }
+        telemetryMetrics?: { [key: string]: number },
     ): Promise<RecognizerResult> {
         const results = await Promise.all(
-            this.recognizers.map(
-                (recognizer: Recognizer): Promise<RecognizerResult> => {
-                    return recognizer.recognize(dialogContext, activity, telemetryProperties, telemetryMetrics);
-                }
-            )
+            this.recognizers.map((recognizer: Recognizer): Promise<RecognizerResult> => {
+                return recognizer.recognize(dialogContext, activity, telemetryProperties, telemetryMetrics);
+            }),
         );
 
         const recognizerResult: RecognizerResult = this.mergeResults(results);
@@ -66,7 +64,7 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
             dialogContext,
             TelemetryLoggerConstants.RecognizerSetResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
-            telemetryMetrics
+            telemetryMetrics,
         );
 
         return recognizerResult;
@@ -118,9 +116,8 @@ export class RecognizerSet extends AdaptiveRecognizer implements RecognizerSetCo
                 for (const [propertyName, propertyVal] of Object.entries(result.entities)) {
                     if (propertyName === '$instance') {
                         for (const [entityName, entityValue] of Object.entries(propertyVal)) {
-                            const mergedInstanceEntities = (mergedRecognizerResult.entities['$instance'][
-                                entityName
-                            ] ??= []);
+                            const mergedInstanceEntities = (mergedRecognizerResult.entities['$instance'][entityName] ??=
+                                []);
                             mergedInstanceEntities.push(...entityValue);
                         }
                     } else {

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -75,7 +75,7 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: { [key: string]: string },
-        telemetryMetrics?: { [key: string]: number }
+        telemetryMetrics?: { [key: string]: number },
     ): Promise<RecognizerResult> {
         const text = activity.text ?? '';
         const locale = activity.locale ?? Culture.English;
@@ -176,13 +176,13 @@ export class RegexRecognizer extends AdaptiveRecognizer implements RegexRecogniz
             'RegexRecognizer',
             recognizerResult,
             'RecognizerResult',
-            'Regex RecognizerResult'
+            'Regex RecognizerResult',
         );
         this.trackRecognizerResult(
             dialogContext,
             TelemetryLoggerConstants.RegexRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
-            telemetryMetrics
+            telemetryMetrics,
         );
         return recognizerResult;
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
@@ -33,7 +33,7 @@ export class ValueRecognizer extends AdaptiveRecognizer {
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: { [key: string]: string },
-        telemetryMetrics?: { [key: string]: number }
+        telemetryMetrics?: { [key: string]: number },
     ): Promise<RecognizerResult> {
         const recognizerResult: RecognizerResult = {
             text: activity.text,
@@ -60,7 +60,7 @@ export class ValueRecognizer extends AdaptiveRecognizer {
             dialogContext,
             TelemetryLoggerConstants.ValueRecognizerResultEvent,
             this.fillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext),
-            telemetryMetrics
+            telemetryMetrics,
         );
 
         return recognizerResult;

--- a/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/skillExtensions.ts
@@ -44,7 +44,7 @@ export class SkillExtensions {
      */
     static useSkillConversationIdFactory(
         dialogManager: DialogManager,
-        skillConversationIdFactory: SkillConversationIdFactoryBase
+        skillConversationIdFactory: SkillConversationIdFactoryBase,
     ): DialogManager {
         dialogManager.initialTurnState.set(skillConversationIdFactoryKey, skillConversationIdFactory);
         return dialogManager;

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
@@ -28,7 +28,8 @@ export interface ActivityTemplateConguration {
  * and processed through registered language generator.
  */
 export class ActivityTemplate
-    implements TemplateInterface<Partial<Activity>, DialogStateManager>, ActivityTemplateConguration, Configurable {
+    implements TemplateInterface<Partial<Activity>, DialogStateManager>, ActivityTemplateConguration, Configurable
+{
     static $kind = 'Microsoft.ActivityTemplate';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
@@ -17,7 +17,8 @@ export interface StaticActivityTemplateConfiguration {
  * Defines a static activity as a template.
  */
 export class StaticActivityTemplate
-    implements TemplateInterface<Partial<Activity>, unknown>, StaticActivityTemplateConfiguration, Configurable {
+    implements TemplateInterface<Partial<Activity>, unknown>, StaticActivityTemplateConfiguration, Configurable
+{
     static $kind = 'Microsoft.StaticActivityTemplate';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
@@ -20,7 +20,8 @@ export interface TextTemplateConfiguration {
  * and processed through registered language generator.
  */
 export class TextTemplate<D = Record<string, unknown>>
-    implements TemplateInterface<string, D>, TextTemplateConfiguration, Configurable {
+    implements TemplateInterface<string, D>, TextTemplateConfiguration, Configurable
+{
     static $kind = 'Microsoft.TextTemplate';
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -49,7 +49,7 @@ describe('LGLanguageGenerator', function () {
                 assert.equal(resourceNames.length, 7);
                 assert.deepStrictEqual(
                     new Set(resourceNames),
-                    new Set(['a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg', 'root.lg', 'subDialog.lg', 'test.lg'])
+                    new Set(['a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg', 'root.lg', 'subDialog.lg', 'test.lg']),
                 );
             });
 
@@ -67,7 +67,7 @@ describe('LGLanguageGenerator', function () {
                         'NormalStructuredLG.lg',
                         'root.lg',
                         'subDialog.lg',
-                    ])
+                    ]),
                 );
             });
 
@@ -85,7 +85,7 @@ describe('LGLanguageGenerator', function () {
                         'NormalStructuredLG.lg',
                         'root.lg',
                         'subDialog.lg',
-                    ])
+                    ]),
                 );
             });
         });

--- a/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/activityFactory.test.js
@@ -38,7 +38,7 @@ describe('ActivityFactoryTest', function () {
         assert.strictEqual(result.attachments, undefined);
         assert.strictEqual(
             result.text.replace(/\r\n/g, '\n').replace(/\n/g, '').replace(/\s+/g, ''),
-            '{"lgType":"Acti","key":"value"}'
+            '{"lgType":"Acti","key":"value"}',
         );
     });
 
@@ -567,7 +567,7 @@ function assertAdaptiveCardActivity(activity) {
     assert.strictEqual(
         activity.attachments[0].contentType,
         'application/vnd.microsoft.card.adaptive',
-        'attachment type should be adaptivecard'
+        'attachment type should be adaptivecard',
     );
     assert.strictEqual(activity.attachments[0].content.body[0].text, 'test', 'text of first body should have value');
 }
@@ -603,7 +603,7 @@ function assertAnimationCardActivity(activity) {
     assert.strictEqual(card.autostart, true);
     assert.strictEqual(
         card.image.url,
-        'https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png'
+        'https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png',
     );
     assert.strictEqual(card.media[0].url, 'http://oi42.tinypic.com/1rchlx.jpg');
 }
@@ -627,7 +627,7 @@ function assertReceiptCardActivity(activity) {
     assert.strictEqual(button.value, 'https://azure.microsoft.com/en-us/pricing/');
     assert.strictEqual(
         button.image,
-        'https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png'
+        'https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png',
     );
 
     const facts = card.facts;
@@ -642,14 +642,14 @@ function assertReceiptCardActivity(activity) {
     assert.strictEqual(items[0].title, 'Data Transfer');
     assert.strictEqual(
         items[0].image.url,
-        'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png'
+        'https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png',
     );
     assert.strictEqual(items[0].price, '$ 38.45');
     assert.strictEqual(items[0].quantity, '368');
     assert.strictEqual(items[1].title, 'App Service');
     assert.strictEqual(
         items[1].image.url,
-        'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png'
+        'https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png',
     );
     assert.strictEqual(items[1].price, '$ 45.00');
     assert.strictEqual(items[1].quantity, '720');

--- a/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
@@ -174,7 +174,7 @@ function createSkillClientAndStub(captureAction, returnStatusCode = StatusCodes.
 
     if (captureAction && typeof captureAction !== 'function') {
         throw new TypeError(
-            `Failed test arrangement - createSkillClientAndStub() received ${typeof captureAction} instead of undefined or a function.`
+            `Failed test arrangement - createSkillClientAndStub() received ${typeof captureAction} instead of undefined or a function.`,
         );
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/choiceSet.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import 'mocha';
 import { ObjectExpression } from 'adaptive-expressions';
 import * as assert from 'assert';
@@ -30,7 +29,7 @@ describe('ChoiceSetTests', function () {
     it('TestValue', async function () {
         const state = {};
         const ep = new ObjectExpression<ChoiceSet>(
-            new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }])
+            new ChoiceSet([{ value: 'test1' }, { value: 'test2' }, { value: 'test3' }]),
         );
         const { value } = ep.tryGetValue(state);
         assertValues(value);

--- a/libraries/botbuilder-dialogs-adaptive/tests/conditionals.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/conditionals.test.js
@@ -79,105 +79,105 @@ describe('ConditionalsTests', function () {
     it('OnCondition with condition', function () {
         assertExpression(
             new OnActivity('event', [], 'turn.test == 1'),
-            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnAssignEntity('property', 'entity', 'operation', [], 'turn.test == 1'),
-            "(((turn.dialogEvent.name == 'assignEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.value.name == 'entity') && (turn.dialogEvent.value.operation == 'operation'))"
+            "(((turn.dialogEvent.name == 'assignEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.value.name == 'entity') && (turn.dialogEvent.value.operation == 'operation'))",
         );
         assertExpression(
             new OnBeginDialog([], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'beginDialog') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'beginDialog') && (turn.test == 1))",
         );
         assertExpression(
             new OnCancelDialog([], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'cancelDialog') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'cancelDialog') && (turn.test == 1))",
         );
         assertExpression(
             new OnChooseEntity('property', 'entity', 'Add()', [], 'turn.test == 1'),
-            "(((turn.dialogEvent.name == 'chooseEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.value.name == 'entity') && (turn.dialogEvent.value.operation == 'Add()'))"
+            "(((turn.dialogEvent.name == 'chooseEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.value.name == 'entity') && (turn.dialogEvent.value.operation == 'Add()'))",
         );
         assertExpression(
             new OnCommandActivity([], 'turn.test == 1'),
-            `((turn.activity.type == '${ActivityTypes.Command}') && ((turn.dialogEvent.name == '${AdaptiveEvents.activityReceived}') && (turn.test == 1)))`
+            `((turn.activity.type == '${ActivityTypes.Command}') && ((turn.dialogEvent.name == '${AdaptiveEvents.activityReceived}') && (turn.test == 1)))`,
         );
         assertExpression(
             new OnCommandResultActivity([], 'turn.test == 1'),
-            `((turn.activity.type == '${ActivityTypes.CommandResult}') && ((turn.dialogEvent.name == '${AdaptiveEvents.activityReceived}') && (turn.test == 1)))`
+            `((turn.activity.type == '${ActivityTypes.CommandResult}') && ((turn.dialogEvent.name == '${AdaptiveEvents.activityReceived}') && (turn.test == 1)))`,
         );
         assertExpression(new OnCondition('turn.test == 1'), '(turn.test == 1)');
         assertExpression(
             new OnContinueConversation([], 'turn.test == 1'),
-            "((turn.activity.name == 'ContinueConversation') && ((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1))))"
+            "((turn.activity.name == 'ContinueConversation') && ((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1))))",
         );
         assertExpression(
             new OnConversationUpdateActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'conversationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'conversationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnDialogEvent('DialogEvent', [], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'DialogEvent') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'DialogEvent') && (turn.test == 1))",
         );
         assertExpression(
             new OnEndOfActions([], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'endOfActions') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'endOfActions') && (turn.test == 1))",
         );
         assertExpression(
             new OnEndOfConversationActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'endOfConversation') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'endOfConversation') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(new OnError([], 'turn.test == 1'), "((turn.dialogEvent.name == 'error') && (turn.test == 1))");
         assertExpression(
             new OnEventActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnHandoffActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'handoff') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'handoff') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnInstallationUpdateActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'installationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'installationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnIntent('Intent', ['@foo', '@@bar', 'turn.recognized.entities.blat', 'gronk'], [], 'turn.test == 1'),
-            "(((turn.recognized.intent == 'Intent') && (exists(@foo) && exists(@@bar) && exists(turn.recognized.entities.blat) && exists(@gronk))) && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))"
+            "(((turn.recognized.intent == 'Intent') && (exists(@foo) && exists(@@bar) && exists(turn.recognized.entities.blat) && exists(@gronk))) && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))",
         );
         assertExpression(
             new OnInvokeActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'invoke') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'invoke') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnMessageActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'message') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'message') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnMessageDeleteActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'messageDelete') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'messageDelete') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnMessageReactionActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'messageReaction') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'messageReaction') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnMessageUpdateActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'messageUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'messageUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnQnAMatch([], 'turn.test == 1'),
-            "((turn.recognized.intent == 'QnAMatch') && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))"
+            "((turn.recognized.intent == 'QnAMatch') && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))",
         );
         assertExpression(
             new OnRepromptDialog([], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'repromptDialog') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'repromptDialog') && (turn.test == 1))",
         );
         assertExpression(
             new OnTypingActivity([], 'turn.test == 1'),
-            "((turn.activity.type == 'typing') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+            "((turn.activity.type == 'typing') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))",
         );
         assertExpression(
             new OnUnknownIntent([], 'turn.test == 1'),
-            "((turn.dialogEvent.name == 'unknownIntent') && (turn.test == 1))"
+            "((turn.dialogEvent.name == 'unknownIntent') && (turn.test == 1))",
         );
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/conversationAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/conversationAction.test.js
@@ -69,7 +69,7 @@ describe('ConversationAction', function () {
             new ContinueConversationLater().configure({
                 date: '=addSeconds(utcNow(), 2)',
                 value: 'foo',
-            })
+            }),
         );
 
         dm.initialTurnState.set(DialogTurnStateConstants.queueStorage, queueStorage);
@@ -118,7 +118,7 @@ describe('ConversationAction', function () {
                         ],
                     }),
                 ],
-            })
+            }),
         );
         dm.initialTurnState.set(DialogTurnStateConstants.queueStorage, queueStorage);
         const adapter = new TestAdapter((turnContext) => {
@@ -176,7 +176,7 @@ describe('ConversationAction', function () {
                         ],
                     }),
                 ],
-            })
+            }),
         );
         dm.initialTurnState.set(DialogTurnStateConstants.queueStorage, queueStorage);
         const adapter = new TestAdapter((turnContext) => {

--- a/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizer.test.js
@@ -40,7 +40,7 @@ const getDialogContext = (testName, text, locale = 'en-us') => {
             from: bot,
             locale,
         }),
-        {}
+        {},
     );
 };
 
@@ -69,7 +69,7 @@ describe('EntityRecognizer Tests', function () {
         new RegexEntityRecognizer().configure({
             name: 'size',
             pattern: '(?i)(small|medium|large)',
-        })
+        }),
     );
 
     it('test age', async function () {

--- a/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizerRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/entityRecognizerRecognizer.test.js
@@ -44,7 +44,7 @@ const getDialogContext = (testName, text, locale = 'en-us') => {
             from: bot,
             locale,
         }),
-        {}
+        {},
     );
 };
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/expressionProperty.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive/tests/expressionProperty.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import * as assert from 'assert';
 import { DialogExpression, AdaptiveDialog } from '../';
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/languageGeneratorConverter.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/languageGeneratorConverter.test.js
@@ -8,7 +8,7 @@ describe('LanguageGeneratorConverter', function () {
         const newGenerator = converter.convert('');
         ok(
             newGenerator instanceof ResourceMultiLanguageGenerator,
-            'expected newGenerator to be instance of ResourceMultiLanguageGenerator'
+            'expected newGenerator to be instance of ResourceMultiLanguageGenerator',
         );
     });
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/memory_memoryScopes.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/memory_memoryScopes.test.js
@@ -28,7 +28,7 @@ describe('Memory - Memory Scopes', function () {
                 new SendActivity("${contains(dialogcontext.stack, 'foo')}"),
                 new SendActivity("${contains(dialogcontext.stack, 'adaptiveDialog')}"),
                 new SendActivity("${contains(dialogcontext.stack, 'adaptiveDialog2')}"),
-            ])
+            ]),
         );
 
         const storage = new MemoryStorage();
@@ -67,15 +67,15 @@ describe('Memory - Memory Scopes', function () {
                     id: 'askForName',
                 }),
                 new SendActivity('I have ${user.name}'),
-            ])
+            ]),
         );
         root.triggers.push(
             new OnIntent(
                 'why',
                 [],
                 [new SendActivity('I need your name to complete the sample')],
-                "contains(dialogcontext.stack, 'askForName')"
-            )
+                "contains(dialogcontext.stack, 'askForName')",
+            ),
         );
         root.triggers.push(new OnIntent('why', [], [new SendActivity('why what?')]));
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const assert = require('assert');
 const { Recognizer } = require('botbuilder-dialogs');
 const {
@@ -59,7 +58,7 @@ describe('RegexRecognizer Tests', function () {
             new UrlEntityRecognizer(),
             new RegexEntityRecognizer('color', '(red|green|blue|purple|orange|violet|white|black)'),
             new RegexEntityRecognizer('backgroundColor', '(back|background) {color}'),
-            new RegexEntityRecognizer('foregroundColor', '(foreground|front) {color}')
+            new RegexEntityRecognizer('foregroundColor', '(foreground|front) {color}'),
         ),
     });
 
@@ -177,7 +176,7 @@ describe('RegexRecognizer Tests', function () {
                     new OrdinalEntityRecognizer(),
                     new RegexEntityRecognizer('color', '(red|green|blue|purple|orange|violet|white|black)'),
                     new RegexEntityRecognizer('backgroundColor', '(back|background) {color}'),
-                    new RegexEntityRecognizer('foregroundColor', '(foreground|front) {color}')
+                    new RegexEntityRecognizer('foregroundColor', '(foreground|front) {color}'),
                 ),
             });
             const trackEventSpy = spyOnTelemetryClientTrackEvent(recognizerWithDefaultLogPii);
@@ -263,7 +262,7 @@ describe('RegexRecognizer Tests', function () {
     it('recognize dimension', async function () {
         const dc = createContext('');
         const activity = createMessageActivity(
-            'The six-mile trip to my airport hotel that had taken 20 minutes earlier in the day took more than three hours.'
+            'The six-mile trip to my airport hotel that had taken 20 minutes earlier in the day took more than three hours.',
         );
         const result = await recognizer.recognize(dc, activity);
         const entities = result.entities;
@@ -450,7 +449,7 @@ describe('RegexRecognizer Tests', function () {
         };
         const properties = recognizer.fillRecognizerResultTelemetryProperties(
             recognizerResultSample,
-            telemetryProperties
+            telemetryProperties,
         );
         assert('Text' in properties);
         assert.strictEqual(properties['Text'], recognizerResultSample['text']);

--- a/libraries/botbuilder-dialogs-adaptive/tests/telemetryUtils.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/telemetryUtils.js
@@ -9,7 +9,7 @@ const { NullTelemetryClient } = require('botbuilder');
 function createTelemetryClientAndStub(captureTelemetryAction) {
     if (captureTelemetryAction && typeof captureTelemetryAction !== 'function') {
         throw new TypeError(
-            `Failed test arrangement - createtelemetryClientAndStub() received ${typeof captureTelemetryAction} instead of undefined or a function.`
+            `Failed test arrangement - createtelemetryClientAndStub() received ${typeof captureTelemetryAction} instead of undefined or a function.`,
         );
     }
 


### PR DESCRIPTION
Addresses # 4684
#minor

## Description
This PR fixes all the new ESLint errors and warnings that appeared after the ESLint packages' upgrade in the botbuilder-dialogs-adaptive project.

## Specific Changes
  - Removed 'only-warn' plugin from 'botbuilder-dialogs-adaptive/eslint.config.cjs' and its dependency.
  - All updated TS and JS files were due to prettier, mocha and jsdoc new rules.

## Testing
The following image shows that there are no more ESLint issues.
![image](https://github.com/user-attachments/assets/89d6889d-2025-4760-af40-773d94aa4475)
