### PR TITLE
fix: Workspaces for update-versions script

### DIFF
--- a/libraries/botbuilder-repo-utils/src/package.ts
+++ b/libraries/botbuilder-repo-utils/src/package.ts
@@ -11,7 +11,7 @@ export interface Package {
     deprecated?: boolean;
     internal?: boolean;
 
-    workspaces?: string[];
+    workspaces?: { packages: string[] };
 
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;

--- a/libraries/botbuilder-repo-utils/src/updateVersions.ts
+++ b/libraries/botbuilder-repo-utils/src/updateVersions.ts
@@ -95,7 +95,7 @@ export const command = (argv: string[], quiet = false) => async (): Promise<Resu
     const commitSha = JSON.parse(flags.git) ? await gitSha('HEAD') : undefined;
 
     // Collect all workspaces from the repo root. Returns workspaces with absolute paths.
-    const workspaces = await collectWorkspacePackages(repoRoot, packageFile.workspaces);
+    const workspaces = await collectWorkspacePackages(repoRoot, packageFile.workspaces?.packages);
 
     // Build an object mapping a package name to its new, updated version
     const workspaceVersions = workspaces.reduce<Record<string, string>>(

--- a/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
+++ b/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
@@ -169,7 +169,7 @@ describe('updateVersions', function () {
                 dependsOn?: string[];
             }>,
             args: string[] = [],
-            { commitSha = '' } = {}
+            { commitSha = '' } = {},
         ) => {
             const root = 'root';
 
@@ -200,7 +200,7 @@ describe('updateVersions', function () {
                 .withArgs(path.join(root, 'package.json'))
                 .resolves({
                     version: packageVersion,
-                    workspaces: workspacePaths.map((workspace) => path.posix.join(...workspace.relPath)),
+                    workspaces: { packages: workspacePaths.map((workspace) => path.posix.join(...workspace.relPath)) },
                 });
 
             sandbox
@@ -219,14 +219,14 @@ describe('updateVersions', function () {
                         deprecated: workspace.deprecated,
                         dependencies: (workspace.dependsOn ?? []).reduce(
                             (acc, name) => ({ ...acc, [name]: dummyVersion }),
-                            {}
+                            {},
                         ),
                     });
 
                 let packageMatch = sinon.match.hasOwn('version', workspace.expectedVersion);
                 if (workspace.expectedDependencies) {
                     packageMatch = packageMatch.and(
-                        sinon.match.hasOwn('dependencies', sinon.match(workspace.expectedDependencies))
+                        sinon.match.hasOwn('dependencies', sinon.match(workspace.expectedDependencies)),
                     );
                 }
 
@@ -300,7 +300,7 @@ describe('updateVersions', function () {
                         },
                     },
                 ],
-                [expectedVersion]
+                [expectedVersion],
             );
         });
 
@@ -339,8 +339,37 @@ describe('updateVersions', function () {
                     },
                 ],
                 ['--buildLabel', 'dev', '--git', 'true', '--date', dateFormat],
-                { commitSha: 'COMMIT' }
+                { commitSha: 'COMMIT' },
             );
+        });
+
+        it('runs properly', async function () {
+            const writeFileStub = sandbox.stub(file, 'writeJsonFile').returns(Promise.resolve());
+            const version = '4.24.0';
+            await command(
+                [
+                    version,
+                    '--buildLabel',
+                    'dev',
+                    '--internal',
+                    'internal',
+                    '--preview',
+                    'preview',
+                    '--deprecated',
+                    'deprecated',
+                    '--date',
+                    'YYYYMMDD',
+                    '--git',
+                    'false',
+                ],
+                true,
+            )();
+
+            assert.ok(writeFileStub.called);
+            const packagesAssertion = (writeFileStub.args as [string, Package][])
+                .filter(([, pkg]) => !pkg.private)
+                .every(([, pkg]) => pkg.version.startsWith(version));
+            assert.ok(packagesAssertion);
         });
     });
 });


### PR DESCRIPTION
#minor

## Description
This PR fixes an issue with the update-versions script that didn't work with the latest workspaces changes.

## Specific Changes
  - Changed workspaces type to use packages property instead of an array.
  - Added unit tests to check if the command is running properly without altering the existing package.json files (using sinon).

## Testing
The following image shows the script working, and the new unit test.
![image](https://github.com/user-attachments/assets/fb233754-0422-4f4a-b065-fc11c658955f)
![image](https://github.com/user-attachments/assets/396bd283-7af5-412a-9400-55a3a1fe674b)

