### PR TITLE
fix: Add deprecated attribute to MsalServiceClientCredentialsFactory class

### DIFF
--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -12,7 +12,9 @@ import { AuthenticationConstants } from './authenticationConstants';
 import { GovernmentConstants } from './governmentConstants';
 
 /**
- * An implementation of ServiceClientCredentialsFactory that generates MsalAppCredentials
+ * An implementation of ServiceClientCredentialsFactory that generates MsalAppCredentials.
+ *
+ * @deprecated Use the ServiceClientCredentialsFactory implementation that corresponds to the authentication type (MSI, Certificate, Federated, etc.).
  */
 export class MsalServiceClientCredentialsFactory implements ServiceClientCredentialsFactory {
     private readonly appId: string;


### PR DESCRIPTION
#minor

## Description
This PR adds the deprecated attribute to the _**MsalServiceClientCredentialsFactory**_ class, so users opt to use one of the other factory classes depending on the type of authentication they use (_ConfigurationServiceClientCredentialFactory_, _CertificateServiceClientCredentialsFactory_, _FederatedServiceClientCredentialsFactory_, etc).

## Specific Changes
- Update _MsalServiceClientCredentialsFactory_ to add the deprecated attribute.

## Testing
This image shows the class marked as deprecated.
![image](https://github.com/user-attachments/assets/5eccc5de-ea25-4906-ba85-8db500743674)
