### PR TITLE
fix: Run the coveralls step only for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn test:github
 
       - name: coveralls
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '22.x' && matrix.os == 'windows'
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#minor

## Description
This PR updates the test GitHub action to run the coveralls step only for Windows due to a change in coveralls.io ([issue](https://github.com/lemurheavy/coveralls-public/issues/1716#issuecomment-1588043075))

## Specific Changes
- Updated tests.yml to run coveralls step only for Windows os.

## Testing
This image shows the tests passing.
![image](https://github.com/user-attachments/assets/2b0d5bea-8103-47dd-b247-74e4124c8bf3)
