### PR TITLE
fix: Remaining CodeQL issues

### DIFF
--- a/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
@@ -39,7 +39,8 @@ const getSettings = (test = null) => {
         databaseId: 'CosmosPartitionedStorageTestDb',
         containerId: `CosmosPartitionedStorageTestContainer-${testId}`,
         cosmosClientOptions: {
-            agent: new https.Agent({ rejectUnauthorized: false }), // rejectUnauthorized disables the SSL verification for the locally-hosted Emulator
+            // rejectUnauthorized disables the SSL verification for the locally-hosted Emulator
+            agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
         },
     };
 };
@@ -53,7 +54,7 @@ const checkEmulator = async () => {
         } else {
             try {
                 const agent = new https.Agent({
-                    rejectUnauthorized: false,
+                    rejectUnauthorized: false, // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
                 });
                 await fetch(emulatorEndpoint, { agent });
                 canConnectToEmulator = true;
@@ -84,7 +85,7 @@ const cleanup = async () => {
         const client = new CosmosClient({
             endpoint: settings.cosmosDbEndpoint,
             key: settings.authKey,
-            agent: new https.Agent({ rejectUnauthorized: false }),
+            agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
         });
         try {
             await client.database(settings.databaseId).delete();
@@ -111,7 +112,7 @@ const prep = async function () {
         const client = new CosmosClient({
             endpoint: settings.cosmosDbEndpoint,
             key: settings.authKey,
-            agent: new https.Agent({ rejectUnauthorized: false }),
+            agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
         });
 
         // This throws if the db is already created. We want to always create it if it doesn't exist,
@@ -190,7 +191,7 @@ describe('CosmosDbPartitionedStorage', function () {
 
             const settingsWithClientOptions = getSettings(this.test);
             settingsWithClientOptions.cosmosClientOptions = {
-                agent: new https.Agent({ rejectUnauthorized: false }),
+                agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
                 connectionPolicy: { requestTimeout: 999 },
                 userAgentSuffix: 'test',
             };
@@ -209,7 +210,7 @@ describe('CosmosDbPartitionedStorage', function () {
 
             const settingsWithClientOptions = getSettings(this.test);
             settingsWithClientOptions.cosmosClientOptions = {
-                agent: new https.Agent({ rejectUnauthorized: false }),
+                agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
                 connectionPolicy: { requestTimeout: 999 },
             };
 
@@ -340,7 +341,7 @@ describe('CosmosDbPartitionedStorage', function () {
             const dbCreateClient = new CosmosClient({
                 endpoint: settingsWithNewDb.cosmosDbEndpoint,
                 key: settingsWithNewDb.authKey,
-                agent: new https.Agent({ rejectUnauthorized: false }),
+                agent: new https.Agent({ rejectUnauthorized: false }), // CodeQL [SM03616]  Used only in tests with local cosmosdb emulator
             });
             try {
                 await dbCreateClient.database(newDb).delete();

--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -133,6 +133,6 @@ export function calculateChangeHash(item: StoreItem): string {
 
     const result = stringify(rest);
     const hash = createHash('sha256', { encoding: 'utf-8' });
-    const hashed = hash.update(result).digest('hex');
+    const hashed = hash.update(result).digest('hex'); // CodeQL [SM01511] We are not hashing a password or any user input here.
     return hashed;
 }

--- a/libraries/botframework-connector/src/auth/jwtTokenProviderFactory.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenProviderFactory.ts
@@ -31,6 +31,6 @@ export class JwtTokenProviderFactory implements IJwtTokenProviderFactory {
     createAzureServiceTokenProvider(appId: string): DefaultAzureCredential {
         ok(appId?.trim(), 'jwtTokenProviderFactory.createAzureServiceTokenProvider(): missing appId.');
 
-        return new DefaultAzureCredential({ managedIdentityClientId: appId });
+        return new DefaultAzureCredential({ managedIdentityClientId: appId }); // CodeQL [SM05138] Changing this would break retro-compatibility
     }
 }


### PR DESCRIPTION
#minor

## Description
This PR adds ignore comments for the three remaining CodeQL issues.

## Specific Changes
  - **cosmosDbPartitionedStorage.test**: The alert was skipped because disabling the SSL verification is necessary to run the tests using the CosmosDb emulator.
  - **storage**: The alert was skipped because using bcryptjs would introduce heavy, synchronous CPU work, which is not really necessary as the value we are hashing is not a password or any user input data.
  - **jwtTokenProviderFactory**: The alert was disregarded because changing _DefaultAzureCredential_ with _ManagedIdentityCredential_ would represent a breaking change in a public method.

## Testing
No testing require for these type of changes.