### PR TITLE
feat: Update versions for generators

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "^4.23.1",
-        "botbuilder-ai": "^4.23.1",
-        "botbuilder-dialogs": "^4.23.1",
-        "botbuilder-testing": "^4.23.1",
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6",
+        "botbuilder-testing": "4.1.6",
         "dotenv": "^8.2.0",
         "restify": "^11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -38,22 +38,23 @@
     },
     "dependencies": {
       "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-      "botbuilder": "^4.23.1",
-      "botbuilder-ai": "^4.23.1",
-      "botbuilder-dialogs": "^4.23.1",
-      "botbuilder-testing": "^4.23.1",
+      "botbuilder": "4.1.6",
+      "botbuilder-ai": "4.1.6",
+      "botbuilder-dialogs": "4.1.6",
+      "botbuilder-testing": "4.1.6",
       "dotenv": "^8.2.0",
       "replace": "~1.2.0",
       "restify": "~11.1.0"
 },
   "devDependencies": {
       "@types/mocha": "^7.0.2",
+      "@types/node": "^18.19.47",
       "@types/restify": "8.4.2",
       "mocha": "^7.1.2",
       "nodemon": "^2.0.4",
       "nyc": "^15.0.1",
       "ts-node": "^8.10.1",
       "tslint": "^6.1.2",
-      "typescript": "^4.0.7"
+      "typescript": "^4.9.3"
   }
 }

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "^4.23.1,
-        "botbuilder-ai": "^4.23.1",
-        "botbuilder-dialogs": "^4.23.1",
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6",
         "dotenv": "~8.2.0",
         "restify": "~11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -19,21 +19,22 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "^4.23.1",
-        "botbuilder-ai": "^4.23.1",
-        "botbuilder-dialogs": "^4.23.1",
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.2",
+        "@types/node": "^18.19.47",
         "@types/restify": "8.4.2",
         "mocha": "^7.1.2",
         "nodemon": "^2.0.4",
         "nyc": "^15.0.1",
         "ts-node": "^8.10.1",
         "tslint": "^6.1.2",
-        "typescript": "^4.0.7"
+        "typescript": "^4.9.3"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
@@ -3,13 +3,15 @@
     "composite": true,
     "declaration": true,
     "target": "es2017",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "resolveJsonModule": true,
     "rootDirs": ["./src", "./resources"],
     "sourceMap": true,
     "incremental": true,
-    "tsBuildInfoFile": "./lib/.tsbuildinfo"
+    "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "esModuleInterop": true
   }
 }

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "^4.23.1",
+        "botbuilder": "4.1.6",
         "dotenv": "~8.2.0",
         "restify": "~11.1.0"
     },

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -18,15 +18,16 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.23.1",
+        "botbuilder": "4.1.6",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },
     "devDependencies": {
+        "@types/node": "^18.19.47",
         "@types/restify": "8.4.2",
         "nodemon": "^2.0.4",
         "tslint": "^6.1.2",
-        "typescript": "^4.0.7"
+        "typescript": "^4.9.3"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/echo/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/echo/tsconfig.json
@@ -2,11 +2,13 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2017",
-    "module": "commonjs",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,
     "incremental": true,
-    "tsBuildInfoFile": "./lib/.tsbuildinfo"
+    "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "esModuleInterop": true
   }
 }

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "^4.23.1",
+        "botbuilder": "4.1.6",
         "restify": "~11.1.0"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -1,6 +1,6 @@
 {
     "name": "<%= botname %>",
-    "version": "1.0.0",
+    "version": "4.1.6",
     "description": "<%= botDescription %>",
     "author": "Generated using Microsoft Bot Builder Yeoman generator v<%= version %>",
     "license": "MIT",
@@ -18,14 +18,15 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "^4.23.1",
+        "botbuilder": "4.1.6",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },
     "devDependencies": {
+        "@types/node": "^18.19.47",
         "@types/restify": "8.4.2",
         "nodemon": "^2.0.4",
         "tslint": "^6.1.2",
-        "typescript": "^4.0.7"
+        "typescript": "^4.9.3"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/empty/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/empty/tsconfig.json
@@ -2,11 +2,13 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2017",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,
     "incremental": true,
-    "tsBuildInfoFile": "./lib/.tsbuildinfo"
+    "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "esModuleInterop": true
   }
 }

--- a/libraries/botbuilder-repo-utils/src/package.ts
+++ b/libraries/botbuilder-repo-utils/src/package.ts
@@ -11,7 +11,7 @@ export interface Package {
     deprecated?: boolean;
     internal?: boolean;
 
-    workspaces?: { packages: string[] };
+    workspaces?: { packages: string[]; generators: string[] };
 
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;

--- a/libraries/botbuilder-repo-utils/src/updateVersions.ts
+++ b/libraries/botbuilder-repo-utils/src/updateVersions.ts
@@ -94,8 +94,13 @@ export const command = (argv: string[], quiet = false) => async (): Promise<Resu
     // Read git commit sha if instructed (JSON.parse properly coerces strings to boolean)
     const commitSha = JSON.parse(flags.git) ? await gitSha('HEAD') : undefined;
 
+        const projects: string[] = [
+            ...(packageFile.workspaces?.packages || []),
+            ...(packageFile.workspaces?.generators || []),
+        ];
+
     // Collect all workspaces from the repo root. Returns workspaces with absolute paths.
-    const workspaces = await collectWorkspacePackages(repoRoot, packageFile.workspaces?.packages);
+        const workspaces = await collectWorkspacePackages(repoRoot, projects);
 
     // Build an object mapping a package name to its new, updated version
     const workspaceVersions = workspaces.reduce<Record<string, string>>(

--- a/libraries/botbuilder-repo-utils/src/updateVersions.ts
+++ b/libraries/botbuilder-repo-utils/src/updateVersions.ts
@@ -100,7 +100,7 @@ export const command = (argv: string[], quiet = false) => async (): Promise<Resu
         ];
 
     // Collect all workspaces from the repo root. Returns workspaces with absolute paths.
-        const workspaces = await collectWorkspacePackages(repoRoot, projects);
+    const workspaces = await collectWorkspacePackages(repoRoot, projects);
 
     // Build an object mapping a package name to its new, updated version
     const workspaceVersions = workspaces.reduce<Record<string, string>>(

--- a/libraries/botbuilder-repo-utils/src/workspace.ts
+++ b/libraries/botbuilder-repo-utils/src/workspace.ts
@@ -41,7 +41,11 @@ export async function collectWorkspacePackages(
     filters: Partial<Filters> = {}
 ): Promise<Array<Workspace>> {
     // Note: posix is required, this emits absolute paths that are platform specific
-    const paths = await glob(workspaces.map((workspace) => path.posix.join(repoRoot, workspace, 'package.json')));
+    const paths = await glob(
+        workspaces.map((workspace) =>
+            path.posix.join(repoRoot, workspace, '{package.json,package-with-tests.json}{,.js,.ts}'),
+        ),
+    );
 
     const maybeWorkspaces = await Promise.all(
         paths.map(

--- a/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
+++ b/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
@@ -189,8 +189,8 @@ describe('updateVersions', function () {
                 return {
                     ...workspace,
                     relPath,
-                    absPath: path.join(root, ...relPath, 'package.json'),
-                    posixPath: path.posix.join(root, ...relPath, 'package.json'),
+                    absPath: path.join(root, ...relPath, '{package.json,package-with-tests.json}{,.js,.ts}'),
+                    posixPath: path.posix.join(root, ...relPath, '{package.json,package-with-tests.json}{,.js,.ts}'),
                 };
             });
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "workspaces": {
     "packages": [
       "libraries/*",
-      "libraries/functional-tests/dialogToDialog/*",
-      "libraries/testskills/*",
       "testing/*",
       "testing/browser-functional/browser-echo-bot",
-      "tools",
-      "transcripts"
+      "tools"
+    ],
+    "generators": [
+      "generators/generator-botbuilder/generators/app/templates/*"
     ],
     "nohoist": [
       "**/@types/selenium-webdriver"


### PR DESCRIPTION
#minor

## Description
This PR includes the generators' templates to be updated by the **_update-versions_** script by including them in the _workspaces_ list.
It also updates the versions in the _package.json_ file to match the one used in the libraries (4.1.6) and upgrades some dependencies in the TS bots to fix errors found when building the generated bots.

## Specific Changes
- Changed botbuilder dependencies' version to 4.1.6 in all bots' templates.
- Updated TS bots by adding the _types/node_ package and upgrading _typescript_ dependency to version 4.9.3. Also, updated _tsconfig_ files updating the _module_ and adding _moduleResolution_ and _esModuleInterop_ properties.
- Added the _'generators/generator-botbuilder/generators/app/templates/'_ path to workspaces in the _package.json_ file.
- Updated _updateVersions_, _workspace_, and _package_ files to include the new projects in the script.

## Testing
These images show the updated version in the bots and the bots working with the changes.
![image](https://github.com/user-attachments/assets/62d501c0-b893-42cf-b9ab-798da2b46d31)
![image](https://github.com/user-attachments/assets/2d58e818-055e-4158-aa88-8663cf381b4e)
