### PR TITLE
port: [#6861]TeamsSSOTokenExchangeMiddleware.DeduplicatedTokenExchangeIdAsync fails on BlobStorage ETag validation

### DIFF
--- a/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsStorage.test.js
@@ -53,6 +53,21 @@ describe('BlobsStorage', function () {
         maybeIt('should write a set of values', async () => {
             await client.write({ foo, bar });
         });
+
+        maybeIt('should fail with eTag conflict error', async () => {
+            const changes = {
+                item1: {
+                    key1: 'value1',
+                    eTag: 'etag1',
+                },
+                item2: {
+                    key2: 'value2',
+                    eTag: 'etag1',
+                },
+            };
+
+            await assert.rejects(() => client.write(changes), 'Storage: error writing "item2" due to eTag conflict.');
+        });
     });
 
     describe('delete()', function () {


### PR DESCRIPTION
#minor

## Description
This PR ports the changes from [BotBuilder-DotNet's PR#6867](https ://github.com/microsoft/botbuilder-dotnet/pull/ 6867) to handle eTag conflicts on concurrent calls to the **_BlobsStorage_** _write_ method.

## Specific Changes
- Added a try-catch block to handle the 412 error code in the _write_ method of _BlobsStorage_ class.
- Added a unit test to cover this scenario in _blobsStorage.tests.js_.

## Testing
This image shows the new unit tests working.
![image](https://github.com/user-attachments/assets/73e910c5-999b-44f7-afee-5ab7bb6e953d)