### PR TITLE
Fix ESLint in botframework-connector

### DIFF
--- a/libraries/botframework-connector/eslint.config.cjs
+++ b/libraries/botframework-connector/eslint.config.cjs
@@ -1,14 +1,8 @@
-const onlyWarn = require("eslint-plugin-only-warn");
-const sharedConfig = require("../../eslint.config.cjs")
+const sharedConfig = require('../../eslint.config.cjs');
 
 module.exports = [
     ...sharedConfig,
     {
-        ignores: ["src/connectorApi/**/*", "src/tokenApi/**/*", "**/*.nock.js"],
-
+        ignores: ['src/connectorApi/**/*', 'src/tokenApi/**/*', '**/*.nock.js'],
     },
-    {
-        plugins: {
-            "only-warn": onlyWarn,
-        },
-    }]
+];

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -38,7 +38,6 @@
     "buffer": "^6.0.3",
     "cross-fetch": "^4.0.0",
     "crypto-browserify": "^3.12.0",
-    "eslint-plugin-only-warn": "^1.1.0",
     "https-browserify": "^1.0.0",
     "https-proxy-agent": "^7.0.5",
     "jsonwebtoken": "^9.0.2",

--- a/libraries/botframework-connector/src/auth/allowedCallersClaimsValidator.ts
+++ b/libraries/botframework-connector/src/auth/allowedCallersClaimsValidator.ts
@@ -23,7 +23,7 @@ export function allowedCallersClaimsValidator(allowedCallers: string[]): Validat
             const appId = JwtTokenValidation.getAppIdFromClaims(claims);
             if (!allowed.has(appId)) {
                 throw new Error(
-                    `Received a request from an application with an appID of "${appId}". To enable requests from this skill, add the skill to your configuration file.`
+                    `Received a request from an application with an appID of "${appId}". To enable requests from this skill, add the skill to your configuration file.`,
                 );
             }
         }

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -43,8 +43,8 @@ export abstract class AppCredentials implements ServiceClientCredentials {
      *
      * @param appId The App ID.
      * @param channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param oAuthScope The scope for the token.

--- a/libraries/botframework-connector/src/auth/aseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/aseChannelValidation.ts
@@ -12,11 +12,11 @@ import { ClaimsIdentity } from './claimsIdentity';
 import { AuthenticationConstants } from './authenticationConstants';
 import { AuthenticationConfiguration } from './authenticationConfiguration';
 import { GovernmentConstants } from './governmentConstants';
-import { ICredentialProvider } from './credentialProvider';
+import { ICredentialProvider, SimpleCredentialProvider } from './credentialProvider';
 import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { JwtTokenValidation } from './jwtTokenValidation';
 import { AuthenticationError } from './authenticationError';
-import { SimpleCredentialProvider } from './credentialProvider';
+
 import { StatusCodes } from 'botframework-schema';
 import { BetweenBotAndAseChannelTokenValidationParameters } from './tokenValidationParameters';
 
@@ -80,18 +80,18 @@ export namespace AseChannelValidation {
      */
     export async function authenticateAseChannelToken(
         authHeader: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             BetweenBotAndAseChannelTokenValidationParameters,
             MetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             ChannelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -111,7 +111,7 @@ export namespace AseChannelValidation {
         if (versionClaim === null) {
             throw new AuthenticationError(
                 'Unauthorized. "ver" claim is required on Emulator Tokens.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -127,7 +127,7 @@ export namespace AseChannelValidation {
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -139,7 +139,7 @@ export namespace AseChannelValidation {
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -148,14 +148,14 @@ export namespace AseChannelValidation {
             // Unknown Version. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
         if (!(await _creadentialProvider.isValidAppId(appId))) {
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${appId}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/authenticationConfiguration.ts
+++ b/libraries/botframework-connector/src/auth/authenticationConfiguration.ts
@@ -28,6 +28,6 @@ export class AuthenticationConfiguration {
     constructor(
         public requiredEndorsements: string[] = [],
         public validateClaims?: ValidateClaims,
-        public validTokenIssuers?: string[]
+        public validTokenIssuers?: string[],
     ) {}
 }

--- a/libraries/botframework-connector/src/auth/authenticationError.ts
+++ b/libraries/botframework-connector/src/auth/authenticationError.ts
@@ -17,7 +17,10 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * @param message The Error message.
      * @param statusCode The `StatusCode` number to use.
      */
-    constructor(message: string, public readonly statusCode: StatusCode) {
+    constructor(
+        message: string,
+        readonly statusCode: StatusCode,
+    ) {
         super(message);
     }
 
@@ -27,7 +30,6 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * @param err The error to validate.
      * @returns If `err` is an [IStatusCodeError](xref:botframework-schema.IStatusCodeError), the result is true; otherwise false.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     static isStatusCodeError(err: any): err is IStatusCodeError {
         return !!(err && typeof err.statusCode === 'number');
     }
@@ -38,7 +40,6 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * @param err The error thrown, used to determine an appropriate status code.
      * @returns The error message to be sent as a response.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     static determineStatusCodeAndBuildMessage(err: any): string {
         const errMessage: string = err && err.message ? err.message : 'Internal Server Error';
         const code: number = AuthenticationError.determineStatusCode(errMessage);

--- a/libraries/botframework-connector/src/auth/botFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkAuthentication.ts
@@ -33,7 +33,7 @@ export abstract class BotFrameworkAuthentication {
      */
     abstract authenticateStreamingRequest(
         authHeader: string,
-        channelIdHeader: string
+        channelIdHeader: string,
     ): Promise<AuthenticateRequestResult>;
 
     /**
@@ -96,7 +96,7 @@ export abstract class BotFrameworkAuthentication {
     protected async generateCallerId(
         credentialFactory: ServiceClientCredentialsFactory,
         claimsIdentity: ClaimsIdentity,
-        callerId: string
+        callerId: string,
     ): Promise<string | null> {
         // Is the bot accepting all incoming messages?
         if (await credentialFactory.isAuthenticationDisabled()) {

--- a/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
@@ -52,7 +52,7 @@ export class BotFrameworkAuthenticationFactory {
         credentialFactory: ServiceClientCredentialsFactory,
         authConfiguration: AuthenticationConfiguration,
         botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-        connectorClientOptions?: ConnectorClientOptions
+        connectorClientOptions?: ConnectorClientOptions,
     ): BotFrameworkAuthentication;
 
     /**
@@ -84,7 +84,7 @@ export class BotFrameworkAuthenticationFactory {
         maybeCredentialFactory?: ServiceClientCredentialsFactory,
         maybeAuthConfiguration?: AuthenticationConfiguration,
         maybeBotFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-        maybeConnectorClientOptions: ConnectorClientOptions = {}
+        maybeConnectorClientOptions: ConnectorClientOptions = {},
     ): BotFrameworkAuthentication {
         if (
             !stringExt.isNilOrEmpty(maybeToChannelFromBotLoginUrl) ||
@@ -108,7 +108,7 @@ export class BotFrameworkAuthenticationFactory {
                 maybeCredentialFactory,
                 maybeAuthConfiguration,
                 maybeBotFrameworkClientFetch,
-                maybeConnectorClientOptions
+                maybeConnectorClientOptions,
             );
         } else {
             // else apply the built in default behavior, which is either the public cloud or the gov cloud depending on whether we have a channelService value present
@@ -125,7 +125,7 @@ export class BotFrameworkAuthenticationFactory {
                     maybeCredentialFactory,
                     maybeAuthConfiguration,
                     maybeBotFrameworkClientFetch,
-                    maybeConnectorClientOptions
+                    maybeConnectorClientOptions,
                 );
             } else if (maybeChannelService === GovernmentConstants.ChannelService) {
                 return new ParameterizedBotFrameworkAuthentication(
@@ -140,7 +140,7 @@ export class BotFrameworkAuthenticationFactory {
                     maybeCredentialFactory,
                     maybeAuthConfiguration,
                     maybeBotFrameworkClientFetch,
-                    maybeConnectorClientOptions
+                    maybeConnectorClientOptions,
                 );
             } else {
                 // The ChannelService value is used an indicator of which built in set of constants to use. If it is not recognized, a full configuration is expected.

--- a/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
@@ -52,7 +52,7 @@ export class BotFrameworkClientImpl implements BotFrameworkClient {
         private readonly credentialsFactory: ServiceClientCredentialsFactory,
         private readonly loginEndpoint: string,
         private readonly botFrameworkClientFetch?: ReturnType<typeof botFrameworkClientFetchImpl>,
-        private readonly connectorClientOptions?: ConnectorClientOptions
+        private readonly connectorClientOptions?: ConnectorClientOptions,
     ) {
         this.botFrameworkClientFetch ??= botFrameworkClientFetchImpl(this.connectorClientOptions);
 
@@ -82,7 +82,7 @@ export class BotFrameworkClientImpl implements BotFrameworkClient {
         toUrl: string,
         serviceUrl: string,
         conversationId: string,
-        activity: Activity
+        activity: Activity,
     ): Promise<InvokeResponse<T>> {
         z.object({
             fromBotId: z.string().optional(),
@@ -104,7 +104,7 @@ export class BotFrameworkClientImpl implements BotFrameworkClient {
             fromBotId,
             toBotId,
             this.loginEndpoint,
-            true
+            true,
         );
 
         // Capture current activity settings before changing them.

--- a/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
@@ -28,8 +28,8 @@ export class CertificateAppCredentials extends AppCredentials {
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.
      * @param channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param oAuthScope Optional. The scope for the token.
@@ -42,7 +42,7 @@ export class CertificateAppCredentials extends AppCredentials {
         certificatePrivateKey: string,
         channelAuthTenant?: string,
         oAuthScope?: string,
-        x5c?: string
+        x5c?: string,
     ) {
         super(appId, channelAuthTenant, oAuthScope);
         this.certificateThumbprint = certificateThumbprint;
@@ -58,7 +58,7 @@ export class CertificateAppCredentials extends AppCredentials {
             this.createClientApplication(),
             this.appId,
             this.oAuthEndpoint,
-            this.oAuthScope
+            this.oAuthScope,
         );
         return this.credentials.getToken(forceRefresh);
     }

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -31,8 +31,8 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.
      * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param x5c Optional. Enables application developers to achieve easy certificates roll-over in Azure AD:
@@ -43,7 +43,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
         certificateThumbprint: string,
         certificatePrivateKey: string,
         tenantId?: string,
-        x5c?: string
+        x5c?: string,
     );
 
     /**
@@ -54,8 +54,8 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
      * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
      * @param certificatePrivateKey A PEM encoded certificate private key.
      * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      */
@@ -69,14 +69,14 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
         certificateThumbprintOrx5c: string,
         certificatePrivateKey: string,
         tenantId?: string,
-        x5c?: string
+        x5c?: string,
     ) {
         super();
 
         ok(appId?.trim(), 'CertificateServiceClientCredentialsFactory.constructor(): missing appId.');
         ok(
             certificatePrivateKey?.trim(),
-            'CertificateServiceClientCredentialsFactory.constructor(): missing certificatePrivateKey.'
+            'CertificateServiceClientCredentialsFactory.constructor(): missing certificatePrivateKey.',
         );
 
         if (certificateThumbprintOrx5c?.includes('-----BEGIN CERTIFICATE-----')) {
@@ -84,7 +84,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
         } else {
             ok(
                 certificateThumbprintOrx5c?.trim(),
-                'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint or x5c value.'
+                'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint or x5c value.',
             );
             this.certificateThumbprint = certificateThumbprintOrx5c;
             this.x5c = x5c;
@@ -128,7 +128,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
     async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
         ok(
             await this.isValidAppId(appId),
-            'CertificateServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.'
+            'CertificateServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.',
         );
 
         return new CertificateAppCredentials(
@@ -137,7 +137,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
             this.certificatePrivateKey,
             this.tenantId,
             audience,
-            this.x5c
+            this.x5c,
         );
     }
 }

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -48,7 +48,7 @@ export namespace ChannelValidation {
         credentials: ICredentialProvider,
         serviceUrl: string,
         channelId: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const identity: ClaimsIdentity = await authenticateChannelToken(authHeader, credentials, channelId, authConfig);
 
@@ -75,18 +75,18 @@ export namespace ChannelValidation {
         authHeader: string,
         credentials: ICredentialProvider,
         channelId: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromChannelTokenValidationParameters,
             OpenIdMetadataEndpoint ? OpenIdMetadataEndpoint : AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
 
         return await validateIdentity(identity, credentials);
@@ -101,7 +101,7 @@ export namespace ChannelValidation {
      */
     export async function validateIdentity(
         identity: ClaimsIdentity,
-        credentials: ICredentialProvider
+        credentials: ICredentialProvider,
     ): Promise<ClaimsIdentity> {
         if (!identity || !identity.isAuthenticated) {
             // The token is in some way invalid. Not Authorized.
@@ -129,7 +129,7 @@ export namespace ChannelValidation {
             // The AppId is not valid or not present. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${audClaim}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/claimsIdentity.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentity.ts
@@ -24,7 +24,10 @@ export class ClaimsIdentity {
      * @param {Claim[]} claims An array of [Claim](xref:botframework-connector.Claim).
      * @param {string | boolean} authenticationType The type of auth for this set of claims, or boolean to override isAuthenticated
      */
-    constructor(public readonly claims: Claim[], private readonly authenticationType?: string | boolean) {}
+    constructor(
+        readonly claims: Claim[],
+        private readonly authenticationType?: string | boolean,
+    ) {}
 
     /**
      * Returns authentication status.

--- a/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
+++ b/libraries/botframework-connector/src/auth/connectorFactoryImpl.ts
@@ -7,7 +7,7 @@ import { ConnectorClientOptions } from '../connectorApi/models';
 import { ConnectorFactory } from './connectorFactory';
 import type { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageInfo: Record<'name' | 'version', string> = require('../../package.json');
 export const USER_AGENT = `Microsoft-BotFramework/3.1 ${packageInfo.name}/${
     packageInfo.version
@@ -32,7 +32,7 @@ export class ConnectorFactoryImpl extends ConnectorFactory {
         private readonly loginEndpoint: string,
         private readonly validateAuthority: boolean,
         private readonly credentialFactory: ServiceClientCredentialsFactory,
-        private readonly connectorClientOptions: ConnectorClientOptions = {}
+        private readonly connectorClientOptions: ConnectorClientOptions = {},
     ) {
         super();
     }
@@ -48,7 +48,7 @@ export class ConnectorFactoryImpl extends ConnectorFactory {
             this.appId,
             audience ?? this.toChannelFromBotOAuthScope,
             this.loginEndpoint,
-            this.validateAuthority
+            this.validateAuthority,
         );
 
         // A new connector client for making calls against this serviceUrl using credentials derived from the current appId and the specified audience.

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -62,7 +62,7 @@ export namespace EmulatorValidation {
         }
 
         // Parse the Big Long String into an actual token.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         const token: any = decode(bearerToken, { complete: true });
         if (!token) {
             return false;
@@ -121,7 +121,7 @@ export namespace EmulatorValidation {
         credentials: ICredentialProvider,
         channelService: string,
         channelId: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const openIdMetadataUrl =
             channelService !== undefined && JwtTokenValidation.isGovernment(channelService)
@@ -131,13 +131,13 @@ export namespace EmulatorValidation {
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromEmulatorTokenValidationParameters,
             openIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -157,7 +157,7 @@ export namespace EmulatorValidation {
         if (versionClaim === null) {
             throw new AuthenticationError(
                 'Unauthorized. "ver" claim is required on Emulator Tokens.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -173,7 +173,7 @@ export namespace EmulatorValidation {
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -185,7 +185,7 @@ export namespace EmulatorValidation {
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -194,14 +194,14 @@ export namespace EmulatorValidation {
             // Unknown Version. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
         if (!(await credentials.isValidAppId(appId))) {
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${appId}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
@@ -47,13 +47,13 @@ export namespace EnterpriseChannelValidation {
         credentials: ICredentialProvider,
         serviceUrl: string,
         channelId: string,
-        channelService: string
+        channelService: string,
     ): Promise<ClaimsIdentity> {
         const identity: ClaimsIdentity = await authenticateChannelToken(
             authHeader,
             credentials,
             channelId,
-            channelService
+            channelService,
         );
 
         const serviceUrlClaim: string = identity.getClaimValue(AuthenticationConstants.ServiceUrlClaim);
@@ -81,7 +81,7 @@ export namespace EnterpriseChannelValidation {
         credentials: ICredentialProvider,
         channelId: string,
         channelService: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromEnterpriseChannelTokenValidationParameters,
@@ -89,15 +89,15 @@ export namespace EnterpriseChannelValidation {
                 ? ChannelValidation.OpenIdMetadataEndpoint
                 : AuthenticationConstants.ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat.replace(
                       '{channelService}',
-                      channelService
+                      channelService,
                   ),
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
 
         return await validateIdentity(identity, credentials);
@@ -112,7 +112,7 @@ export namespace EnterpriseChannelValidation {
      */
     export async function validateIdentity(
         identity: ClaimsIdentity,
-        credentials: ICredentialProvider
+        credentials: ICredentialProvider,
     ): Promise<ClaimsIdentity> {
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -145,7 +145,7 @@ export namespace EnterpriseChannelValidation {
             // The AppId is not valid or not present. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${audClaim}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/federatedAppCredentials.ts
@@ -26,8 +26,8 @@ export class FederatedAppCredentials extends AppCredentials {
      * @param {string} appId App ID for the Application.
      * @param {string} clientId Client ID for the managed identity assigned to the bot.
      * @param {string} channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
-     *   * **Required** for SingleTenant app types.
-     *   * **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   **Required** for SingleTenant app types.
+     *   **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param {string} oAuthScope **Optional**. The scope for the token.
@@ -38,7 +38,7 @@ export class FederatedAppCredentials extends AppCredentials {
         clientId: string,
         channelAuthTenant?: string,
         oAuthScope?: string,
-        clientAudience?: string
+        clientAudience?: string,
     ) {
         super(appId, channelAuthTenant, oAuthScope);
 
@@ -58,7 +58,7 @@ export class FederatedAppCredentials extends AppCredentials {
             this.createClientApplication(await this.fetchExternalToken(forceRefresh)),
             this.oAuthEndpoint,
             this.oAuthEndpoint,
-            this.oAuthScope
+            this.oAuthScope,
         );
         return this.credentials.getToken(forceRefresh);
     }

--- a/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/federatedServiceClientCredentialsFactory.ts
@@ -19,8 +19,8 @@ export class FederatedServiceClientCredentialsFactory extends ServiceClientCrede
      * @param {string} appId App ID for the Application.
      * @param {string} clientId Client ID for the managed identity assigned to the bot.
      * @param {string} tenantId Tenant ID of the Azure AD tenant where the bot is created.
-     *   * **Required** for SingleTenant app types.
-     *   * **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   **Required** for SingleTenant app types.
+     *   **Optional** for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param {string} clientAudience **Optional**. The Audience used in the Client's Federated Credential. **Default** (_api://AzureADTokenExchange_).
@@ -29,7 +29,7 @@ export class FederatedServiceClientCredentialsFactory extends ServiceClientCrede
         private appId: string,
         private clientId: string,
         private tenantId?: string,
-        private clientAudience?: string
+        private clientAudience?: string,
     ) {
         super();
 
@@ -58,7 +58,7 @@ export class FederatedServiceClientCredentialsFactory extends ServiceClientCrede
     async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
         ok(
             await this.isValidAppId(appId),
-            'FederatedServiceClientCredentialsFactory.createCredentials(): Invalid App ID.'
+            'FederatedServiceClientCredentialsFactory.createCredentials(): Invalid App ID.',
         );
 
         return new FederatedAppCredentials(this.appId, this.clientId, this.tenantId, audience, this.clientAudience);

--- a/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
@@ -48,7 +48,7 @@ export namespace GovernmentChannelValidation {
         authHeader: string,
         credentials: ICredentialProvider,
         serviceUrl: string,
-        channelId: string
+        channelId: string,
     ): Promise<ClaimsIdentity> {
         const identity: ClaimsIdentity = await authenticateChannelToken(authHeader, credentials, channelId);
 
@@ -75,18 +75,18 @@ export namespace GovernmentChannelValidation {
         authHeader: string,
         credentials: ICredentialProvider,
         channelId: string,
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromGovernmentChannelTokenValidationParameters,
             OpenIdMetadataEndpoint ? OpenIdMetadataEndpoint : GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
 
         return await validateIdentity(identity, credentials);
@@ -101,7 +101,7 @@ export namespace GovernmentChannelValidation {
      */
     export async function validateIdentity(
         identity: ClaimsIdentity,
-        credentials: ICredentialProvider
+        credentials: ICredentialProvider,
     ): Promise<ClaimsIdentity> {
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -134,7 +134,7 @@ export namespace GovernmentChannelValidation {
             // The AppId is not valid or not present. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${audClaim}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -39,7 +39,7 @@ export class JwtTokenExtractor {
         tokenValidationParameters: VerifyOptions,
         metadataUrl: string,
         allowedSigningAlgorithms: string[] | Algorithm[],
-        proxySettings?: ProxySettings
+        proxySettings?: ProxySettings,
     ) {
         this.tokenValidationParameters = { ...tokenValidationParameters };
         this.tokenValidationParameters.algorithms = allowedSigningAlgorithms as Algorithm[];
@@ -67,7 +67,7 @@ export class JwtTokenExtractor {
     async getIdentityFromAuthHeader(
         authorizationHeader: string,
         channelId: string,
-        requiredEndorsements?: string[]
+        requiredEndorsements?: string[],
     ): Promise<ClaimsIdentity | null> {
         if (!authorizationHeader) {
             return null;
@@ -94,7 +94,7 @@ export class JwtTokenExtractor {
         scheme: string,
         parameter: string,
         channelId: string,
-        requiredEndorsements: string[] = []
+        requiredEndorsements: string[] = [],
     ): Promise<ClaimsIdentity | null> {
         // No header in correct scheme or no token
         if (scheme !== 'Bearer' || !parameter) {
@@ -139,7 +139,7 @@ export class JwtTokenExtractor {
     private async validateToken(
         jwtToken: string,
         channelId: string,
-        requiredEndorsements: string[]
+        requiredEndorsements: string[],
     ): Promise<ClaimsIdentity> {
         let header: Partial<JwtHeader> = {};
         const decodedToken = decode(jwtToken, { complete: true });
@@ -169,21 +169,21 @@ export class JwtTokenExtractor {
                 if (!isEndorsed) {
                     throw new AuthenticationError(
                         `Could not validate endorsement for key: ${keyId} with endorsements: ${endorsements.join(',')}`,
-                        StatusCodes.UNAUTHORIZED
+                        StatusCodes.UNAUTHORIZED,
                     );
                 }
 
                 // Verify that additional endorsements are satisfied. If no additional endorsements are expected, the requirement is satisfied as well
                 const additionalEndorsementsSatisfied = requiredEndorsements.every((endorsement) =>
-                    EndorsementsValidator.validate(endorsement, endorsements)
+                    EndorsementsValidator.validate(endorsement, endorsements),
                 );
 
                 if (!additionalEndorsementsSatisfied) {
                     throw new AuthenticationError(
                         `Could not validate additional endorsement for key: ${keyId} with endorsements: ${requiredEndorsements.join(
-                            ','
+                            ',',
                         )}. Expected endorsements: ${requiredEndorsements.join(',')}`,
-                        StatusCodes.UNAUTHORIZED
+                        StatusCodes.UNAUTHORIZED,
                     );
                 }
             }
@@ -192,7 +192,7 @@ export class JwtTokenExtractor {
                 if (this.tokenValidationParameters.algorithms.indexOf(header.alg as Algorithm) === -1) {
                     throw new AuthenticationError(
                         `"Token signing algorithm '${header.alg}' not in allowed list`,
-                        StatusCodes.UNAUTHORIZED
+                        StatusCodes.UNAUTHORIZED,
                     );
                 }
             }

--- a/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
@@ -41,7 +41,7 @@ export namespace JwtTokenValidation {
         authHeader: string,
         credentials: ICredentialProvider,
         channelService: string,
-        authConfig?: AuthenticationConfiguration
+        authConfig?: AuthenticationConfiguration,
     ): Promise<ClaimsIdentity> {
         if (!authConfig) {
             authConfig = new AuthenticationConfiguration();
@@ -53,7 +53,7 @@ export namespace JwtTokenValidation {
             if (!isAuthDisabled) {
                 throw new AuthenticationError(
                     'Unauthorized Access. Request is not authorized',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -78,7 +78,7 @@ export namespace JwtTokenValidation {
             channelService,
             activity.channelId,
             activity.serviceUrl,
-            authConfig
+            authConfig,
         );
 
         return claimsIdentity;
@@ -101,7 +101,7 @@ export namespace JwtTokenValidation {
         channelService: string,
         channelId: string,
         serviceUrl = '',
-        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
+        authConfig: AuthenticationConfiguration = new AuthenticationConfiguration(),
     ): Promise<ClaimsIdentity> {
         if (!authHeader.trim()) {
             throw new AuthenticationError("'authHeader' required.", StatusCodes.BAD_REQUEST);
@@ -113,7 +113,7 @@ export namespace JwtTokenValidation {
             channelService,
             channelId,
             authConfig,
-            serviceUrl
+            serviceUrl,
         );
 
         await validateClaims(authConfig, identity.claims);
@@ -121,14 +121,13 @@ export namespace JwtTokenValidation {
         return identity;
     }
 
-    // eslint-disable-next-line jsdoc/require-jsdoc, no-inner-declarations
     async function authenticateToken(
         authHeader: string,
         credentials: ICredentialProvider,
         channelService: string,
         channelId: string,
         authConfig: AuthenticationConfiguration,
-        serviceUrl: string
+        serviceUrl: string,
     ): Promise<ClaimsIdentity> {
         if (AseChannelValidation.isTokenFromAseChannel(channelId)) {
             return AseChannelValidation.authenticateAseChannelToken(authHeader);
@@ -140,7 +139,7 @@ export namespace JwtTokenValidation {
                 credentials,
                 channelService,
                 channelId,
-                authConfig
+                authConfig,
             );
         }
 
@@ -149,7 +148,7 @@ export namespace JwtTokenValidation {
                 authHeader,
                 credentials,
                 channelService,
-                channelId
+                channelId,
             );
         }
 
@@ -160,7 +159,7 @@ export namespace JwtTokenValidation {
                     authHeader,
                     credentials,
                     serviceUrl,
-                    channelId
+                    channelId,
                 );
             }
 
@@ -174,7 +173,7 @@ export namespace JwtTokenValidation {
                     authHeader,
                     credentials,
                     serviceUrl,
-                    channelId
+                    channelId,
                 );
             }
 
@@ -189,7 +188,7 @@ export namespace JwtTokenValidation {
                 credentials,
                 serviceUrl,
                 channelId,
-                channelService
+                channelService,
             );
         }
 
@@ -197,7 +196,7 @@ export namespace JwtTokenValidation {
             authHeader,
             credentials,
             channelId,
-            channelService
+            channelService,
         );
     }
 
@@ -207,7 +206,7 @@ export namespace JwtTokenValidation {
      * @param authConfig The authentication configuration.
      * @param claims The list of claims to validate.
      */
-    // eslint-disable-next-line no-inner-declarations
+
     async function validateClaims(authConfig: AuthenticationConfiguration, claims: Claim[] = []): Promise<void> {
         if (authConfig.validateClaims) {
             // Call the validation method if defined (it should throw an exception if the validation fails)
@@ -216,7 +215,7 @@ export namespace JwtTokenValidation {
             // Skill claims must be validated using AuthenticationConfiguration validateClaims
             throw new AuthenticationError(
                 'Unauthorized Access. Request is not authorized. Skill Claims require validation.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
     }
@@ -267,7 +266,6 @@ export namespace JwtTokenValidation {
         return appId;
     }
 
-    // eslint-disable-next-line jsdoc/require-jsdoc, no-inner-declarations
     function isPublicAzure(channelService: string): boolean {
         return !channelService || channelService.length === 0;
     }

--- a/libraries/botframework-connector/src/auth/managedIdentityServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/managedIdentityServiceClientCredentialsFactory.ts
@@ -30,7 +30,7 @@ export class ManagedIdentityServiceClientCredentialsFactory extends ServiceClien
         ok(appId?.trim(), 'ManagedIdentityServiceClientCredentialsFactory.constructor(): missing appId.');
         ok(
             tokenProviderFactory,
-            'ManagedIdentityServiceClientCredentialsFactory.constructor(): missing tokenProviderFactory.'
+            'ManagedIdentityServiceClientCredentialsFactory.constructor(): missing tokenProviderFactory.',
         );
 
         this.appId = appId;
@@ -58,7 +58,7 @@ export class ManagedIdentityServiceClientCredentialsFactory extends ServiceClien
     async createCredentials(appId: string, audience: string): Promise<ServiceClientCredentials> {
         ok(
             await this.isValidAppId(appId),
-            'ManagedIdentityServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.'
+            'ManagedIdentityServiceClientCredentialsFactory.createCredentials(): Invalid Managed ID.',
         );
 
         return new ManagedIdentityAppCredentials(this.appId, audience, this.tokenProviderFactory);

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -27,13 +27,18 @@ export class MicrosoftAppCredentials extends AppCredentials {
      * @param {string} appId The Microsoft app ID.
      * @param {string} appPassword The Microsoft app password.
      * @param {string} channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param {string} oAuthScope Optional. The scope for the token.
      */
-    constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {
+    constructor(
+        appId: string,
+        public appPassword: string,
+        channelAuthTenant?: string,
+        oAuthScope?: string,
+    ) {
         super(appId, channelAuthTenant, oAuthScope);
     }
 

--- a/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
@@ -21,7 +21,12 @@ export class MicrosoftGovernmentAppCredentials extends MicrosoftAppCredentials {
      * @param {string} channelAuthTenant Optional. The oauth token tenant.
      * @param {string} oAuthScope Optional. The scope for the token.
      */
-    constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {
+    constructor(
+        appId: string,
+        public appPassword: string,
+        channelAuthTenant?: string,
+        oAuthScope?: string,
+    ) {
         super(appId, appPassword, channelAuthTenant, oAuthScope);
     }
 

--- a/libraries/botframework-connector/src/auth/msalAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/msalAppCredentials.ts
@@ -64,14 +64,14 @@ export class MsalAppCredentials extends AppCredentials {
         maybeClientApplicationOrAppId?: ConfidentialClientApplication | string,
         maybeAppIdOrAppPasswordOrCertificate?: string | Certificate,
         maybeAuthority?: string,
-        maybeScope?: string
+        maybeScope?: string,
     ) {
         const appId =
             typeof maybeClientApplicationOrAppId === 'string'
                 ? maybeClientApplicationOrAppId
                 : typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
-                ? maybeAppIdOrAppPasswordOrCertificate
-                : undefined;
+                  ? maybeAppIdOrAppPasswordOrCertificate
+                  : undefined;
 
         super(appId, undefined, maybeScope);
 

--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -24,7 +24,10 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
      * @param appId App ID for validation.
      * @param clientApplication An `@azure/msal-node` `ConfidentialClientApplication` instance.
      */
-    constructor(appId: string, private readonly clientApplication: ConfidentialClientApplication) {
+    constructor(
+        appId: string,
+        private readonly clientApplication: ConfidentialClientApplication,
+    ) {
         this.appId = appId;
     }
 
@@ -49,7 +52,7 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
         appId: string,
         audience: string,
         loginEndpoint: string,
-        _validateAuthority: boolean
+        _validateAuthority: boolean,
     ): Promise<ServiceClientCredentials> {
         if (await this.isAuthenticationDisabled()) {
             return MsalAppCredentials.Empty;
@@ -66,7 +69,7 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
                 this.clientApplication,
                 appId,
                 undefined,
-                audience || AuthenticationConstants.ToBotFromChannelTokenIssuer
+                audience || AuthenticationConstants.ToBotFromChannelTokenIssuer,
             );
         }
 
@@ -75,7 +78,7 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
                 this.clientApplication,
                 appId,
                 undefined,
-                audience || GovernmentConstants.ToChannelFromBotOAuthScope
+                audience || GovernmentConstants.ToChannelFromBotOAuthScope,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -27,7 +27,10 @@ export class OpenIdMetadata {
      * @param url Metadata Url.
      * @param proxySettings The proxy settings for the request.
      */
-    constructor(private url: string, private proxySettings?: ProxySettings) {}
+    constructor(
+        private url: string,
+        private proxySettings?: ProxySettings,
+    ) {}
 
     /**
      * Gets the Signing key.
@@ -76,13 +79,13 @@ export class OpenIdMetadata {
             } else {
                 throw new AuthenticationError(
                     `Failed to load Keys: ${getKeyResponse.status}`,
-                    StatusCodes.INTERNAL_SERVER_ERROR
+                    StatusCodes.INTERNAL_SERVER_ERROR,
                 );
             }
         } else {
             throw new AuthenticationError(
                 `Failed to load openID config: ${res.status}`,
-                StatusCodes.INTERNAL_SERVER_ERROR
+                StatusCodes.INTERNAL_SERVER_ERROR,
             );
         }
     }

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -66,7 +66,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         private readonly credentialsFactory: ServiceClientCredentialsFactory,
         private readonly authConfiguration: AuthenticationConfiguration,
         private readonly botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-        private readonly connectorClientOptions: ConnectorClientOptions = {}
+        private readonly connectorClientOptions: ConnectorClientOptions = {},
     ) {
         super();
     }
@@ -90,7 +90,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             if (!isAuthDisabled) {
                 throw new AuthenticationError(
                     'Unauthorized Access. Request is not authorized',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -125,7 +125,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toChannelFromBotLoginUrl,
             this.validateAuthority,
             this.credentialsFactory,
-            this.connectorClientOptions
+            this.connectorClientOptions,
         );
 
         return {
@@ -145,7 +145,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
      */
     async authenticateStreamingRequest(
         authHeader: string,
-        channelIdHeader: string
+        channelIdHeader: string,
     ): Promise<AuthenticateRequestResult> {
         if (!channelIdHeader?.trim() && !(await this.credentialsFactory.isAuthenticationDisabled())) {
             throw new AuthenticationError("'channelIdHeader' required.", StatusCodes.UNAUTHORIZED);
@@ -172,7 +172,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             appId,
             this.toChannelFromBotOAuthScope,
             this.toChannelFromBotLoginUrl,
-            this.validateAuthority
+            this.validateAuthority,
         );
 
         return new UserTokenClientImpl(appId, credentials, this.oAuthUrl, this.connectorClientOptions);
@@ -191,7 +191,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toChannelFromBotLoginUrl,
             this.validateAuthority,
             this.credentialsFactory,
-            this.connectorClientOptions
+            this.connectorClientOptions,
         );
     }
 
@@ -205,20 +205,20 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.credentialsFactory,
             this.toChannelFromBotLoginUrl,
             this.botFrameworkClientFetch,
-            this.connectorClientOptions
+            this.connectorClientOptions,
         );
     }
 
     private async JwtTokenValidation_authenticateRequest(
         activity: Partial<Activity>,
-        authHeader: string
+        authHeader: string,
     ): Promise<ClaimsIdentity> {
         if (!authHeader.trim()) {
             const isAuthDisabled = await this.credentialsFactory.isAuthenticationDisabled();
             if (!isAuthDisabled) {
                 throw new AuthenticationError(
                     'Unauthorized Access. Request is not authorized',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -236,7 +236,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         const claimsIdentity: ClaimsIdentity = await this.JwtTokenValidation_validateAuthHeader(
             authHeader,
             activity.channelId,
-            activity.serviceUrl
+            activity.serviceUrl,
         );
 
         return claimsIdentity;
@@ -245,7 +245,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
     private async JwtTokenValidation_validateAuthHeader(
         authHeader: string,
         channelId: string,
-        serviceUrl = ''
+        serviceUrl = '',
     ): Promise<ClaimsIdentity> {
         const identity = await this.JwtTokenValidation_authenticateToken(authHeader, channelId, serviceUrl);
 
@@ -262,7 +262,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // Skill claims must be validated using AuthenticationConfiguration validateClaims
             throw new AuthenticationError(
                 'Unauthorized Access. Request is not authorized. Skill Claims require validation.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
     }
@@ -270,7 +270,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
     private async JwtTokenValidation_authenticateToken(
         authHeader: string,
         channelId: string,
-        serviceUrl: string
+        serviceUrl: string,
     ): Promise<ClaimsIdentity | undefined> {
         if (AseChannelValidation.isTokenFromAseChannel(channelId)) {
             return AseChannelValidation.authenticateAseChannelToken(authHeader);
@@ -290,7 +290,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
 
     private async SkillValidation_authenticateChannelToken(
         authHeader: string,
-        channelId: string
+        channelId: string,
     ): Promise<ClaimsIdentity> {
         // Add allowed token issuers from configuration.
         const verifyOptions: VerifyOptions = {
@@ -305,7 +305,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             verifyOptions,
             this.toBotFromEmulatorOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
-            this.connectorClientOptions?.proxySettings
+            this.connectorClientOptions?.proxySettings,
         );
 
         const parts: string[] = authHeader.split(' ');
@@ -313,7 +313,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             parts[0],
             parts[1],
             channelId,
-            this.authConfiguration.requiredEndorsements
+            this.authConfiguration.requiredEndorsements,
         );
 
         await this.SkillValidation_ValidateIdentity(identity);
@@ -326,7 +326,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // No valid identity. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid identity',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -334,7 +334,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // The token is in some way invalid. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Token not authenticated',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -343,7 +343,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // No version claim
             throw new AuthenticationError(
                 `SkillValidation.validateIdentity(): '${AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -353,7 +353,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // Claim is not present or doesn't have a value. Not Authorized.
             throw new AuthenticationError(
                 `SkillValidation.validateIdentity(): '${AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -361,7 +361,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // The AppId is not valid. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid audience.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -370,14 +370,14 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // Invalid appId
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid appId.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
     }
 
     private async EmulatorValidation_authenticateEmulatorToken(
         authHeader: string,
-        channelId: string
+        channelId: string,
     ): Promise<ClaimsIdentity> {
         // Add allowed token issuers from configuration.
         const verifyOptions: VerifyOptions = {
@@ -392,13 +392,13 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             verifyOptions,
             this.toBotFromEmulatorOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
-            this.connectorClientOptions?.proxySettings
+            this.connectorClientOptions?.proxySettings,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            this.authConfiguration.requiredEndorsements
+            this.authConfiguration.requiredEndorsements,
         );
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -418,7 +418,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
         if (versionClaim === null) {
             throw new AuthenticationError(
                 'Unauthorized. "ver" claim is required on Emulator Tokens.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -434,7 +434,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -446,7 +446,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
                 // No claim around AppID. Not Authorized.
                 throw new AuthenticationError(
                     'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
-                    StatusCodes.UNAUTHORIZED
+                    StatusCodes.UNAUTHORIZED,
                 );
             }
 
@@ -455,14 +455,14 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // Unknown Version. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
         if (!(await this.credentialsFactory.isValidAppId(appId))) {
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${appId}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -472,20 +472,20 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
     private async ChannelValidation_authenticateChannelToken(
         authHeader: string,
         serviceUrl: string,
-        channelId: string
+        channelId: string,
     ): Promise<ClaimsIdentity> {
         const tokenValidationParameters = this.ChannelValidation_GetTokenValidationParameters();
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             tokenValidationParameters,
             this.toBotFromChannelOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
-            this.connectorClientOptions?.proxySettings
+            this.connectorClientOptions?.proxySettings,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
             authHeader,
             channelId,
-            this.authConfiguration.requiredEndorsements
+            this.authConfiguration.requiredEndorsements,
         );
 
         return this.governmentChannelValidation_ValidateIdentity(identity, serviceUrl);
@@ -502,7 +502,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
 
     private async governmentChannelValidation_ValidateIdentity(
         identity: ClaimsIdentity,
-        serviceUrl: string
+        serviceUrl: string,
     ): Promise<ClaimsIdentity> {
         if (!identity) {
             // No valid identity. Not Authorized.
@@ -532,7 +532,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             // The AppId is not valid or not present. Not Authorized.
             throw new AuthenticationError(
                 `Unauthorized. Invalid AppId passed on token: ${audClaim}`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -53,8 +53,8 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
      * @param appId The app ID.
      * @param password The app password.
      * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
-     *   * Required for SingleTenant app types.
-     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *   Required for SingleTenant app types.
+     *   Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
      *
      * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      */
@@ -101,7 +101,7 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
         appId: string,
         audience: string,
         loginEndpoint: string,
-        validateAuthority: boolean
+        validateAuthority: boolean,
     ): Promise<ServiceClientCredentials> {
         if (await this.isAuthenticationDisabled()) {
             return MicrosoftAppCredentials.Empty;
@@ -125,7 +125,7 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
                 this.tenantId,
                 audience,
                 normalizedEndpoint,
-                validateAuthority
+                validateAuthority,
             );
         }
         return credentials;
@@ -142,7 +142,7 @@ class PrivateCloudAppCredentials extends MicrosoftAppCredentials {
         tenantId: string,
         oAuthScope: string,
         oAuthEndpoint: string,
-        validateAuthority: boolean
+        validateAuthority: boolean,
     ) {
         super(appId, password, tenantId, oAuthScope);
         this.oAuthEndpoint = oAuthEndpoint;

--- a/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
@@ -39,6 +39,6 @@ export abstract class ServiceClientCredentialsFactory {
         appId: string,
         audience: string | undefined,
         loginEndpoint: string,
-        validateAuthority: boolean
+        validateAuthority: boolean,
     ): Promise<ServiceClientCredentials>;
 }

--- a/libraries/botframework-connector/src/auth/skillValidation.ts
+++ b/libraries/botframework-connector/src/auth/skillValidation.ts
@@ -124,12 +124,12 @@ export namespace SkillValidation {
         credentials: ICredentialProvider,
         channelService: string,
         channelId: string,
-        authConfig: AuthenticationConfiguration
+        authConfig: AuthenticationConfiguration,
     ): Promise<ClaimsIdentity> {
         if (!authConfig) {
             throw new AuthenticationError(
                 'SkillValidation.authenticateChannelToken(): invalid authConfig parameter',
-                StatusCodes.INTERNAL_SERVER_ERROR
+                StatusCodes.INTERNAL_SERVER_ERROR,
             );
         }
 
@@ -149,7 +149,7 @@ export namespace SkillValidation {
         const tokenExtractor = new JwtTokenExtractor(
             verifyOptions,
             openIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
+            AuthenticationConstants.AllowedSigningAlgorithms,
         );
 
         const parts: string[] = authHeader.split(' ');
@@ -157,7 +157,7 @@ export namespace SkillValidation {
             parts[0],
             parts[1],
             channelId,
-            authConfig.requiredEndorsements
+            authConfig.requiredEndorsements,
         );
 
         await validateIdentity(identity, credentials);
@@ -176,7 +176,7 @@ export namespace SkillValidation {
             // No valid identity. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid identity',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -184,7 +184,7 @@ export namespace SkillValidation {
             // The token is in some way invalid. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Token not authenticated',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -194,7 +194,7 @@ export namespace SkillValidation {
             // No version claim
             throw new AuthenticationError(
                 `SkillValidation.validateIdentity(): '${AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -204,7 +204,7 @@ export namespace SkillValidation {
             // Claim is not present or doesn't have a value. Not Authorized.
             throw new AuthenticationError(
                 `SkillValidation.validateIdentity(): '${AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.`,
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -212,7 +212,7 @@ export namespace SkillValidation {
             // The AppId is not valid. Not Authorized.
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid audience.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -221,7 +221,7 @@ export namespace SkillValidation {
             // Invalid appId
             throw new AuthenticationError(
                 'SkillValidation.validateIdentity(): Invalid appId.',
-                StatusCodes.UNAUTHORIZED
+                StatusCodes.UNAUTHORIZED,
             );
         }
 
@@ -244,7 +244,7 @@ export namespace SkillValidation {
                     value: AuthenticationConstants.AnonymousSkillAppId,
                 },
             ],
-            AuthenticationConstants.AnonymousAuthType
+            AuthenticationConstants.AnonymousAuthType,
         );
     }
 }

--- a/libraries/botframework-connector/src/auth/userTokenClient.ts
+++ b/libraries/botframework-connector/src/auth/userTokenClient.ts
@@ -30,7 +30,7 @@ export abstract class UserTokenClient {
         userId: string,
         connectionName: string,
         channelId: string,
-        magicCode: string
+        magicCode: string,
     ): Promise<TokenResponse>;
 
     /**
@@ -44,7 +44,7 @@ export abstract class UserTokenClient {
     abstract getSignInResource(
         connectionName: string,
         activity: Activity,
-        finalRediect: string
+        finalRediect: string,
     ): Promise<SignInUrlResponse>;
 
     /**
@@ -79,7 +79,7 @@ export abstract class UserTokenClient {
         userId: string,
         connectionName: string,
         resourceUrls: string[],
-        channelId: string
+        channelId: string,
     ): Promise<Record<string, TokenResponse>>;
 
     /**
@@ -95,7 +95,7 @@ export abstract class UserTokenClient {
         userId: string,
         connectionName: string,
         channelId: string,
-        exchangeRequest: TokenExchangeRequest
+        exchangeRequest: TokenExchangeRequest,
     ): Promise<TokenResponse>;
 
     /**

--- a/libraries/botframework-connector/src/auth/userTokenClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/userTokenClientImpl.ts
@@ -24,12 +24,12 @@ export class UserTokenClientImpl extends UserTokenClient {
         private readonly appId: string,
         credentials: ServiceClientCredentials,
         oauthEndpoint: string,
-        connectorClientOptions: ConnectorClientOptions = {}
+        connectorClientOptions: ConnectorClientOptions = {},
     ) {
         super();
         this.client = new TokenApiClient(
             credentials,
-            Object.assign({ baseUri: oauthEndpoint }, connectorClientOptions)
+            Object.assign({ baseUri: oauthEndpoint }, connectorClientOptions),
         );
     }
 
@@ -46,7 +46,7 @@ export class UserTokenClientImpl extends UserTokenClient {
         userId: string,
         connectionName: string,
         channelId: string,
-        magicCode: string
+        magicCode: string,
     ): Promise<TokenResponse> {
         z.object({
             userId: z.string(),
@@ -73,7 +73,7 @@ export class UserTokenClientImpl extends UserTokenClient {
     async getSignInResource(
         connectionName: string,
         activity: Activity,
-        finalRedirect: string
+        finalRedirect: string,
     ): Promise<SignInUrlResponse> {
         z.object({
             activity: z.record(z.unknown()),
@@ -85,7 +85,7 @@ export class UserTokenClientImpl extends UserTokenClient {
 
         const result = await this.client.botSignIn.getSignInResource(
             UserTokenClient.createTokenExchangeState(this.appId, connectionName, activity),
-            { finalRedirect }
+            { finalRedirect },
         );
 
         return result._response.parsedBody;
@@ -149,7 +149,7 @@ export class UserTokenClientImpl extends UserTokenClient {
         userId: string,
         connectionName: string,
         resourceUrls: string[],
-        channelId: string
+        channelId: string,
     ): Promise<Record<string, TokenResponse>> {
         z.object({
             userId: z.string(),
@@ -165,7 +165,7 @@ export class UserTokenClientImpl extends UserTokenClient {
             userId,
             connectionName,
             { resourceUrls },
-            { channelId }
+            { channelId },
         );
         return result._response.parsedBody as Record<string, TokenResponse>;
     }
@@ -183,7 +183,7 @@ export class UserTokenClientImpl extends UserTokenClient {
         userId: string,
         connectionName: string,
         channelId: string,
-        exchangeRequest: TokenExchangeRequest
+        exchangeRequest: TokenExchangeRequest,
     ): Promise<TokenResponse> {
         z.object({
             userId: z.string(),

--- a/libraries/botframework-connector/src/emulatorApiClient.ts
+++ b/libraries/botframework-connector/src/emulatorApiClient.ts
@@ -26,7 +26,7 @@ export class EmulatorApiClient {
     static async emulateOAuthCards(
         credentials: AppCredentials,
         emulatorUrl: string,
-        emulate: boolean
+        emulate: boolean,
     ): Promise<boolean> {
         const token = await credentials.getToken();
         const requestUrl: string =

--- a/libraries/botframework-connector/src/skills/botFrameworkClient.ts
+++ b/libraries/botframework-connector/src/skills/botFrameworkClient.ts
@@ -14,13 +14,13 @@ export interface BotFrameworkClient {
      * @param conversationId A conversation ID to use for the conversation with the skill.
      * @param activity Activity to forward.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     postActivity: <T = any>(
         fromBotId: string,
         toBotId: string,
         toUrl: string,
         serviceUrl: string,
         conversationId: string,
-        activity: Activity
+        activity: Activity,
     ) => Promise<InvokeResponse<T>>;
 }

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -18,7 +18,7 @@ import {
 /**
  * @interface
  * An interface representing TeamsConnectorClientOptions.
- * @extends ServiceClientOptions
+ * @augments ServiceClientOptions
  */
 export interface TeamsConnectorClientOptions extends ServiceClientOptions {
     /**
@@ -100,7 +100,7 @@ export type TeamsFetchMeetingParticipantResponse = TeamsMeetingParticipant & {
  * An interface representing TeamsFetchMeetingParticipantOptionalParams.
  * Optional Parameters.
  *
- * @extends RequestOptionsBase
+ * @augments RequestOptionsBase
  */
 export interface TeamsFetchMeetingParticipantOptionalParams extends RequestOptionsBase {
     /**

--- a/libraries/botframework-connector/src/teams/retryAction.ts
+++ b/libraries/botframework-connector/src/teams/retryAction.ts
@@ -14,7 +14,7 @@
 export async function retryAction<T>(
     promise: (n: number) => Promise<T>,
     maxRetries: number,
-    initialDelay = 500
+    initialDelay = 500,
 ): Promise<T | undefined> {
     let delay = initialDelay,
         n = 1;

--- a/libraries/botframework-connector/src/teams/teamsConnectorClient.ts
+++ b/libraries/botframework-connector/src/teams/teamsConnectorClient.ts
@@ -9,6 +9,9 @@ import * as Mappers from './models/mappers';
 import * as operations from './operations';
 import { TeamsConnectorClientContext } from './teamsConnectorClientContext';
 
+/**
+ * Implements a client for the Teams Bot Connector service.
+ */
 class TeamsConnectorClient extends TeamsConnectorClientContext {
     // Operation groups
     teams: operations.Teams;
@@ -27,11 +30,6 @@ class TeamsConnectorClient extends TeamsConnectorClientContext {
 
 // Operation Specifications
 
-export {
-    TeamsConnectorClient,
-    TeamsConnectorClientContext,
-    Models as TeamsConnectorModels,
-    Mappers as TeamsConnectorMappers,
-};
+export { TeamsConnectorClient, Models as TeamsConnectorModels, Mappers as TeamsConnectorMappers };
 
 export * from './operations';

--- a/libraries/botframework-connector/tests/appCredentials.test.js
+++ b/libraries/botframework-connector/tests/appCredentials.test.js
@@ -20,7 +20,7 @@ describe('AppCredentials', function () {
         const certCreds = new CertificateAppCredentials(APP_ID, CERT_THUMBPRINT, CERT_KEY);
         strictEqual(
             certCreds.oAuthEndpoint,
-            AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + AuthenticationConstants.DefaultChannelAuthTenant
+            AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + AuthenticationConstants.DefaultChannelAuthTenant,
         );
         strictEqual(certCreds.oAuthScope, AuthenticationConstants.ToBotFromChannelTokenIssuer);
 
@@ -65,7 +65,7 @@ describe('AppCredentials', function () {
             const tokenGenerator = new MicrosoftAppCredentials(APP_ID);
             strictEqual(
                 tokenGenerator.tokenCacheKey,
-                `${APP_ID}${AuthenticationConstants.ToBotFromChannelTokenIssuer}-cache`
+                `${APP_ID}${AuthenticationConstants.ToBotFromChannelTokenIssuer}-cache`,
             );
 
             const oAuthScope = 'oAuthScope';
@@ -76,7 +76,7 @@ describe('AppCredentials', function () {
             const certCreds = new CertificateAppCredentials(APP_ID, CERT_THUMBPRINT, CERT_KEY);
             strictEqual(
                 certCreds.tokenCacheKey,
-                `${APP_ID}${AuthenticationConstants.ToBotFromChannelTokenIssuer}-cache`
+                `${APP_ID}${AuthenticationConstants.ToBotFromChannelTokenIssuer}-cache`,
             );
             certCreds.oAuthScope = oAuthScope;
             strictEqual(certCreds.tokenCacheKey, `${APP_ID}${oAuthScope}-cache`);

--- a/libraries/botframework-connector/tests/auth/aseChannelValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/aseChannelValidation.test.js
@@ -15,7 +15,7 @@ describe('AseChannelTestSuite', function () {
             AseChannelValidation.init(config);
             assert.strictEqual(
                 AseChannelValidation.MetadataUrl,
-                GovernmentConstants.ToBotFromEmulatorOpenIdMetadataUrl
+                GovernmentConstants.ToBotFromEmulatorOpenIdMetadataUrl,
             );
         });
 
@@ -24,7 +24,7 @@ describe('AseChannelTestSuite', function () {
             AseChannelValidation.init(config);
             assert.strictEqual(
                 AseChannelValidation.MetadataUrl,
-                AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl
+                AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
             );
         });
 
@@ -42,20 +42,20 @@ describe('AseChannelTestSuite', function () {
                 assert.strictEqual(
                     true,
                     BetweenBotAndAseChannelTokenValidationParameters.issuer.includes(
-                        `https://sts.windows.net/${tmpId}/`
-                    )
+                        `https://sts.windows.net/${tmpId}/`,
+                    ),
                 );
                 assert.strictEqual(
                     true,
                     BetweenBotAndAseChannelTokenValidationParameters.issuer.includes(
-                        `https://login.microsoftonline.com/${tmpId}/v2.0`
-                    )
+                        `https://login.microsoftonline.com/${tmpId}/v2.0`,
+                    ),
                 );
                 assert.strictEqual(
                     true,
                     BetweenBotAndAseChannelTokenValidationParameters.issuer.includes(
-                        `https://login.microsoftonline.us/${tmpId}/v2.0`
-                    )
+                        `https://login.microsoftonline.us/${tmpId}/v2.0`,
+                    ),
                 );
             });
         });

--- a/libraries/botframework-connector/tests/auth/channelValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/channelValidation.test.js
@@ -7,18 +7,19 @@ const { StatusCodes } = require('botframework-schema');
 
 describe('ChannelValidation', function () {
     const credentials = new SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+
     describe('validateIdentity', function () {
         it('should fail if unauthenticated', async function () {
             await assert.rejects(
                 ChannelValidation.validateIdentity(new ClaimsIdentity([], false), undefined),
-                new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED),
             );
         });
 
         it('should fail if no identity', async function () {
             await assert.rejects(
                 ChannelValidation.validateIdentity(undefined, undefined),
-                new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED),
             );
         });
 
@@ -26,9 +27,9 @@ describe('ChannelValidation', function () {
             await assert.rejects(
                 ChannelValidation.validateIdentity(
                     new ClaimsIdentity([{ type: 'peanut', value: 'peanut' }], true),
-                    credentials
+                    credentials,
                 ),
-                new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED),
             );
         });
 
@@ -36,9 +37,9 @@ describe('ChannelValidation', function () {
             await assert.rejects(
                 ChannelValidation.validateIdentity(
                     new ClaimsIdentity([{ type: 'iss', value: 'peanut' }], true),
-                    credentials
+                    credentials,
                 ),
-                new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED),
             );
         });
 
@@ -46,9 +47,9 @@ describe('ChannelValidation', function () {
             await assert.rejects(
                 ChannelValidation.validateIdentity(
                     new ClaimsIdentity([{ type: 'iss', value: 'https://api.botframework.com' }], true),
-                    credentials
+                    credentials,
                 ),
-                new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED),
             );
         });
 
@@ -60,11 +61,14 @@ describe('ChannelValidation', function () {
                             { type: 'iss', value: 'https://api.botframework.com' },
                             { type: 'aud', value: 'peanut' },
                         ],
-                        true
+                        true,
                     ),
-                    credentials
+                    credentials,
                 ),
-                new AuthenticationError('Unauthorized. Invalid AppId passed on token: peanut', StatusCodes.UNAUTHORIZED)
+                new AuthenticationError(
+                    'Unauthorized. Invalid AppId passed on token: peanut',
+                    StatusCodes.UNAUTHORIZED,
+                ),
             );
         });
 
@@ -75,9 +79,9 @@ describe('ChannelValidation', function () {
                         { type: 'iss', value: 'https://api.botframework.com' },
                         { type: 'aud', value: credentials.appId },
                     ],
-                    true
+                    true,
                 ),
-                credentials
+                credentials,
             );
         });
     });

--- a/libraries/botframework-connector/tests/auth/enterpriseChannelValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/enterpriseChannelValidation.test.js
@@ -11,14 +11,14 @@ describe('EnterpriseChannelValidator', function () {
     it('validateIdentity should fail if unauthenticated', async function () {
         await assert.rejects(
             EnterpriseChannelValidation.validateIdentity(new ClaimsIdentity([], false), undefined),
-            new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED),
         );
     });
 
     it('validateIdentity should fail if no identity', async function () {
         await assert.rejects(
             EnterpriseChannelValidation.validateIdentity(undefined, undefined),
-            new AuthenticationError('Unauthorized. No valid identity.', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. No valid identity.', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -26,9 +26,9 @@ describe('EnterpriseChannelValidator', function () {
         await assert.rejects(
             EnterpriseChannelValidation.validateIdentity(
                 new ClaimsIdentity([{ type: 'iss', value: 'peanut' }], true),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -36,9 +36,9 @@ describe('EnterpriseChannelValidator', function () {
         await assert.rejects(
             EnterpriseChannelValidation.validateIdentity(
                 new ClaimsIdentity([{ type: 'iss', value: 'https://api.botframework.com' }], true),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -50,11 +50,11 @@ describe('EnterpriseChannelValidator', function () {
                         { type: 'iss', value: 'https://api.botframework.com' },
                         { type: 'aud', value: 'peanut' },
                     ],
-                    true
+                    true,
                 ),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Invalid AppId passed on token: peanut', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Invalid AppId passed on token: peanut', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -65,9 +65,9 @@ describe('EnterpriseChannelValidator', function () {
                     { type: 'iss', value: 'https://api.botframework.com' },
                     { type: 'aud', value: credentials.appId },
                 ],
-                true
+                true,
             ),
-            credentials
+            credentials,
         );
     });
 });

--- a/libraries/botframework-connector/tests/auth/governmentChannelValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/governmentChannelValidation.test.js
@@ -11,7 +11,7 @@ describe('GovernmentChannelValidator', function () {
     it('validateIdentity should fail if no identity', async function () {
         await assert.rejects(
             GovernmentChannelValidation.validateIdentity(new ClaimsIdentity([], false), undefined),
-            new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -19,9 +19,9 @@ describe('GovernmentChannelValidator', function () {
         await assert.rejects(
             GovernmentChannelValidation.validateIdentity(
                 new ClaimsIdentity([{ type: 'iss', value: 'peanut' }], true),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Issuer Claim MUST be present.', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -29,9 +29,9 @@ describe('GovernmentChannelValidator', function () {
         await assert.rejects(
             GovernmentChannelValidation.validateIdentity(
                 new ClaimsIdentity([{ type: 'iss', value: 'https://api.botframework.us' }], true),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Invalid AppId passed on token: null', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -43,11 +43,11 @@ describe('GovernmentChannelValidator', function () {
                         { type: 'iss', value: 'https://api.botframework.us' },
                         { type: 'aud', value: 'peanut' },
                     ],
-                    true
+                    true,
                 ),
-                credentials
+                credentials,
             ),
-            new AuthenticationError('Unauthorized. Invalid AppId passed on token: peanut', StatusCodes.UNAUTHORIZED)
+            new AuthenticationError('Unauthorized. Invalid AppId passed on token: peanut', StatusCodes.UNAUTHORIZED),
         );
     });
 
@@ -58,9 +58,9 @@ describe('GovernmentChannelValidator', function () {
                     { type: 'iss', value: 'https://api.botframework.us' },
                     { type: 'aud', value: credentials.appId },
                 ],
-                true
+                true,
             ),
-            credentials
+            credentials,
         );
     });
 });

--- a/libraries/botframework-connector/tests/auth/jwtTokenExtractor.test.js
+++ b/libraries/botframework-connector/tests/auth/jwtTokenExtractor.test.js
@@ -17,7 +17,7 @@ describe('JwtTokenExtractor', function () {
                 issuer,
             },
             metadata,
-            [algorithm]
+            [algorithm],
         );
 
         return { client, issuer, sign, verify };
@@ -52,7 +52,7 @@ describe('JwtTokenExtractor', function () {
                     clockTolerance: -10,
                 },
                 metadata,
-                [algorithm]
+                [algorithm],
             );
 
             await assert.rejects(client.getIdentityFromAuthHeader(`Bearer ${token}`), {

--- a/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
@@ -68,7 +68,7 @@ describe('JwtTokenValidation', function () {
                     [AuthenticationConstants.ServiceUrlClaim]: activity.serviceUrl,
                     [AuthenticationConstants.VersionClaim]: version,
                     tid: tenant,
-                })
+                }),
             );
             const credentials = makeCredentials(appId, appPassword, tenant, token);
 
@@ -82,7 +82,7 @@ describe('JwtTokenValidation', function () {
                 activity,
                 makeAuthHeader('Bearer', accessToken),
                 provider,
-                channelService
+                channelService,
             );
 
             // Assert expected results
@@ -140,7 +140,7 @@ describe('JwtTokenValidation', function () {
                     assert(claims.isAuthenticated);
                     assert.strictEqual(
                         claims.getClaimValue(AuthenticationConstants.ServiceUrlClaim),
-                        'https://service.url'
+                        'https://service.url',
                     );
                 },
                 label: 'succeeds with a specific tenant',

--- a/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
@@ -7,7 +7,7 @@ describe('MicrosoftAppCredentialsTestSuite', function () {
             const credentials1 = new MicrosoftAppCredentials('appId', 'password', 'tenantId', 'audience');
             assert.strictEqual(
                 AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + 'tenantId',
-                credentials1.oAuthEndpoint
+                credentials1.oAuthEndpoint,
             );
             assert.strictEqual('audience', credentials1.oAuthScope);
 
@@ -15,7 +15,7 @@ describe('MicrosoftAppCredentialsTestSuite', function () {
             assert.strictEqual(
                 AuthenticationConstants.ToChannelFromBotLoginUrlPrefix +
                     AuthenticationConstants.DefaultChannelAuthTenant,
-                credentials2.oAuthEndpoint
+                credentials2.oAuthEndpoint,
             );
             assert.strictEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, credentials2.oAuthScope);
         });

--- a/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
@@ -7,14 +7,14 @@ describe('MicrosoftGovernmentAppCredentialsTestSuite', function () {
             const credentials1 = new MicrosoftGovernmentAppCredentials('appId', 'password', 'tenantId', 'audience');
             assert.strictEqual(
                 GovernmentConstants.ToChannelFromBotLoginUrlPrefix + 'tenantId',
-                credentials1.oAuthEndpoint
+                credentials1.oAuthEndpoint,
             );
             assert.strictEqual('audience', credentials1.oAuthScope);
 
             const credentials2 = new MicrosoftGovernmentAppCredentials('appId', 'password');
             assert.strictEqual(
                 GovernmentConstants.ToChannelFromBotLoginUrlPrefix + GovernmentConstants.DefaultChannelAuthTenant,
-                credentials2.oAuthEndpoint
+                credentials2.oAuthEndpoint,
             );
             assert.strictEqual(GovernmentConstants.ToChannelFromBotOAuthScope, credentials2.oAuthScope);
         });

--- a/libraries/botframework-connector/tests/auth/userTokenClient.test.js
+++ b/libraries/botframework-connector/tests/auth/userTokenClient.test.js
@@ -13,7 +13,7 @@ describe('UserTokenClient', function () {
             it(`should throw with null ${paramName}`, function () {
                 assert.throws(
                     () => UserTokenClient.createTokenExchangeState(...values),
-                    (thrown) => thrown.message.includes(paramName) && thrown.message.includes('received null')
+                    (thrown) => thrown.message.includes(paramName) && thrown.message.includes('received null'),
                 );
             });
         });

--- a/libraries/botframework-connector/tests/botFrameworkAuthenticationFactory.test.js
+++ b/libraries/botframework-connector/tests/botFrameworkAuthenticationFactory.test.js
@@ -30,7 +30,7 @@ describe('BotFrameworkAuthenticationFactory', function () {
     it('should throw with an unknown channel service', function () {
         assert.throws(
             () => BotFrameworkAuthenticationFactory.create('unknown'),
-            new Error('The provided ChannelService value is not supported.')
+            new Error('The provided ChannelService value is not supported.'),
         );
     });
 
@@ -66,7 +66,7 @@ describe('BotFrameworkAuthenticationFactory', function () {
                 undefined,
                 undefined,
                 credsFactory,
-                { requiredEndorsements: [] }
+                { requiredEndorsements: [] },
             );
             assert.strictEqual(pBFA.getOriginatingAudience(), AuthenticationConstants.ToChannelFromBotOAuthScope);
             assert.strictEqual(pBFA.credentialsFactory, credsFactory);
@@ -85,7 +85,7 @@ describe('BotFrameworkAuthenticationFactory', function () {
             // If authentication was enabled 'UnusedAudienceWhenAuthIsDisabled' would have been used, but is unnecessary with disabled authentication.
             assert.strictEqual(
                 connectorClient.credentials.oAuthScope,
-                AuthenticationConstants.ToChannelFromBotOAuthScope
+                AuthenticationConstants.ToChannelFromBotOAuthScope,
             );
 
             const userTokenClient = await pBFA.createUserTokenClient(claimsIdentity);
@@ -107,7 +107,7 @@ describe('BotFrameworkAuthenticationFactory', function () {
                 undefined,
                 undefined,
                 credsFactory,
-                { requiredEndorsements: [] }
+                { requiredEndorsements: [] },
             );
             assert.strictEqual(pBFA.getOriginatingAudience(), AuthenticationConstants.ToChannelFromBotOAuthScope);
             assert.strictEqual(pBFA.credentialsFactory, credsFactory);

--- a/libraries/botframework-connector/tests/connector.test.js
+++ b/libraries/botframework-connector/tests/connector.test.js
@@ -136,6 +136,7 @@ describe('Bot Framework Connector SDK', function () {
                     message: 'Invalid userId: invalid-id',
                 });
             });
+
             it('should fail without members', async function () {
                 const params = createConversation();
                 params.members = [];
@@ -145,6 +146,7 @@ describe('Bot Framework Connector SDK', function () {
                     message: 'Conversations must be to a single member',
                 });
             });
+
             it('should fail with bot member', async function () {
                 const params = createConversation();
                 params.members = [bot];
@@ -164,6 +166,7 @@ describe('Bot Framework Connector SDK', function () {
                 const members = await client.conversations.getConversationMembers(result.id);
                 members.should.matchAny((member) => member.id === user.id);
             });
+
             it('should fail with invalid conversationId', async function () {
                 const params = createConversation();
 
@@ -173,7 +176,7 @@ describe('Bot Framework Connector SDK', function () {
                     {
                         code: 'BadArgument',
                         message: 'Slack API error',
-                    }
+                    },
                 );
             });
         });
@@ -186,6 +189,7 @@ describe('Bot Framework Connector SDK', function () {
                 const result2 = await client.conversations.sendToConversation(result.id, createActivity());
                 assert(!!result2.id);
             });
+
             it('should return a valid activityId with Teams activity', async function () {
                 const params = createConversation();
                 const activity = createActivity();
@@ -212,6 +216,7 @@ describe('Bot Framework Connector SDK', function () {
                 const result2 = await client.conversations.sendToConversation(result.id, activity);
                 assert(!!result2.id);
             });
+
             it('should fail with invalid conversationId', async function () {
                 const params = createConversation();
 
@@ -221,9 +226,10 @@ describe('Bot Framework Connector SDK', function () {
                     {
                         code: 'BadArgument',
                         message: 'Slack API error',
-                    }
+                    },
                 );
             });
+
             it('should send a Hero card', async function () {
                 const params = createConversation();
                 const activity = createActivity();
@@ -235,8 +241,7 @@ describe('Bot Framework Connector SDK', function () {
                             subtitle: 'JPEG image',
                             images: [
                                 {
-                                    url:
-                                        'https://docs.microsoft.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png',
+                                    url: 'https://docs.microsoft.com/en-us/bot-framework/media/designing-bots/core/dialogs-screens.png',
                                 },
                             ],
                         },
@@ -258,6 +263,7 @@ describe('Bot Framework Connector SDK', function () {
                 const members = await client.conversations.getActivityMembers(result.id, result.activityId);
                 members.should.matchAny((member) => member.id === user.id);
             });
+
             it('should fail with invalid conversationId', async function () {
                 const params = createConversation();
                 params.activity = createActivity();
@@ -268,7 +274,7 @@ describe('Bot Framework Connector SDK', function () {
                     {
                         code: 'BadArgument',
                         message: 'Slack API error',
-                    }
+                    },
                 );
             });
         });
@@ -285,6 +291,7 @@ describe('Bot Framework Connector SDK', function () {
                 const result3 = await client.conversations.replyToActivity(conversationId, result2.id, reply);
                 assert(!!result3.id);
             });
+
             it('should fail with invalid conversationId', async function () {
                 const result = await client.conversations.createConversation(createConversation());
                 const result2 = await client.conversations.sendToConversation(result.id, createActivity());
@@ -293,7 +300,7 @@ describe('Bot Framework Connector SDK', function () {
                     {
                         code: 'ServiceError',
                         message: 'Invalid ConversationId: invalid-id',
-                    }
+                    },
                 );
             });
         });
@@ -304,9 +311,10 @@ describe('Bot Framework Connector SDK', function () {
                 conversation.activity = createActivity();
                 const result = await client.conversations.createConversation(conversation);
                 await assert.doesNotReject(
-                    async () => await client.conversations.deleteActivity(result.id, result.activityId)
+                    async () => await client.conversations.deleteActivity(result.id, result.activityId),
                 );
             });
+
             it('should fail with invalid conversationId', async function () {
                 const result = await client.conversations.createConversation(createConversation());
                 const result2 = await client.conversations.sendToConversation(result.id, createActivity());
@@ -329,6 +337,7 @@ describe('Bot Framework Connector SDK', function () {
                 const result3 = await client.conversations.updateActivity(conversationId, result2.id, updatedActivity);
                 assert(!!result3.id);
             });
+
             it('should fail with invalid conversationId', async function () {
                 const result = await client.conversations.createConversation(createConversation());
                 const result2 = await client.conversations.sendToConversation(result.id, createActivity());
@@ -337,7 +346,7 @@ describe('Bot Framework Connector SDK', function () {
                     {
                         code: 'ServiceError',
                         message: 'Invalid ConversationId: invalid-id',
-                    }
+                    },
                 );
             });
         });
@@ -379,6 +388,7 @@ describe('Bot Framework Connector SDK', function () {
             });
         });
     });
+
     describe('TokenApiClient', function () {
         describe('tokenApiClient Construction', function () {
             it('should not throw on http url', function () {
@@ -387,6 +397,7 @@ describe('Bot Framework Connector SDK', function () {
                 });
                 assert(client);
             });
+
             it('should throw on null credentials', function () {
                 assert.throws(
                     () =>
@@ -395,10 +406,11 @@ describe('Bot Framework Connector SDK', function () {
                         }),
                     {
                         message: "'credentials' cannot be null.",
-                    }
+                    },
                 );
             });
         });
+
         describe('botSignIn', function () {
             it('should return a valid sign in url', async function () {
                 const urlRegex = /https:\/\/token.botframework.com\/api\/oauth\/signin\?signin=.*/i;
@@ -415,6 +427,7 @@ describe('Bot Framework Connector SDK', function () {
                 assert(result._response.bodyAsText.match(urlRegex));
             });
         });
+
         describe('userToken', function () {
             describe('getToken', function () {
                 it('should throw on null userId', async function () {
@@ -422,15 +435,18 @@ describe('Bot Framework Connector SDK', function () {
                         message: 'userId cannot be null',
                     });
                 });
+
                 it('should throw on null connectionName', async function () {
                     await assert.rejects(async () => await tokenApiClient.userToken.getToken(user.id, null), {
                         message: 'connectionName cannot be null',
                     });
                 });
+
                 it('should return null on invalid connection string', async function () {
                     const result = await tokenApiClient.userToken.getToken(user.id, 'invalid');
                     assert.strictEqual(result.token, null);
                 });
+
                 it('should return token with no magic code', async function () {
                     const result = await tokenApiClient.userToken.getToken(user.id, 'slack', { code: null });
                     assert(result.channelId);
@@ -439,6 +455,7 @@ describe('Bot Framework Connector SDK', function () {
                     assert(result.expiration);
                 });
             });
+
             describe('getAadTokens', function () {
                 it('should throw on null userId', async function () {
                     await assert.rejects(
@@ -448,9 +465,10 @@ describe('Bot Framework Connector SDK', function () {
                             }),
                         {
                             message: 'userId cannot be null',
-                        }
+                        },
                     );
                 });
+
                 it('should throw on null connectionName', async function () {
                     await assert.rejects(
                         async () =>
@@ -459,9 +477,10 @@ describe('Bot Framework Connector SDK', function () {
                             }),
                         {
                             message: 'connectionName cannot be null',
-                        }
+                        },
                     );
                 });
+
                 it('should return token', async function () {
                     const result = await tokenApiClient.userToken.getAadTokens(user.id, 'slack', {
                         resourceUrls: ['http://localhost'],
@@ -472,12 +491,14 @@ describe('Bot Framework Connector SDK', function () {
                     assert(result.expiration);
                 });
             });
+
             describe('getTokenStatus', function () {
                 it('should throw on null userId', async function () {
                     await assert.rejects(async () => await tokenApiClient.userToken.getTokenStatus(null), {
                         message: 'userId cannot be null',
                     });
                 });
+
                 it('should return token', async function () {
                     const result = await tokenApiClient.userToken.getTokenStatus(user.id);
                     assert(result.channelId);
@@ -486,12 +507,14 @@ describe('Bot Framework Connector SDK', function () {
                     assert(result.serviceProviderDisplayName);
                 });
             });
+
             describe('signOut', function () {
                 it('should throw on null userId', async function () {
                     await assert.rejects(async () => tokenApiClient.userToken.signOut(null), {
                         message: 'userId cannot be null',
                     });
                 });
+
                 it('should return a response', async function () {
                     const result = await tokenApiClient.userToken.signOut(user.id);
                     assert(result.body);

--- a/libraries/botframework-connector/tests/ms-rest-mappers-test.js
+++ b/libraries/botframework-connector/tests/ms-rest-mappers-test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 describe('serialize', function () {
     const entity = [{ type: 'mention', keyone: 'valueOne', keytwo: { keythree: 'valueThree' } }];
     const activity = { type: 'message', entities: entity };
+
     it('should retain custom Entity properties', function () {
         const serializedObject = serializer.serialize(Mappers.Activity, activity);
         assert.deepStrictEqual(serializedObject.entities, entity);

--- a/libraries/botframework-connector/tests/passwordServiceClientCredentialFactory.test.js
+++ b/libraries/botframework-connector/tests/passwordServiceClientCredentialFactory.test.js
@@ -47,7 +47,7 @@ describe('PasswordServiceClientCredentialFactory', function () {
         ];
 
         const credentials = await Promise.all(
-            testArgs.map((args) => credFactory.createCredentials(args[0], args[1], args[2]))
+            testArgs.map((args) => credFactory.createCredentials(args[0], args[1], args[2])),
         );
         credentials.forEach((cred, idx) => {
             // The PasswordServiceClientCredentialFactory generates subclasses of the AppCredentials class.

--- a/libraries/botframework-connector/tests/skillValidation.test.js
+++ b/libraries/botframework-connector/tests/skillValidation.test.js
@@ -22,7 +22,7 @@ describe('SkillValidation', function () {
             // No claims (falsy value)
             assert.throws(
                 () => SkillValidation.isSkillClaim(),
-                new TypeError('SkillValidation.isSkillClaim(): missing claims.')
+                new TypeError('SkillValidation.isSkillClaim(): missing claims.'),
             );
 
             // Empty list of claims
@@ -71,55 +71,55 @@ describe('SkillValidation', function () {
             // No Authentication Scheme
             assert(
                 !SkillValidation.isSkillToken(
-                    'ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ'
-                )
+                    'ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ',
+                ),
             );
 
             // Incorrect Authentication Scheme
             assert(
                 !SkillValidation.isSkillToken(
-                    'Potato ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ'
-                )
+                    'Potato ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ',
+                ),
             );
         });
 
         it('should fail for messages to bot from WebChat using version claim v2', function () {
             assert(
                 !SkillValidation.isSkillToken(
-                    'Bearer ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ'
-                )
+                    'Bearer ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ',
+                ),
             );
         });
 
         it('should fail for messages to bot from Emulator using version claim v1', function () {
             assert(
                 !SkillValidation.isSkillToken(
-                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5ODczLCJuYmYiOjE1NzExODk4NzMsImV4cCI6MTU3MTE5Mzc3MywiYWlvIjoiNDJWZ1lLaWJGUDIyMUxmL0NjL1Yzai8zcGF2RUFBPT0iLCJhcHBpZCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJOdXJ3bTVOQnkwR2duT3dKRnFVREFBIiwidmVyIjoiMS4wIn0.GcKs3XZ_4GONVsAoPYI7otqUZPoNN8pULUnlJMxQa-JKXRKV0KtvTAdcMsfYudYxbz7HwcNYerFT1q3RZAimJFtfF4x_sMN23yEVxsQmYQrsf2YPmEsbCfNiEx0YEoWUdS38R1N0Iul2P_P_ZB7XreG4aR5dT6lY5TlXbhputv9pi_yAU7PB1aLuB05phQme5NwJEY22pUfx5pe1wVHogI0JyNLi-6gdoSL63DJ32tbQjr2DNYilPVtLsUkkz7fTky5OKd4p7FmG7P5EbEK4H5j04AGe_nIFs-X6x_FIS_5OSGK4LGA2RPnqa-JYpngzlNWVkUbnuH10AovcAprgdg'
-                )
+                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5ODczLCJuYmYiOjE1NzExODk4NzMsImV4cCI6MTU3MTE5Mzc3MywiYWlvIjoiNDJWZ1lLaWJGUDIyMUxmL0NjL1Yzai8zcGF2RUFBPT0iLCJhcHBpZCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJOdXJ3bTVOQnkwR2duT3dKRnFVREFBIiwidmVyIjoiMS4wIn0.GcKs3XZ_4GONVsAoPYI7otqUZPoNN8pULUnlJMxQa-JKXRKV0KtvTAdcMsfYudYxbz7HwcNYerFT1q3RZAimJFtfF4x_sMN23yEVxsQmYQrsf2YPmEsbCfNiEx0YEoWUdS38R1N0Iul2P_P_ZB7XreG4aR5dT6lY5TlXbhputv9pi_yAU7PB1aLuB05phQme5NwJEY22pUfx5pe1wVHogI0JyNLi-6gdoSL63DJ32tbQjr2DNYilPVtLsUkkz7fTky5OKd4p7FmG7P5EbEK4H5j04AGe_nIFs-X6x_FIS_5OSGK4LGA2RPnqa-JYpngzlNWVkUbnuH10AovcAprgdg',
+                ),
             );
         });
 
         it('should fail for messages to bot from Emulator using version claim v2', function () {
             assert(
                 !SkillValidation.isSkillToken(
-                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODkwMTEsIm5iZiI6MTU3MTE4OTAxMSwiZXhwIjoxNTcxMTkyOTExLCJhaW8iOiI0MlZnWUxnYWxmUE90Y2IxaEoxNzJvbmxIc3ZuQUFBPSIsImF6cCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJucEVxVTFoR1pVbXlISy1MUVdJQ0FBIiwidmVyIjoiMi4wIn0.CXcPx7LfatlRsOX4QG-jaC-guwcY3PFxpFICqwfoOTxAjHpeJNFXOpFeA3Qb5VKM6Yw5LyA9eraL5QDJB_4uMLCCKErPXMyoSm8Hw-GGZkHgFV5ciQXSXhE-IfOinqHE_0Lkt_VLR2q6ekOncnJeCR111QCqt3D8R0Ud0gvyLv_oONxDtqg7HUgNGEfioB-BDnBsO4RN7NGrWQFbyPxPmhi8a_Xc7j5Bb9jeiiIQbVaWkIrrPN31aWY1tEZLvdN0VluYlOa0EBVrzpXXZkIyWx99mpklg0lsy7mRyjuM1xydmyyGkzbiCKtODOanf8UwTjkTg5XTIluxe79_hVk2JQ'
-                )
+                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODkwMTEsIm5iZiI6MTU3MTE4OTAxMSwiZXhwIjoxNTcxMTkyOTExLCJhaW8iOiI0MlZnWUxnYWxmUE90Y2IxaEoxNzJvbmxIc3ZuQUFBPSIsImF6cCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJucEVxVTFoR1pVbXlISy1MUVdJQ0FBIiwidmVyIjoiMi4wIn0.CXcPx7LfatlRsOX4QG-jaC-guwcY3PFxpFICqwfoOTxAjHpeJNFXOpFeA3Qb5VKM6Yw5LyA9eraL5QDJB_4uMLCCKErPXMyoSm8Hw-GGZkHgFV5ciQXSXhE-IfOinqHE_0Lkt_VLR2q6ekOncnJeCR111QCqt3D8R0Ud0gvyLv_oONxDtqg7HUgNGEfioB-BDnBsO4RN7NGrWQFbyPxPmhi8a_Xc7j5Bb9jeiiIQbVaWkIrrPN31aWY1tEZLvdN0VluYlOa0EBVrzpXXZkIyWx99mpklg0lsy7mRyjuM1xydmyyGkzbiCKtODOanf8UwTjkTg5XTIluxe79_hVk2JQ',
+                ),
             );
         });
 
         it('should succeed for messages to skill using valid v1 token', function () {
             assert(
                 SkillValidation.isSkillToken(
-                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5NjMwLCJuYmYiOjE1NzExODk2MzAsImV4cCI6MTU3MTE5MzUzMCwiYWlvIjoiNDJWZ1lJZzY1aDFXTUVPd2JmTXIwNjM5V1lLckFBPT0iLCJhcHBpZCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJhWlpOUTY3RjRVNnNmY3d0S0R3RUFBIiwidmVyIjoiMS4wIn0.Yogk9fptxxJKO8jRkk6FrlLQsAulNNgoa0Lqv2JPkswyyizse8kcwQhxOaZOotY0UBduJ-pCcrejk6k4_O_ZReYXKz8biL9Q7Z02cU9WUMvuIGpAhttz8v0VlVSyaEJVJALc5B-U6XVUpZtG9LpE6MVror_0WMnT6T9Ijf9SuxUvdVCcmAJyZuoqudodseuFI-jtCpImEapZp0wVN4BUodrBacMbTeYjdZyAbNVBqF5gyzDztMKZR26HEz91gqulYZvJJZOJO6ejnm0j62s1tqvUVRBywvnSOon-MV0Xt2Vm0irhv6ipzTXKwWhT9rGHSLj0g8r6NqWRyPRFqLccvA'
-                )
+                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5NjMwLCJuYmYiOjE1NzExODk2MzAsImV4cCI6MTU3MTE5MzUzMCwiYWlvIjoiNDJWZ1lJZzY1aDFXTUVPd2JmTXIwNjM5V1lLckFBPT0iLCJhcHBpZCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJhWlpOUTY3RjRVNnNmY3d0S0R3RUFBIiwidmVyIjoiMS4wIn0.Yogk9fptxxJKO8jRkk6FrlLQsAulNNgoa0Lqv2JPkswyyizse8kcwQhxOaZOotY0UBduJ-pCcrejk6k4_O_ZReYXKz8biL9Q7Z02cU9WUMvuIGpAhttz8v0VlVSyaEJVJALc5B-U6XVUpZtG9LpE6MVror_0WMnT6T9Ijf9SuxUvdVCcmAJyZuoqudodseuFI-jtCpImEapZp0wVN4BUodrBacMbTeYjdZyAbNVBqF5gyzDztMKZR26HEz91gqulYZvJJZOJO6ejnm0j62s1tqvUVRBywvnSOon-MV0Xt2Vm0irhv6ipzTXKwWhT9rGHSLj0g8r6NqWRyPRFqLccvA',
+                ),
             );
         });
 
         it('should succeed for messages to skill using valid v2 token', function () {
             assert(
                 SkillValidation.isSkillToken(
-                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODk3NTUsIm5iZiI6MTU3MTE4OTc1NSwiZXhwIjoxNTcxMTkzNjU1LCJhaW8iOiI0MlZnWUpnZDROZkZKeG1tMTdPaVMvUk8wZll2QUE9PSIsImF6cCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJMc2ZQME9JVkNVS1JzZ1IyYlFBQkFBIiwidmVyIjoiMi4wIn0.SggsEbEyXDYcg6EdhK-RA1y6S97z4hwEccXc6a3ymnHP-78frZ3N8rPLsqLoK5QPGA_cqOXsX1zduA4vlFSy3MfTV_npPfsyWa1FIse96-2_3qa9DIP8bhvOHXEVZeq-r-0iF972waFyPPC_KVYWnIgAcunGhFWvLhhOUx9dPgq7824qTq45ma1rOqRoYbhhlRn6PJDymIin5LeOzDGJJ8YVLnFUgntc6_4z0P_fnuMktzar88CUTtGvR4P7XNJhS8v9EwYQujglsJNXg7LNcwV7qOxDYWJtT_UMuMAts9ctD6FkuTGX_-6FTqmdUPPUS4RWwm4kkl96F_dXnos9JA'
-                )
+                    'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODk3NTUsIm5iZiI6MTU3MTE4OTc1NSwiZXhwIjoxNTcxMTkzNjU1LCJhaW8iOiI0MlZnWUpnZDROZkZKeG1tMTdPaVMvUk8wZll2QUE9PSIsImF6cCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJMc2ZQME9JVkNVS1JzZ1IyYlFBQkFBIiwidmVyIjoiMi4wIn0.SggsEbEyXDYcg6EdhK-RA1y6S97z4hwEccXc6a3ymnHP-78frZ3N8rPLsqLoK5QPGA_cqOXsX1zduA4vlFSy3MfTV_npPfsyWa1FIse96-2_3qa9DIP8bhvOHXEVZeq-r-0iF972waFyPPC_KVYWnIgAcunGhFWvLhhOUx9dPgq7824qTq45ma1rOqRoYbhhlRn6PJDymIin5LeOzDGJJ8YVLnFUgntc6_4z0P_fnuMktzar88CUTtGvR4P7XNJhS8v9EwYQujglsJNXg7LNcwV7qOxDYWJtT_UMuMAts9ctD6FkuTGX_-6FTqmdUPPUS4RWwm4kkl96F_dXnos9JA',
+                ),
             );
         });
     });
@@ -131,9 +131,9 @@ describe('SkillValidation', function () {
                     'authHeader',
                     new SimpleCredentialProvider('', ''),
                     '',
-                    'unknown'
+                    'unknown',
                 ),
-                new Error('SkillValidation.authenticateChannelToken(): invalid authConfig parameter')
+                new Error('SkillValidation.authenticateChannelToken(): invalid authConfig parameter'),
             );
         });
     });
@@ -176,7 +176,7 @@ describe('SkillValidation', function () {
 
             await assert.rejects(
                 SkillValidation.validateIdentity(undefined, credentials),
-                new Error('SkillValidation.validateIdentity(): Invalid identity')
+                new Error('SkillValidation.validateIdentity(): Invalid identity'),
             );
         });
 
@@ -187,7 +187,7 @@ describe('SkillValidation', function () {
 
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
-                new Error('SkillValidation.validateIdentity(): Token not authenticated')
+                new Error('SkillValidation.validateIdentity(): Token not authenticated'),
             );
         });
 
@@ -199,8 +199,8 @@ describe('SkillValidation', function () {
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
                 new Error(
-                    `SkillValidation.validateIdentity(): '${AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.`
-                )
+                    `SkillValidation.validateIdentity(): '${AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.`,
+                ),
             );
         });
 
@@ -212,8 +212,8 @@ describe('SkillValidation', function () {
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
                 new Error(
-                    `SkillValidation.validateIdentity(): '${AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.`
-                )
+                    `SkillValidation.validateIdentity(): '${AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.`,
+                ),
             );
         });
 
@@ -225,7 +225,7 @@ describe('SkillValidation', function () {
 
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
-                new Error('SkillValidation.validateIdentity(): Invalid audience.')
+                new Error('SkillValidation.validateIdentity(): Invalid audience.'),
             );
         });
 
@@ -237,7 +237,7 @@ describe('SkillValidation', function () {
 
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
-                new Error('SkillValidation.validateIdentity(): Invalid appId.')
+                new Error('SkillValidation.validateIdentity(): Invalid appId.'),
             );
         });
 
@@ -249,7 +249,7 @@ describe('SkillValidation', function () {
 
             await assert.rejects(
                 SkillValidation.validateIdentity(identity, credentials),
-                new Error('SkillValidation.validateIdentity(): Invalid appId.')
+                new Error('SkillValidation.validateIdentity(): Invalid appId.'),
             );
         });
 

--- a/libraries/botframework-connector/tsup.config.ts
+++ b/libraries/botframework-connector/tsup.config.ts
@@ -1,5 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 import { defineConfig } from 'tsup';
+/* eslint-disable-next-line import/no-unresolved */
 import { polyfillNode } from 'esbuild-plugin-polyfill-node';
 import packageJson from './package.json';
 


### PR DESCRIPTION
Addresses # 4684
#minor

## Description
This PR fixes all the new ESLint errors and warnings that appeared after the ESLint packages' upgrade in the botframework-connector project.

## Specific Changes
  - Removed 'only-warn' plugin from 'botframework-connector/eslint.config.cjs' and its dependency.
  - All updated TS and JS files were due to prettier and jsdoc new rules.

## Testing
The following image shows that there are no more ESLint issues.
![image](https://github.com/user-attachments/assets/d51f154e-6128-45ce-a990-48db5476a7b8)
