### PR TITLE
fix: [#4684] ESLint issues in botbuilder-lg

### DIFF
--- a/libraries/botbuilder-lg/eslint.config.cjs
+++ b/libraries/botbuilder-lg/eslint.config.cjs
@@ -1,13 +1,8 @@
-const onlyWarn = require("eslint-plugin-only-warn");
-const sharedConfig = require("../../eslint.config.cjs")
+const sharedConfig = require('../../eslint.config.cjs');
 
 module.exports = [
     ...sharedConfig,
     {
-        ignores: ["**/generated/*"],
+        ignores: ['**/generated/*'],
     },
-    {
-        plugins: {
-            "only-warn": onlyWarn,
-        },
-    }];
+];

--- a/libraries/botbuilder-lg/package.json
+++ b/libraries/botbuilder-lg/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "adaptive-expressions": "4.1.6",
     "antlr4ts": "0.5.0-alpha.4",
-    "eslint-plugin-only-warn": "^1.1.0",
     "lodash": "^4.17.19",
     "uuid": "^10.0.0"
   },

--- a/libraries/botbuilder-lg/src/analyzer.ts
+++ b/libraries/botbuilder-lg/src/analyzer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 /**
  * @module botbuilder-lg
  */
@@ -16,7 +15,7 @@ import { LGTemplateParserVisitor } from './generated/LGTemplateParserVisitor';
 import { Template } from './template';
 import { TemplateExtensions } from './templateExtensions';
 import { Templates } from './templates';
-import keyBy = require('lodash/keyBy');
+import keyBy from 'lodash/keyBy';
 
 import {
     IfConditionRuleContext,
@@ -37,7 +36,8 @@ import { TemplateErrors } from './templateErrors';
  */
 export class Analyzer
     extends AbstractParseTreeVisitor<AnalyzerResult>
-    implements LGTemplateParserVisitor<AnalyzerResult> {
+    implements LGTemplateParserVisitor<AnalyzerResult>
+{
     /**
      * Templates.
      */
@@ -85,7 +85,7 @@ export class Analyzer
                 throw new Error(
                     `${TemplateErrors.loopDetected} ${this.evalutationTargetStack
                         .reverse()
-                        .map((e) => e.templateName)} => ${templateName}`
+                        .map((e) => e.templateName)} => ${templateName}`,
                 );
             }
         }

--- a/libraries/botbuilder-lg/src/customizedMemory.ts
+++ b/libraries/botbuilder-lg/src/customizedMemory.ts
@@ -63,7 +63,6 @@ export class CustomizedMemory implements MemoryInterface {
      * @param _path Memory path.
      * @param _value Value to set.
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setValue(_path: string, _value: any): void {
         return;
     }

--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -43,7 +43,7 @@ export class Diagnostic {
         message: string,
         severity: DiagnosticSeverity = DiagnosticSeverity.Error,
         source?: string,
-        code?: string
+        code?: string,
     ) {
         this.message = message;
         this.range = range;

--- a/libraries/botbuilder-lg/src/errorListener.ts
+++ b/libraries/botbuilder-lg/src/errorListener.ts
@@ -48,22 +48,21 @@ export class ErrorListener implements ANTLRErrorListener<void> {
         offendingSymbol: any,
         line: number,
         charPositionInLine: number,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         msg: string,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e: RecognitionException | undefined
+        e: RecognitionException | undefined,
     ): void {
         const startPosition: Position = new Position(this.lineOffset + line, charPositionInLine);
         const stopPosition: Position = new Position(
             this.lineOffset + line,
-            charPositionInLine + offendingSymbol.stopIndex - offendingSymbol.startIndex + 1
+            charPositionInLine + offendingSymbol.stopIndex - offendingSymbol.startIndex + 1,
         );
         const range: Range = new Range(startPosition, stopPosition);
         const diagnostic: Diagnostic = new Diagnostic(
             range,
             TemplateErrors.syntaxError(msg),
             DiagnosticSeverity.Error,
-            this.source
+            this.source,
         );
 
         throw new TemplateException(diagnostic.toString(), [diagnostic]);

--- a/libraries/botbuilder-lg/src/evaluationOptions.ts
+++ b/libraries/botbuilder-lg/src/evaluationOptions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 /**
  * @module botbuilder-lg
  */

--- a/libraries/botbuilder-lg/src/extractor.ts
+++ b/libraries/botbuilder-lg/src/extractor.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { AbstractParseTreeVisitor, TerminalNode } from 'antlr4ts/tree';
-import keyBy = require('lodash/keyBy');
+import keyBy from 'lodash/keyBy';
 import { LGTemplateParserVisitor } from './generated/LGTemplateParserVisitor';
 import { Template } from './template';
 
@@ -26,7 +26,8 @@ import {
  */
 export class Extractor
     extends AbstractParseTreeVisitor<Map<string, string[]>>
-    implements LGTemplateParserVisitor<Map<string, string[]>> {
+    implements LGTemplateParserVisitor<Map<string, string[]>>
+{
     readonly templates: Template[];
 
     readonly templateMap: Record<string, Template>;
@@ -55,7 +56,7 @@ export class Extractor
             const templateBodies = this.visit(template.templateBodyParseTree);
             let isNormalTemplate = true;
             templateBodies.forEach(
-                (templateBody) => (isNormalTemplate = isNormalTemplate && templateBody === undefined)
+                (templateBody) => (isNormalTemplate = isNormalTemplate && templateBody === undefined),
             );
 
             if (isNormalTemplate) {
@@ -128,8 +129,8 @@ export class Extractor
             const node: TerminalNode = ifExpr
                 ? conditionNode.IF()
                 : elseIfExpr
-                ? conditionNode.ELSEIF()
-                : conditionNode.ELSE();
+                  ? conditionNode.ELSEIF()
+                  : conditionNode.ELSE();
             const conditionLabel: string = node.text.toLowerCase();
             const childTemplateBodyResult: string[] = [];
             const templateBodies = this.visit(ifRule.normalTemplateBody());
@@ -167,8 +168,8 @@ export class Extractor
             const node: TerminalNode = switchExpr
                 ? switchCaseStat.SWITCH()
                 : caseExpr
-                ? switchCaseStat.CASE()
-                : switchCaseStat.DEFAULT();
+                  ? switchCaseStat.CASE()
+                  : switchCaseStat.DEFAULT();
             if (switchExpr) {
                 continue;
             }

--- a/libraries/botbuilder-lg/src/index.ts
+++ b/libraries/botbuilder-lg/src/index.ts
@@ -22,7 +22,6 @@ export * from './evaluationTarget';
 export * from './templateExtensions';
 export * from './analyzerResult';
 export * from './templateErrors';
-export * from './evaluator';
 export * from './errorListener';
 export * from './customizedMemory';
 export * from './expander';

--- a/libraries/botbuilder-lg/src/multiLanguageLG.ts
+++ b/libraries/botbuilder-lg/src/multiLanguageLG.ts
@@ -877,7 +877,7 @@ export class MultiLanguageLG {
     constructor(
         templatesPerLocale: Map<string, Templates> | undefined,
         filePerLocale: Map<string, string> | undefined,
-        defaultLanguage?: string
+        defaultLanguage?: string,
     ) {
         if (templatesPerLocale !== undefined) {
             this.lgPerLocale = templatesPerLocale;

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -35,7 +35,8 @@ import {
  */
 export class StaticChecker
     extends AbstractParseTreeVisitor<Diagnostic[]>
-    implements LGTemplateParserVisitor<Diagnostic[]> {
+    implements LGTemplateParserVisitor<Diagnostic[]>
+{
     private readonly templates: Templates;
     private currentTemplate: Template;
     private _expressionParser: ExpressionParserInterface;
@@ -77,7 +78,7 @@ export class StaticChecker
                 Range.DefaultRange,
                 TemplateErrors.noTemplate,
                 DiagnosticSeverity.Warning,
-                this.templates.source
+                this.templates.source,
             );
             result.push(diagnostic);
             return result;
@@ -96,10 +97,10 @@ export class StaticChecker
                         range,
                         TemplateErrors.duplicatedTemplateInDiffTemplate(
                             sameTemplate.name,
-                            sameTemplate.sourceRange.source
+                            sameTemplate.sourceRange.source,
                         ),
                         DiagnosticSeverity.Error,
-                        this.templates.source
+                        this.templates.source,
                     );
                     templateDiagnostics.push(diagnostic);
                 }
@@ -151,8 +152,8 @@ export class StaticChecker
                 this.buildLGDiagnostic(
                     TemplateErrors.invalidStrucName(errorName.text),
                     undefined,
-                    context.structuredBodyNameLine()
-                )
+                    context.structuredBodyNameLine(),
+                ),
             );
         }
 
@@ -209,12 +210,12 @@ export class StaticChecker
             const node: TerminalNode = ifExpr
                 ? conditionNode.IF()
                 : elseIfExpr
-                ? conditionNode.ELSEIF()
-                : conditionNode.ELSE();
+                  ? conditionNode.ELSEIF()
+                  : conditionNode.ELSE();
 
             if (node.text.split(' ').length - 1 > 1) {
                 result.push(
-                    this.buildLGDiagnostic(TemplateErrors.invalidWhitespaceInCondition, undefined, conditionNode)
+                    this.buildLGDiagnostic(TemplateErrors.invalidWhitespaceInCondition, undefined, conditionNode),
                 );
             }
 
@@ -223,8 +224,8 @@ export class StaticChecker
                     this.buildLGDiagnostic(
                         TemplateErrors.notStartWithIfInCondition,
                         DiagnosticSeverity.Warning,
-                        conditionNode
-                    )
+                        conditionNode,
+                    ),
                 );
             }
 
@@ -237,8 +238,8 @@ export class StaticChecker
                     this.buildLGDiagnostic(
                         TemplateErrors.notEndWithElseInCondition,
                         DiagnosticSeverity.Warning,
-                        conditionNode
-                    )
+                        conditionNode,
+                    ),
                 );
             }
 
@@ -249,7 +250,7 @@ export class StaticChecker
             if (!elseExpr) {
                 if (ifRule.ifCondition().expression().length !== 1) {
                     result.push(
-                        this.buildLGDiagnostic(TemplateErrors.invalidExpressionInCondition, undefined, conditionNode)
+                        this.buildLGDiagnostic(TemplateErrors.invalidExpressionInCondition, undefined, conditionNode),
                     );
                 } else {
                     const errorPrefix = "Condition '" + conditionNode.expression(0).text + "': ";
@@ -258,7 +259,7 @@ export class StaticChecker
             } else {
                 if (ifRule.ifCondition().expression().length !== 0) {
                     result.push(
-                        this.buildLGDiagnostic(TemplateErrors.extraExpressionInCondition, undefined, conditionNode)
+                        this.buildLGDiagnostic(TemplateErrors.extraExpressionInCondition, undefined, conditionNode),
                     );
                 }
             }
@@ -266,7 +267,7 @@ export class StaticChecker
                 result = result.concat(this.visit(ifRule.normalTemplateBody()));
             } else {
                 result.push(
-                    this.buildLGDiagnostic(TemplateErrors.missingTemplateBodyInCondition, undefined, conditionNode)
+                    this.buildLGDiagnostic(TemplateErrors.missingTemplateBodyInCondition, undefined, conditionNode),
                 );
             }
 
@@ -296,23 +297,27 @@ export class StaticChecker
             const node: TerminalNode = switchExpr
                 ? switchCaseStat.SWITCH()
                 : caseExpr
-                ? switchCaseStat.CASE()
-                : switchCaseStat.DEFAULT();
+                  ? switchCaseStat.CASE()
+                  : switchCaseStat.DEFAULT();
             if (node.text.split(' ').length - 1 > 1) {
                 result.push(
-                    this.buildLGDiagnostic(TemplateErrors.invalidWhitespaceInSwitchCase, undefined, switchCaseStat)
+                    this.buildLGDiagnostic(TemplateErrors.invalidWhitespaceInSwitchCase, undefined, switchCaseStat),
                 );
             }
 
             if (idx === 0 && !switchExpr) {
                 result.push(
-                    this.buildLGDiagnostic(TemplateErrors.notStartWithSwitchInSwitchCase, undefined, switchCaseStat)
+                    this.buildLGDiagnostic(TemplateErrors.notStartWithSwitchInSwitchCase, undefined, switchCaseStat),
                 );
             }
 
             if (idx > 0 && switchExpr) {
                 result.push(
-                    this.buildLGDiagnostic(TemplateErrors.multipleSwithStatementInSwitchCase, undefined, switchCaseStat)
+                    this.buildLGDiagnostic(
+                        TemplateErrors.multipleSwithStatementInSwitchCase,
+                        undefined,
+                        switchCaseStat,
+                    ),
                 );
             }
 
@@ -321,8 +326,8 @@ export class StaticChecker
                     this.buildLGDiagnostic(
                         TemplateErrors.invalidStatementInMiddlerOfSwitchCase,
                         undefined,
-                        switchCaseStat
-                    )
+                        switchCaseStat,
+                    ),
                 );
             }
 
@@ -332,8 +337,8 @@ export class StaticChecker
                         this.buildLGDiagnostic(
                             TemplateErrors.notEndWithDefaultInSwitchCase,
                             DiagnosticSeverity.Warning,
-                            switchCaseStat
-                        )
+                            switchCaseStat,
+                        ),
                     );
                 } else {
                     if (length === 2) {
@@ -341,8 +346,8 @@ export class StaticChecker
                             this.buildLGDiagnostic(
                                 TemplateErrors.missingCaseInSwitchCase,
                                 DiagnosticSeverity.Warning,
-                                switchCaseStat
-                            )
+                                switchCaseStat,
+                            ),
                         );
                     }
                 }
@@ -350,7 +355,7 @@ export class StaticChecker
             if (switchExpr || caseExpr) {
                 if (switchCaseStat.expression().length !== 1) {
                     result.push(
-                        this.buildLGDiagnostic(TemplateErrors.invalidExpressionInSwiathCase, undefined, switchCaseStat)
+                        this.buildLGDiagnostic(TemplateErrors.invalidExpressionInSwiathCase, undefined, switchCaseStat),
                     );
                 } else {
                     let errorPrefix = switchExpr ? 'Switch' : 'Case';
@@ -360,7 +365,7 @@ export class StaticChecker
             } else {
                 if (switchCaseStat.expression().length !== 0 || switchCaseStat.TEXT().length !== 0) {
                     result.push(
-                        this.buildLGDiagnostic(TemplateErrors.extraExpressionInSwitchCase, undefined, switchCaseStat)
+                        this.buildLGDiagnostic(TemplateErrors.extraExpressionInSwitchCase, undefined, switchCaseStat),
                     );
                 }
             }
@@ -372,8 +377,8 @@ export class StaticChecker
                         this.buildLGDiagnostic(
                             TemplateErrors.missingTemplateBodyInSwitchCase,
                             undefined,
-                            switchCaseStat
-                        )
+                            switchCaseStat,
+                        ),
                     );
                 }
             }
@@ -446,7 +451,7 @@ export class StaticChecker
     private buildLGDiagnostic(
         message: string,
         severity: DiagnosticSeverity = undefined,
-        context: ParserRuleContext = undefined
+        context: ParserRuleContext = undefined,
     ): Diagnostic {
         const lineOffset = this.currentTemplate !== undefined ? this.currentTemplate.sourceRange.range.start.line : 0;
 

--- a/libraries/botbuilder-lg/src/templateExtensions.ts
+++ b/libraries/botbuilder-lg/src/templateExtensions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 /**
  * @module botbuilder-lg
  */
@@ -188,7 +187,7 @@ export class TemplateExtensions {
         const startPosition = new Position(lineOffset + context.start.line, context.start.charPositionInLine);
         const stopPosition = new Position(
             lineOffset + context.stop.line,
-            context.stop.charPositionInLine + context.stop.text.length
+            context.stop.charPositionInLine + context.stop.text.length,
         );
 
         return new Range(startPosition, stopPosition);

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 /**
  * @module botbuilder-lg
  */
@@ -20,11 +19,10 @@ import {
     SimpleObjectMemory,
     ValueWithError,
 } from 'adaptive-expressions';
-import { ImportResolverDelegate, TemplatesTransformer } from './templatesParser';
+import { ImportResolverDelegate, TemplatesTransformer, TemplatesParser } from './templatesParser';
 import { Evaluator } from './evaluator';
 import { Expander } from './expander';
 import { Analyzer } from './analyzer';
-import { TemplatesParser } from './templatesParser';
 import { AnalyzerResult } from './analyzerResult';
 import { TemplateErrors } from './templateErrors';
 import { TemplateExtensions } from './templateExtensions';
@@ -133,7 +131,7 @@ export class Templates implements Iterable<Template> {
         importResolverDelegate?: ImportResolverDelegate,
         options?: string[],
         source?: string,
-        namedReferences?: Record<string, Templates>
+        namedReferences?: Record<string, Templates>,
     ) {
         this.items = items || [];
         this.imports = imports || [];
@@ -236,7 +234,7 @@ export class Templates implements Iterable<Template> {
     static parseFile(
         filePath: string,
         importResolver?: ImportResolverDelegate,
-        expressionParser?: ExpressionParser
+        expressionParser?: ExpressionParser,
     ): Templates {
         return TemplatesParser.parseFile(filePath, importResolver, expressionParser).injectToExpressionFunction();
     }
@@ -255,7 +253,7 @@ export class Templates implements Iterable<Template> {
         content: string,
         id = '',
         importResolver?: ImportResolverDelegate,
-        expressionParser?: ExpressionParser
+        expressionParser?: ExpressionParser,
     ): Templates {
         return TemplatesParser.parseText(content, id, importResolver, expressionParser).injectToExpressionFunction();
     }
@@ -271,7 +269,7 @@ export class Templates implements Iterable<Template> {
     static parseResource(
         resource: LGResource,
         importResolver?: ImportResolverDelegate,
-        expressionParser?: ExpressionParser
+        expressionParser?: ExpressionParser,
     ): Templates {
         return TemplatesParser.parseResource(resource, importResolver, expressionParser).injectToExpressionFunction();
     }
@@ -373,7 +371,7 @@ export class Templates implements Iterable<Template> {
         templateName: string,
         newTemplateName: string,
         parameters: string[],
-        templateBody: string
+        templateBody: string,
     ): Templates {
         const template: Template = this.items.find((u: Template): boolean => u.name === templateName);
         if (template) {
@@ -388,7 +386,7 @@ export class Templates implements Iterable<Template> {
                 this.content,
                 template.sourceRange.range.start.line - 1,
                 template.sourceRange.range.end.line - 1,
-                content
+                content,
             );
 
             let updatedTemplates = new Templates();
@@ -399,7 +397,7 @@ export class Templates implements Iterable<Template> {
 
             const resource = new LGResource(this.id, this.id, content);
             updatedTemplates = new TemplatesTransformer(updatedTemplates).transform(
-                TemplatesParser.antlrParseTemplates(resource)
+                TemplatesParser.antlrParseTemplates(resource),
             );
 
             const originalStartLine = template.sourceRange.range.start.line - 1;
@@ -447,7 +445,7 @@ export class Templates implements Iterable<Template> {
 
         const resource = new LGResource(this.id, this.id, content);
         updatedTemplates = new TemplatesTransformer(updatedTemplates).transform(
-            TemplatesParser.antlrParseTemplates(resource)
+            TemplatesParser.antlrParseTemplates(resource),
         );
 
         this.appendDiagnosticWithOffset(updatedTemplates.diagnostics, originalStartLine);
@@ -584,7 +582,7 @@ export class Templates implements Iterable<Template> {
         originString: string,
         startLine: number,
         stopLine: number,
-        replaceString: string
+        replaceString: string,
     ): string {
         const originList: string[] = TemplateExtensions.readLine(originString);
         if (startLine < 0 || startLine > stopLine || stopLine >= originList.length) {
@@ -694,8 +692,8 @@ export class Templates implements Iterable<Template> {
 
                                 return { value, error };
                             },
-                            ReturnType.Object
-                        )
+                            ReturnType.Object,
+                        ),
                     );
                 }
             }

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable security/detect-object-injection */
-/* eslint-disable security/detect-non-literal-fs-filename */
 const {
     Templates,
     LGLineBreakStyle,
@@ -150,7 +148,7 @@ describe('LG', function () {
         assert.strictEqual(
             evaled.replace(/\r\n/g, '\n'),
             'markdown\n## Manage the knowledge base\n',
-            `Evaled is ${evaled}`
+            `Evaled is ${evaled}`,
         );
 
         evaled = templates.evaluate('template4').toString();
@@ -310,7 +308,7 @@ describe('LG', function () {
         assert.strictEqual(
             evaled,
             'Your most recent task is Task1. You can let me know if you want to add or complete a task.',
-            `Evaled is ${evaled}`
+            `Evaled is ${evaled}`,
         );
     });
 
@@ -379,7 +377,7 @@ describe('LG', function () {
         evaled = templates.evaluate('showTodo', { todos: ['A', 'B', 'C'] });
         assert.strictEqual(
             evaled.replace(/\r\n/g, '\n'),
-            '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    '
+            '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ',
         );
 
         evaled = templates.evaluate('showTodo', undefined);
@@ -529,7 +527,7 @@ describe('LG', function () {
         const resource = new LGResource(
             GetExampleFilePath('xx.lg'),
             GetExampleFilePath('xx.lg'),
-            '[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n'
+            '[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n',
         );
         templates = Templates.parseResource(resource);
 
@@ -751,13 +749,13 @@ describe('LG', function () {
         evaled = templates.expandTemplate('showTodo', { todos });
         assert.strictEqual(
             evaled[0].toString().replace(/\r\n/g, '\n'),
-            '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    '
+            '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ',
         );
 
         evaled = templates.expandTemplate('showTodo');
         assert.strictEqual(
             evaled[0].toString().replace(/\r\n/g, '\n'),
-            '\n    You don\'t have any "t\\\\odo\'".\n    '
+            '\n    You don\'t have any "t\\\\odo\'".\n    ',
         );
 
         evaled = templates.expandTemplate('getUserName');
@@ -801,11 +799,11 @@ describe('LG', function () {
             (err) => {
                 assert(
                     err.message.includes(
-                        "'variable_not_defined' evaluated to null. [StrictTrue]  Error occurred when evaluating '-${variable_not_defined}'"
-                    )
+                        "'variable_not_defined' evaluated to null. [StrictTrue]  Error occurred when evaluating '-${variable_not_defined}'",
+                    ),
                 );
                 return true;
-            }
+            },
         );
     });
 
@@ -825,7 +823,7 @@ describe('LG', function () {
             (err) => {
                 assert(err.message.includes("it's not a built-in function or a custom function"));
                 return true;
-            }
+            },
         );
     });
 
@@ -951,7 +949,7 @@ describe('LG', function () {
             'newtemplate2',
             'newtemplateName2',
             ['newtemplate2', 'newtemplateName2'],
-            '- new hi\r\n#hi2\r\n'
+            '- new hi\r\n#hi2\r\n',
         );
         assert.strictEqual(templates.toArray().length, 4);
         assert.strictEqual(templates.imports.length, 0);
@@ -1013,7 +1011,7 @@ describe('LG', function () {
         // add an exist template
         assert.throws(
             () => templates.addTemplate('newtemplate', undefined, '- hi2 '),
-            new Error(TemplateErrors.templateExist('newtemplate'))
+            new Error(TemplateErrors.templateExist('newtemplate')),
         );
     });
 
@@ -1112,7 +1110,7 @@ describe('LG', function () {
         let evaled = templates.evaluate('T1', { turn: { name: 'Dong', count: 3 } });
         assert.strictEqual(
             evaled,
-            'Hi Dong, welcome to Seattle, Seattle is a beautiful place, how many burgers do you want, 3?'
+            'Hi Dong, welcome to Seattle, Seattle is a beautiful place, how many burgers do you want, 3?',
         );
 
         const objscope = {
@@ -1138,25 +1136,25 @@ describe('LG', function () {
         if (evaled.text.includes('how old')) {
             assert.deepStrictEqual(
                 evaled,
-                JSON.parse('{"lgType":"Activity","text":"how old are you?","suggestedactions":["10","20","30"]}')
+                JSON.parse('{"lgType":"Activity","text":"how old are you?","suggestedactions":["10","20","30"]}'),
             );
         } else {
             assert.deepStrictEqual(
                 evaled,
-                JSON.parse('{"lgType":"Activity","text":"what\'s your age?","suggestedactions":["10","20","30"]}')
+                JSON.parse('{"lgType":"Activity","text":"what\'s your age?","suggestedactions":["10","20","30"]}'),
             );
         }
 
         evaled = templates.evaluate('AskForAge.prompt3');
         assert.deepStrictEqual(
             evaled,
-            JSON.parse('{"lgType":"Activity","text":"${GetAge()}","suggestions":["10 | cards","20 | cards"]}')
+            JSON.parse('{"lgType":"Activity","text":"${GetAge()}","suggestions":["10 | cards","20 | cards"]}'),
         );
 
         evaled = templates.evaluate('T1');
         assert.deepStrictEqual(
             evaled,
-            JSON.parse('{"lgType":"Activity","text":"This is awesome","speak":"hello world I can also speak!"}')
+            JSON.parse('{"lgType":"Activity","text":"This is awesome","speak":"hello world I can also speak!"}'),
         );
 
         evaled = templates.evaluate('ST1');
@@ -1166,14 +1164,14 @@ describe('LG', function () {
         assert.deepStrictEqual(
             evaled,
             JSON.parse(
-                '{"lgType":"Activity","suggestedactions":[{"lgType":"MyStruct","speak":"beta","text":"food"},{"lgType":"Activity","speak":"I can also speak!"}]}'
-            )
+                '{"lgType":"Activity","suggestedactions":[{"lgType":"MyStruct","speak":"beta","text":"food"},{"lgType":"Activity","speak":"I can also speak!"}]}',
+            ),
         );
 
         evaled = templates.evaluate('MultiExpression');
         assert.strictEqual(
             evaled,
-            '{"lgType":"Activity","speak":"I can also speak!"} {"lgType":"MyStruct","text":"hi"}'
+            '{"lgType":"Activity","speak":"I can also speak!"} {"lgType":"MyStruct","text":"hi"}',
         );
 
         evaled = templates.evaluate('StructuredTemplateRef');
@@ -1183,8 +1181,8 @@ describe('LG', function () {
         assert.deepStrictEqual(
             evaled,
             JSON.parse(
-                '{"lgType":"MyStruct","list":[{"lgType":"SubStruct","text":"hello"},{"lgType":"SubStruct","text":"world"}]}'
-            )
+                '{"lgType":"MyStruct","list":[{"lgType":"SubStruct","text":"hello"},{"lgType":"SubStruct","text":"world"}]}',
+            ),
         );
 
         evaled = templates.evaluate('templateWithSquareBrackets', { manufacturer: { Name: 'Acme Co' } });
@@ -1193,7 +1191,7 @@ describe('LG', function () {
         evaled = templates.evaluate('ValueWithEqualsMark', { name: 'Jack' });
         assert.deepStrictEqual(
             evaled,
-            JSON.parse('{"lgType":"Activity","text":"Hello! welcome back. I have your name = Jack"}')
+            JSON.parse('{"lgType":"Activity","text":"Hello! welcome back. I have your name = Jack"}'),
         );
     });
 
@@ -1649,13 +1647,13 @@ describe('LG', function () {
         ({ value: evaled, error } = Expression.parse('common.countTotal()').tryEvaluate(scope1));
         assert.strictEqual(
             error,
-            "list1 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'."
+            "list1 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'.",
         );
 
         ({ value: evaled, error } = Expression.parse('common.countTotal(a, b, c)').tryEvaluate(scope1));
         assert.strictEqual(
             error,
-            "list2 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'."
+            "list2 is not a list or array. [countTotal]  Error occurred when evaluating '-${count(union(list1,list2))}'.",
         );
 
         const scope2 = { i: 1, j: 2, k: 3, l: 4 };

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -131,14 +131,14 @@ describe('LGExceptionTest', function () {
         assert.strictEqual(diagnostics[2].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[2].message.includes(
-                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator",
+            ),
         );
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[3].severity);
         assert(
             diagnostics[3].message.includes(
-                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator",
+            ),
         );
         assert.strictEqual(diagnostics[4].severity, DiagnosticSeverity.Error);
         assert(diagnostics[4].message.includes(TemplateErrors.invalidStrucName('Activity%')));
@@ -193,14 +193,14 @@ describe('LGExceptionTest', function () {
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[0].message.includes(
-                "Error occurred when parsing expression 'NotExistTemplate()'. NotExistTemplate does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'NotExistTemplate()'. NotExistTemplate does not have an evaluator",
+            ),
         );
         assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[1].message.includes(
-                "Error occurred when parsing expression 'template5('hello', 'world')'. arguments mismatch for template 'template5'. Expecting '1' arguments, actual '2'"
-            )
+                "Error occurred when parsing expression 'template5('hello', 'world')'. arguments mismatch for template 'template5'. Expecting '1' arguments, actual '2'",
+            ),
         );
     });
 
@@ -240,20 +240,20 @@ describe('LGExceptionTest', function () {
         assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[0].message.includes(
-                "Error occurred when parsing expression 'templateRef()'. templateRef does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'templateRef()'. templateRef does not have an evaluator",
+            ),
         );
         assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[1].message.includes(
-                "Error occurred when parsing expression 'templateRef(a)'. templateRef does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'templateRef(a)'. templateRef does not have an evaluator",
+            ),
         );
         assert.strictEqual(diagnostics[2].severity, DiagnosticSeverity.Error);
         assert(
             diagnostics[2].message.includes(
-                "Error occurred when parsing expression 'templateRefInMultiLine()'. templateRefInMultiLine does not have an evaluator"
-            )
+                "Error occurred when parsing expression 'templateRefInMultiLine()'. templateRefInMultiLine does not have an evaluator",
+            ),
         );
     });
 
@@ -297,8 +297,8 @@ describe('LGExceptionTest', function () {
         assert.throws(
             () => templates.evaluate('wPhrase'),
             new Error(
-                "Loop detected: welcome_user => wPhrase [wPhrase]  Error occurred when evaluating '-${wPhrase()}'. [welcome_user]  Error occurred when evaluating '-${welcome_user()}'."
-            )
+                "Loop detected: welcome_user => wPhrase [wPhrase]  Error occurred when evaluating '-${wPhrase()}'. [welcome_user]  Error occurred when evaluating '-${welcome_user()}'.",
+            ),
         );
 
         // Without ThrowOnRecursive does not throw exception when loop is detected
@@ -313,18 +313,19 @@ describe('LGExceptionTest', function () {
         // ThrowOnRecursive throws InvalidOperationException
         assert.throws(
             () => templates.analyzeTemplate('wPhrase', { ThrowOnRecursive: true }),
-            new Error('Loop detected: welcome_user,wPhrase => wPhrase')
+            new Error('Loop detected: welcome_user,wPhrase => wPhrase'),
         );
 
         assert.throws(
             () => templates.analyzeTemplate('selfLoop', { ThrowOnRecursive: true }),
-            new Error('Loop detected: selfLoop => selfLoop')
+            new Error('Loop detected: selfLoop => selfLoop'),
         );
     });
 
     it('AddTextWithWrongId', function () {
-        const diagnostics = Templates.parseResource(new LGResource('a.lg', 'a.lg', '[import](xx.lg) \r\n # t \n - hi'))
-            .diagnostics;
+        const diagnostics = Templates.parseResource(
+            new LGResource('a.lg', 'a.lg', '[import](xx.lg) \r\n # t \n - hi'),
+        ).diagnostics;
         assert.strictEqual(diagnostics.length, 1);
         assert(diagnostics[0].message.includes('Could not find file'));
     });
@@ -334,8 +335,8 @@ describe('LGExceptionTest', function () {
         assert.throws(
             () => templates.evaluate('template1'),
             new Error(
-                "first(createArray(1, 2)) is neither a string nor a null object. [template1]  Error occurred when evaluating '-${length(first(createArray(1,2)))}'."
-            )
+                "first(createArray(1, 2)) is neither a string nor a null object. [template1]  Error occurred when evaluating '-${length(first(createArray(1,2)))}'.",
+            ),
         );
     });
 
@@ -345,71 +346,71 @@ describe('LGExceptionTest', function () {
         assert.throws(
             () => templates.evaluate('template1'),
             new Error(
-                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'."
-            )
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('prebuilt1'),
             new Error(
-                "'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'."
-            )
+                "'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('template2'),
             new Error(
-                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'."
-            )
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('conditionalTemplate1', { dialog: true }),
             new Error(
-                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'."
-            )
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('conditionalTemplate2'),
             new Error(
-                "'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'."
-            )
+                "'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('structured1'),
             new Error(
-                "'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'."
-            )
+                "'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('structured2'),
             new Error(
-                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'."
-            )
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('structured3'),
             new Error(
-                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'."
-            )
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('switchcase1', { turn: { testValue: 1 } }),
             new Error(
-                "'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'."
-            )
+                "'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'.",
+            ),
         );
 
         assert.throws(
             () => templates.evaluate('switchcase2', { turn: { testValue: 0 } }),
             new Error(
-                "'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'."
-            )
+                "'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'.",
+            ),
         );
     });
 
@@ -424,13 +425,14 @@ describe('LGExceptionTest', function () {
         assert.strictEqual(diagnostics.length, 1);
         assert(diagnostics[0].message.includes('Close } is missing in Expression'));
 
-        diagnostics = Templates.parseResource(new LGResource('', '', '#Demo2\r\n- ${createArray(1,\r\n, 2,3)'))
-            .diagnostics;
+        diagnostics = Templates.parseResource(
+            new LGResource('', '', '#Demo2\r\n- ${createArray(1,\r\n, 2,3)'),
+        ).diagnostics;
         assert.strictEqual(diagnostics.length, 1);
         assert(diagnostics[0].message.includes('Close } is missing in Expression'));
 
         diagnostics = Templates.parseResource(
-            new LGResource('', '', '#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment')
+            new LGResource('', '', '#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment'),
         ).diagnostics;
         assert.strictEqual(diagnostics.length, 1);
         assert(diagnostics[0].message.includes('Close } is missing in Expression'));

--- a/libraries/botbuilder-lg/tests/multilanguageLG.test.js
+++ b/libraries/botbuilder-lg/tests/multilanguageLG.test.js
@@ -23,7 +23,7 @@ describe('MultilanguageLGTest', function () {
         SpecificFallbackLocale2: (function () {
             const enTemplates = Templates.parseResource(
                 new LGResource('abc', 'abc', '[import](1.lg)\r\n # template\r\n - hi'),
-                defaultFileResolver
+                defaultFileResolver,
             );
             const templatesDict = new Map();
             templatesDict.set('en', enTemplates);


### PR DESCRIPTION
Addresses # 4684
#minor

## Description
This PR fixes the new ESLint errors and warnings that occur after upgrading the ESLint packages in the **_botbuilder-lg_** project.

## Specific Changes
  - Removed the 'only-warnings' plugin from 'botbuilder-lg/eslint.config.cjs' file and the related dependency.
  - Applied the auto fix flag for most issues (spacing, trailing commas, indentation, and removal of unnecessary eslint exceptions). 
  - Applied manual fixes for new rules like 'no-require-imports'.

## Testing
The following images show the number of issues fixed in the library and the tests passing after the changes.
![image](https://github.com/user-attachments/assets/76f11e9c-7648-470a-ac0e-e6620ea558b6)